### PR TITLE
Add Vulnetix vulnerability intelligence skills

### DIFF
--- a/plugins/vulnetix/.claude-plugin/plugin.json
+++ b/plugins/vulnetix/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vulnetix",
   "version": "1.0.0",
-  "description": "Vulnerability intelligence and remediation skills for Claude Code — 7 skills for exploit analysis, fix proposals, CWSS scoring, threat modeling, and package security via the Vulnetix VDB API",
+  "description": "Vulnerability intelligence and remediation skills for Claude Code — 7 skills for exploit analysis, fix proposals, scoring, exploits, and package security via the Vulnetix VDB API",
   "author": {
     "name": "Vulnetix",
     "url": "https://github.com/Vulnetix"
@@ -14,8 +14,11 @@
     "exploits",
     "remediation",
     "cve",
-    "cwss",
-    "threat-modeling",
+    "cvss",
+    "epss",
+    "threat",
+    "exploit",
+    "eol",
     "package-security",
     "vdb"
   ]

--- a/plugins/vulnetix/.claude-plugin/plugin.json
+++ b/plugins/vulnetix/.claude-plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "vulnetix",
+  "version": "1.0.0",
+  "description": "Vulnerability intelligence and remediation skills for Claude Code — 7 skills for exploit analysis, fix proposals, CWSS scoring, threat modeling, and package security via the Vulnetix VDB API",
+  "author": {
+    "name": "Vulnetix",
+    "url": "https://github.com/Vulnetix"
+  },
+  "repository": "https://github.com/Vulnetix/claude-code-plugin",
+  "license": "Apache-2.0",
+  "keywords": [
+    "security",
+    "vulnerability",
+    "exploits",
+    "remediation",
+    "cve",
+    "cwss",
+    "threat-modeling",
+    "package-security",
+    "vdb"
+  ]
+}

--- a/plugins/vulnetix/skills/dashboard/SKILL.md
+++ b/plugins/vulnetix/skills/dashboard/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: dashboard
+description: View all tracked vulnerabilities and their current status
+user-invocable: true
+allowed-tools: Read, Glob, Grep
+model: haiku
+---
+
+# Vulnetix Vulnerability Dashboard
+
+This skill reads `.vulnetix/memory.yaml` and displays a comprehensive vulnerability status report. It is read-only and does not modify any files.
+
+## Workflow
+
+### Step 1: Load Memory
+
+1. Use **Glob** to check if `.vulnetix/memory.yaml` exists in the repo root
+2. If it does not exist, display: **"No vulnerability data found. Run `/vulnetix:vuln <package>` or `/vulnetix:exploits-search` to start tracking."** and stop.
+3. Use **Read** to load the full contents of `.vulnetix/memory.yaml`
+
+### Step 2: Parse and Categorize
+
+From the `vulnerabilities:` section, categorize each entry:
+
+**Open (unresolved):**
+- `status: affected` -- "Vulnerable"
+- `status: under_investigation` -- "Investigating"
+
+**Resolved:**
+- `status: fixed` -- "Fixed"
+- `status: not_affected` -- "Not affected"
+- Entries with `decision.choice: risk-accepted` -- "Risk accepted"
+- Entries with `decision.choice: deferred` -- "Deferred"
+
+From the `manifests:` section, collect manifest tracking info.
+
+### Step 3: Display Summary Header
+
+```
+Vulnetix Security Dashboard
+============================
+Open: <N> (<X> vulnerable, <Y> investigating)
+Resolved: <N> (<X> fixed, <Y> not affected, <Z> risk-accepted, <W> deferred)
+Manifests tracked: <N> (last scan: <timestamp>)
+```
+
+If there are zero vulnerabilities and zero manifests, display: **"Clean slate -- no vulnerabilities tracked yet."**
+
+### Step 4: Open Vulnerabilities Table
+
+If there are open vulnerabilities, display them sorted by CWSS priority (P1 first), then by severity:
+
+```
+Open Vulnerabilities
+--------------------
+| ID | Package | Severity | Status | Priority | Decision |
+|----|---------|----------|--------|----------|----------|
+| CVE-2021-44228 | log4j-core | critical | Vulnerable | P1 (87.5) | investigating |
+| GHSA-xxxx-yyyy | express | high | Investigating | P2 (62.0) | investigating |
+```
+
+For each column:
+- **ID**: Primary vulnerability key
+- **Package**: `package` field
+- **Severity**: `severity` field
+- **Status**: Developer-friendly status (see VEX mapping above)
+- **Priority**: `cwss.priority` and `cwss.score` if available, otherwise "--"
+- **Decision**: `decision.choice` if available, otherwise "--"
+
+### Step 5: Resolved Vulnerabilities Table
+
+If there are resolved vulnerabilities, display them:
+
+```
+Resolved Vulnerabilities
+------------------------
+| ID | Package | Severity | Resolution | Decision | Date |
+|----|---------|----------|------------|----------|------|
+| CVE-2023-1234 | lodash | high | Fixed | fix-applied | 2024-01-15 |
+```
+
+For the **Date** column, use the most recent `history` entry timestamp, or `discovery.date` as fallback.
+
+### Step 6: Manifest Tracking
+
+If manifests are tracked, display:
+
+```
+Tracked Manifests
+-----------------
+| Manifest | Ecosystem | Last Scanned | Vulns Found |
+|----------|-----------|--------------|-------------|
+| package.json | npm | 2024-01-15T10:30:00Z | 3 |
+| go.mod | go | 2024-01-15T10:31:00Z | 0 |
+```
+
+### Step 7: Suggested Actions
+
+For each open vulnerability (up to 5), suggest a next action based on its state:
+
+- Has no `threat_model` or `cwss`: `"/vulnetix:exploits <id>"` -- get exploit analysis and priority scoring
+- Has `cwss` but no fix applied: `"/vulnetix:fix <id>"` -- get fix intelligence
+- General: `"/vulnetix:remediation <id>"` -- get a full remediation plan
+
+If there are more than 5 open vulns, add: `"Use /vulnetix:exploits-search to find exploited vulnerabilities across your ecosystem."`
+
+Always end with: `"Use /vulnetix:vuln <id> for detailed info on any vulnerability."`

--- a/plugins/vulnetix/skills/exploits-search/SKILL.md
+++ b/plugins/vulnetix/skills/exploits-search/SKILL.md
@@ -1,0 +1,262 @@
+---
+name: exploits-search
+description: Search for exploits across all vulnerabilities with filtering by ecosystem, severity, source, and EPSS
+argument-hint: [search query]
+user-invocable: true
+allowed-tools: Bash, Read, Glob, Grep, Edit, Write
+model: sonnet
+---
+
+# Vulnetix Exploit Search Skill
+
+This skill searches for vulnerabilities with known exploits across the entire VDB, with filtering by ecosystem, severity, exploit source, EPSS score, and CISA KEV status. Use it to **discover** exploited vulnerabilities relevant to your repository's technology stack. **This skill does not modify application code** -- it only updates `.vulnetix/memory.yaml` to track findings.
+
+**How this differs from `/vulnetix:exploits`:** The existing `/vulnetix:exploits <vuln-id>` skill performs deep analysis of a *single known* vulnerability (PoC fetching, ATT&CK mapping, CWSS scoring). This skill *discovers* exploited vulnerabilities across the landscape, optionally filtered to your repository's ecosystems.
+
+## Vulnerability Memory (.vulnetix/memory.yaml)
+
+This skill reads and updates the `.vulnetix/memory.yaml` file in the repository root. This file is shared with `/vulnetix:fix`, `/vulnetix:exploits`, `/vulnetix:package-search`, `/vulnetix:vuln`, and `/vulnetix:remediation`.
+
+### Schema
+
+The canonical schema is defined in `/vulnetix:fix`. This skill creates minimal stub entries for newly discovered vulnerabilities that affect the repository.
+
+### Reading Prior State
+
+**At the start of every invocation:**
+
+1. Use **Glob** to check if `.vulnetix/memory.yaml` exists in the repo root
+2. If it exists, use **Read** to load it -- used in Step 4 to annotate results with prior status
+3. Use **Glob** for `.vulnetix/scans/*.cdx.json` -- cross-reference against search results
+
+### Writing Updated State
+
+**After completing the search (Step 5):**
+
+For each result that matches a dependency in the repository and is **not already tracked**:
+1. Create a stub entry with `status: under_investigation`, `discovery.source: scan`, `decision.choice: investigating`, `decision.reason: "Discovered via /vulnetix:exploits-search"`
+2. Append to `history`: `event: discovered`, detail: `"Found via exploit search (<filters used>)"`
+
+For existing entries, do **not** change `status` or `decision`.
+
+### VEX Status Mapping
+
+- `not_affected` --> "Not affected"
+- `affected` --> "Vulnerable"
+- `fixed` --> "Fixed"
+- `under_investigation` --> "Investigating"
+
+## Workflow
+
+### Step 1: Load Memory and Detect Repository Ecosystems
+
+1. Load `.vulnetix/memory.yaml` if it exists
+2. Use **Glob** to detect manifest files and determine repository ecosystems:
+   - `package.json`, `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml` --> **npm**
+   - `go.mod`, `go.sum` --> **go**
+   - `Cargo.toml`, `Cargo.lock` --> **cargo**
+   - `requirements.txt`, `pyproject.toml`, `Pipfile`, `poetry.lock`, `uv.lock` --> **pypi**
+   - `Gemfile`, `Gemfile.lock` --> **rubygems**
+   - `pom.xml`, `build.gradle`, `gradle.lockfile` --> **maven**
+   - `composer.json`, `composer.lock` --> **packagist**
+
+The detected ecosystem is used as a default filter if the user does not specify one.
+
+### Step 2: Parse Filters from User Message
+
+Map the user's natural language and any explicit arguments to CLI flags:
+
+**CLI Reference** (from `vulnetix vdb exploits search` docs):
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--ecosystem` | string | -- | Filter by package ecosystem (npm, pypi, maven, go, cargo, nuget, rubygems, packagist, etc.) |
+| `--source` | enum | -- | Filter by exploit source: `exploitdb`, `metasploit`, `nuclei`, `vulncheck-xdb`, `crowdsec`, `github`, `poc` |
+| `--severity` | enum | -- | Filter by CVSS severity: `CRITICAL`, `HIGH`, `MEDIUM`, `LOW` |
+| `--in-kev` | bool | false | Only show exploits listed in CISA KEV catalog |
+| `--min-epss` | float | -- | Minimum EPSS score threshold (0.0-1.0) |
+| `-q` | string | -- | Free-text search query (CVE ID, title, description) |
+| `--sort` | enum | recent | Sort order: `recent`, `epss`, `severity`, `maturity` |
+| `--limit` | int | 100 | Maximum results per page (1-100) |
+| `--offset` | int | 0 | Pagination offset |
+| `-o, --output` | string | pretty | Output format: `json` or `pretty` |
+
+**Natural language mapping examples:**
+
+| User says | Flags |
+|-----------|-------|
+| "npm exploits" | `--ecosystem npm` |
+| "critical vulnerabilities" | `--severity CRITICAL` |
+| "metasploit modules" | `--source metasploit` |
+| "actively exploited" / "in KEV" | `--in-kev` |
+| "high EPSS" / "likely exploited" | `--min-epss 0.7 --sort epss` |
+| "critical npm with metasploit" | `--ecosystem npm --severity CRITICAL --source metasploit` |
+| "remote code execution" | `-q "remote code execution"` |
+| "sort by severity" | `--sort severity` |
+| "sort by maturity" | `--sort maturity` |
+| "first 20" / "top 20" | `--limit 20` |
+| "next page" / "more" | `--offset <previous + limit>` |
+
+**Auto-ecosystem detection:** If the user does not specify an ecosystem and the repository uses a single ecosystem, automatically add `--ecosystem <detected>`. If the repo uses multiple ecosystems, ask whether to filter or search across all.
+
+If the argument `$ARGUMENTS` is provided as free text (not a flag), use it as the `-q` value.
+
+### Step 3: Execute Exploit Search
+
+Build and run the CLI command:
+
+```bash
+vulnetix vdb exploits search [flags] -o json
+```
+
+Examples:
+```bash
+# Search for critical npm exploits
+vulnetix vdb exploits search --ecosystem npm --severity CRITICAL -o json
+
+# CISA KEV entries with high EPSS
+vulnetix vdb exploits search --in-kev --min-epss 0.5 --sort epss -o json
+
+# Free-text search
+vulnetix vdb exploits search -q "remote code execution" --ecosystem npm -o json
+
+# Metasploit modules for Maven
+vulnetix vdb exploits search --source metasploit --ecosystem maven -o json
+
+# Sort by exploitation maturity
+vulnetix vdb exploits search --ecosystem pypi --sort maturity --limit 20 -o json
+```
+
+**Response structure** (from V2 OAS ExploitSearchResult schema):
+
+```json
+{
+  "timestamp": 1711382400000,
+  "total": 142,
+  "limit": 100,
+  "offset": 0,
+  "hasMore": true,
+  "filters": { "ecosystem": "npm", "severity": "CRITICAL" },
+  "results": [
+    {
+      "cveId": "CVE-2021-44228",
+      "state": "PUBLISHED",
+      "title": "Apache Log4j2 JNDI injection",
+      "description": "...",
+      "aliases": ["GHSA-jfh8-c2jp-5v3q"],
+      "metrics": {
+        "cvssV3Score": 10.0,
+        "cvssV3Vector": "AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+        "cvssV4Score": null
+      },
+      "epss": { "score": 0.97, "percentile": 0.999 },
+      "cess": { "score": 0.92 },
+      "cwes": [{ "id": "CWE-502", "description": "Deserialization" }],
+      "affectedProducts": [{ "vendor": "apache", "product": "log4j" }],
+      "fixAvailability": { "hasRegistryFix": true, "hasSourceFix": true },
+      "kev": {
+        "inCisaKev": true,
+        "dateAdded": "2021-12-10",
+        "dueDate": "2021-12-24",
+        "overdue": true,
+        "ransomwareUse": true
+      },
+      "exploitationMaturity": {
+        "score": 95,
+        "level": "WIDESPREAD",
+        "confidence": "HIGH"
+      },
+      "exploitTriviality": { "level": "TRIVIAL" },
+      "exploitSources": {
+        "exploitdb": 3,
+        "metasploit": 2,
+        "nuclei": 5,
+        "github": 12,
+        "vulncheckXdb": 1,
+        "crowdsec": 1
+      },
+      "sightings": {
+        "totalSightings": 50000,
+        "uniqueIPs": 12000,
+        "isActive": true
+      },
+      "timeline": {
+        "publishedDate": "2021-12-09",
+        "firstExploitDate": "2021-12-09",
+        "ageDays": 1567
+      },
+      "ecosystems": ["maven", "npm"]
+    }
+  ]
+}
+```
+
+### Step 4: Present Results
+
+Render a results table:
+
+```
+Exploit Search Results
+Filters: ecosystem=npm, severity=CRITICAL
+Total: N results (showing 1-20)
+
+| # | CVE ID          | Severity | EPSS | Maturity   | Exploit Sources       | KEV | Fix? |
+|---|-----------------|----------|------|------------|-----------------------|-----|------|
+| 1 | CVE-2021-44228  | critical | 0.97 | WIDESPREAD | ExDB:3 MSF:2 Nuc:5   | Yes | Yes  |
+| 2 | CVE-2024-XXXXX  | critical | 0.82 | ACTIVE     | MSF:1 GH:3            | Yes | Yes  |
+| 3 | CVE-2023-YYYYY  | critical | 0.65 | WEAPONIZED | ExDB:1 Nuc:2          | No  | No   |
+```
+
+**Column definitions:**
+- **CVE ID** -- primary identifier
+- **Severity** -- CVSS severity (critical/high/medium/low)
+- **EPSS** -- Exploit Prediction Scoring System probability (0.00-1.00)
+- **Maturity** -- exploitation maturity level: NONE, POC, WEAPONIZED, ACTIVE, WIDESPREAD
+- **Exploit Sources** -- abbreviated counts: ExDB (ExploitDB), MSF (Metasploit), Nuc (Nuclei), GH (GitHub PoCs), VCX (VulnCheck XDB), CS (CrowdSec)
+- **KEV** -- in CISA Known Exploited Vulnerabilities catalog (Yes/No). If overdue, append "(overdue)"
+- **Fix?** -- whether a registry or source fix is available (Yes/No)
+
+**Below the table**, for each result cross-reference with memory:
+- If tracked: `CVE-2021-44228 -- Fixed (2024-01-15)` (developer-friendly status)
+- If not tracked: no annotation
+
+**CrowdSec activity** -- if any result has active sightings, note: `"N results have active CrowdSec sightings (live exploitation detected)"`
+
+**Ransomware flag** -- if any KEV result has `ransomwareUse: true`, note: `"N results are associated with known ransomware campaigns"`
+
+**Pagination:** `Showing 1-20 of 142. Say "next page" or "page 3" for more.`
+
+**Actionable recommendations:**
+- For any result: `"Run /vulnetix:exploits <vuln-id> for deep exploit analysis (PoCs, ATT&CK mapping, CWSS scoring)"`
+- For results with fixes: `"Run /vulnetix:fix <vuln-id> for fix intelligence"` or `"Run /vulnetix:remediation <vuln-id> for a context-aware remediation plan"`
+- For details: `"Run /vulnetix:vuln <vuln-id> for full vulnerability info"`
+
+### Step 5: Update Vulnerability Memory
+
+1. Use **Read** to load the current memory file (or start fresh)
+2. For each result that matches a dependency in the repository (cross-ref affected products/ecosystems against repo manifests):
+   - If not already tracked, create a stub entry
+   - Record the search filters used in the history detail
+3. Use **Write** to save
+4. Confirm: `"Vulnerability memory updated: N new vulnerabilities tracked from exploit search"`
+
+If no results match repo dependencies, skip memory updates and note: `"No results match packages in this repository. Consider broadening the search or checking other ecosystems."`
+
+## Error Handling
+
+- If `vulnetix vdb exploits search` returns an error, suggest checking `vulnetix vdb status` for API health
+- If no results found, suggest broadening filters (remove severity, lower min-epss, try different ecosystem)
+- If the user's natural language is ambiguous, ask for clarification rather than guessing
+- If `.vulnetix/memory.yaml` cannot be written, warn but do not block results display
+
+## Important Reminders
+
+1. This skill **does not modify application code** -- it is a discovery tool
+2. This skill searches **across all vulnerabilities** -- it is not scoped to a single vuln ID (use `/vulnetix:exploits` for that)
+3. Auto-detect the repo ecosystem as a default filter to keep results relevant
+4. Exploitation maturity levels: NONE (0-14), POC (15-34), WEAPONIZED (35-54), ACTIVE (55-74), WIDESPREAD (75+)
+5. EPSS display: decimal in tables (0.97), not percentage
+6. Safe Harbour scores: not applicable to search results (they are per-version, not per-CVE)
+7. **Always update `.vulnetix/memory.yaml`** for results matching repo dependencies
+8. CrowdSec sightings indicate live exploitation -- flag prominently
+9. Ransomware associations are high-priority signals -- always surface them

--- a/plugins/vulnetix/skills/exploits/SKILL.md
+++ b/plugins/vulnetix/skills/exploits/SKILL.md
@@ -1,0 +1,641 @@
+---
+name: exploits
+description: Analyze exploit intelligence for a vulnerability against the current repository
+argument-hint: <vuln-id>
+user-invocable: true
+allowed-tools: Bash, Read, Glob, Grep, Edit, Write, WebFetch
+model: sonnet
+---
+
+# Vulnetix Exploit Analysis Skill
+
+This skill analyzes exploit intelligence for a specific vulnerability (CVE, GHSA, etc.) and assesses its impact against the current repository. **This skill does not modify application code** — it only updates `.vulnetix/memory.yaml` to track findings. Use `/vulnetix:fix` for remediation.
+
+## Output & Analysis Guidelines
+
+**Primary output format:** Markdown. All reports, tables, assessments, and evidence summaries MUST be presented as formatted markdown text directly — never generate scripts or programs to produce output that can be expressed as markdown.
+
+**Visual data — use Mermaid diagrams** to display data visually when it aids comprehension. Mermaid renders natively in markdown and requires no external tools. Use it for:
+- Attack path / kill chain visualization → `graph TD`
+- CWSS factor breakdown → `pie` or `quadrantChart`
+- Exploit timeline (discovery dates, PoC releases) → `timeline`
+- Threat model reachability → `flowchart` (dependency → vulnerable code → exposure)
+- Priority comparison across multiple vulns → `bar` or `xychart-beta`
+
+Example — CWSS factor breakdown:
+````markdown
+```mermaid
+pie title CWSS Priority Factors (Score: 87.5)
+    "Technical Impact (100)" : 25
+    "Exploitability (95)" : 25
+    "Exposure (100)" : 15
+    "Complexity (90)" : 15
+    "Repo Relevance (70)" : 20
+```
+````
+
+Example — attack path:
+````markdown
+```mermaid
+graph LR
+    A[Internet] -->|network| B[Web App]
+    B -->|imports| C[log4j-core 2.14.1]
+    C -->|JNDI lookup| D[RCE]
+    style C fill:#f66,stroke:#333
+    style D fill:#f00,color:#fff
+```
+````
+
+**If `uv` is available**, richer visualizations can be generated with Python (matplotlib, plotly) and saved to `.vulnetix/`:
+```bash
+command -v uv &>/dev/null && uv run --with matplotlib python3 -c '
+import matplotlib.pyplot as plt
+# ... generate chart ...
+plt.savefig(".vulnetix/chart.png", dpi=150, bbox_inches="tight")
+'
+```
+When Python charts are generated, display them inline and keep the Mermaid version as a text fallback.
+
+**Data processing — tooling cascade (strict order):**
+
+1. **jq / yq + bash builtins** (preferred) — `jq` for JSON extraction/filtering (API responses, CycloneDX SBOMs), `yq` for YAML (memory file reads). Pipe to `head`, `tail`, `cut`, `sed`, `grep`, `sort`, `uniq`, `wc` for shaping.
+2. **uv** (for complex analysis or charts) — If CWSS scoring, statistical aggregation, or visualization beyond Mermaid are needed, check `uv` first:
+   ```bash
+   command -v uv &>/dev/null && uv run --with pandas,matplotlib python3 -c '...'
+   ```
+3. **python3 stdlib** (last resort) — Only if `uv` is unavailable. Use `json`, `csv`, `collections`, `statistics`, `math` modules — **no pip dependencies**:
+   ```bash
+   command -v python3 &>/dev/null && python3 -c 'import json, sys; ...'
+   ```
+
+**Never assume any runtime is available** — always check with `command -v` before use. If all programmatic tools are unavailable, perform CWSS calculations manually and present results as markdown with Mermaid diagrams.
+
+**CWE pattern matching** (Step 5 `grep` commands for code analysis) uses the Grep tool directly — these are not data processing and are exempt from this cascade.
+
+## Vulnerability Memory (.vulnetix/memory.yaml)
+
+This skill reads and updates the `.vulnetix/memory.yaml` file in the repository root. This file is shared with `/vulnetix:fix` and `/vulnetix:package-search` and tracks all vulnerability encounters, threat models, priority scores, and user decisions across sessions.
+
+### Schema
+
+The canonical schema is defined in `/vulnetix:fix`. This skill adds and maintains the `threat_model` and `cwss` fields on each vulnerability entry. The full per-vulnerability entry structure:
+
+```yaml
+# .vulnetix/memory.yaml
+# Auto-maintained by Vulnetix Claude Code Plugin
+# Do not remove — tracks vulnerability decisions and fix history
+
+schema_version: 1
+vulnerabilities:
+  CVE-2021-44228:                       # Primary vuln ID (key)
+    aliases:                             # Other IDs for the same vuln
+      - GHSA-jfh8-c2jp-5v3q
+    package: log4j-core
+    ecosystem: maven
+    discovery:
+      date: "2024-01-15T10:30:00Z"      # ISO 8601 UTC
+      source: manifest                   # manifest | lockfile | sbom | scan | user | hook
+      file: pom.xml                      # The manifest where it was found
+      sbom: .vulnetix/scans/pom.xml.cdx.json  # CycloneDX v1.7 SBOM (when produced by scan/hook)
+    versions:
+      current: "2.14.1"
+      current_source: "lockfile: pom.xml"
+      fixed_in: "2.17.1"
+      fix_source: "registry: Maven Central"
+    severity: critical                   # critical | high | medium | low | unknown
+    safe_harbour: 0.82                   # 0.00-1.00 confidence score
+    status: affected                     # VEX: not_affected | affected | fixed | under_investigation
+    justification: null                  # VEX justification (for not_affected)
+    action_response: null                # VEX action (for affected)
+    threat_model:                        # Populated by /vulnetix:exploits
+      techniques:                        # MITRE ATT&CK technique IDs (internal reference)
+        - T1190
+        - T1059
+      tactics:                           # Developer-friendly descriptions (shown to user)
+        - "Attackable from the internet"
+        - "Can run arbitrary commands"
+      attack_vector: network             # network | local | adjacent | physical
+      attack_complexity: low             # low | high
+      privileges_required: none          # none | low | high
+      user_interaction: none             # none | required
+      reachability: direct               # direct | transitive | not-found | unknown
+      exposure: public-facing            # public-facing | internal | local-only | unknown
+    pocs:                                # PoC sources (static analysis only, never executed)
+      - url: "https://exploit-db.com/exploits/12345"
+        source: exploitdb
+        type: poc                        # poc | exploit-framework | article
+        local_path: ".vulnetix/pocs/CVE-2021-44228/exploit_12345.py"
+        fetched_date: "2024-01-15T10:35:00Z"
+        verified: true
+        analysis: "RCE via JNDI lookup injection, network vector, no auth required"
+    cwss:                                # CWSS-derived priority scoring
+      score: 87.5                        # 0-100 composite priority score
+      priority: P1                       # P1 | P2 | P3 | P4
+      factors:
+        technical_impact: 100            # 0-100 from CVSS impact / CWE consequence
+        exploitability: 95               # 0-100 from EPSS, exploit availability
+        exposure: 100                    # 0-100 from attack vector + repo deployment
+        complexity: 90                   # 0-100 inverted (higher = easier to exploit)
+        repo_relevance: 70               # 0-100 from dependency relationship, reachability
+    decision:
+      choice: investigating              # See Decision Values below
+      reason: "Exploit analysis in progress"
+      date: "2024-01-15T10:30:00Z"
+    history:                             # Append-only event log
+      - date: "2024-01-15T10:30:00Z"
+        event: discovered
+        detail: "Found via /vulnetix:exploits CVE-2021-44228"
+      - date: "2024-01-15T10:35:00Z"
+        event: exploit-analysis
+        detail: "3 public exploits, EPSS 0.97, Metasploit module, CISA KEV listed. CWSS 87.5 (P1)."
+```
+
+### MITRE ATT&CK Mapping
+
+Use ATT&CK technique IDs internally in `threat_model.techniques`. **Always communicate to the user using the developer-friendly language in `threat_model.tactics`.** Never surface ATT&CK IDs, tactic names, or technique names to the user — those are internal metadata only.
+
+| ATT&CK ID | ATT&CK Name | Developer Language (store in `tactics`) |
+|---|---|---|
+| T1190 | Exploit Public-Facing Application | "Attackable from the internet — web app or API is the entry point" |
+| T1195.001 | Supply Chain: Compromise Software Dependencies | "Compromised dependency — malicious code injected via a package you use" |
+| T1195.002 | Supply Chain: Compromise Software Supply Chain | "Tampered build or distribution — the package source or registry was compromised" |
+| T1059 | Command and Scripting Interpreter | "Can run arbitrary commands on your server" |
+| T1203 | Exploitation for Client Execution | "Exploitable via user interaction — opening a file or clicking a link triggers it" |
+| T1068 | Exploitation for Privilege Escalation | "Can escalate to admin or root access" |
+| T1210 | Exploitation of Remote Services | "Exploitable over the network between services" |
+| T1212 | Exploitation for Credential Access | "Can steal credentials — passwords, tokens, or keys" |
+| T1005 | Data from Local System | "Can read sensitive data — files, env vars, or secrets on the host" |
+| T1499 | Endpoint Denial of Service | "Can crash your service or exhaust resources" |
+| T1565 | Data Manipulation | "Can tamper with, corrupt, or inject data" |
+
+**How to select techniques:** Map from the CWE, CVSS vector, and exploit analysis:
+- CWE-78/CWE-77 (OS/Command injection) → T1059
+- CWE-502 (Deserialization) → T1059 + T1068
+- CWE-89 (SQL injection) → T1005 + T1565
+- CWE-79 (XSS) → T1203 + T1212
+- CWE-22 (Path traversal) → T1005
+- CWE-400/CWE-770 (Resource exhaustion) → T1499
+- CWE-306/CWE-287 (Auth issues) → T1068
+- CVSS AV:N → T1190 or T1210
+- Supply chain advisory → T1195.001 or T1195.002
+- RCE impact → T1059
+- Privilege escalation impact → T1068
+- Info disclosure impact → T1005 or T1212
+
+Multiple techniques may apply to a single vulnerability.
+
+### CWSS Priority Scoring
+
+Compute a CWSS-derived priority score (0–100) from Vulnetix data to help developers decide what to fix first. This uses Common Weakness Scoring System principles simplified into five factors that map directly to available API data and repo analysis.
+
+**Factors:**
+
+| Factor | Weight | Source | How to score (0–100) |
+|---|---|---|---|
+| Technical Impact | 25% | CVSS impact sub-score, CWE consequence | RCE → 100, Priv escalation → 90, Data exfil → 85, Data tampering → 70, DoS → 40, Info disclosure → 30 |
+| Exploitability | 25% | EPSS score, exploit records, CISA KEV | Base: EPSS × 100. Adjustments: Metasploit module → +20, Verified PoC → +15, CISA KEV → +15. Cap at 100. |
+| Exposure | 15% | CVSS attack vector + repo deployment analysis | Network + public-facing → 100, Network + internal → 70, Adjacent → 50, Local → 30, Physical → 10 |
+| Complexity | 15% | CVSS attack complexity, privileges, user interaction (inverted: higher = easier to exploit) | Low complexity + no auth + no interaction → 100. Each: high complexity → −30, auth required → −25, interaction required → −20. Floor at 0. |
+| Repo Relevance | 20% | Dependency analysis from Step 5 | Direct dep + reachable code → 100, Direct dep + unknown reachability → 70, Transitive dep → 40, Not found → 0 |
+
+**Composite score:**
+
+```
+CWSS = (technical_impact × 0.25) + (exploitability × 0.25) + (exposure × 0.15) + (complexity × 0.15) + (repo_relevance × 0.20)
+```
+
+**Priority tiers** (shown to user):
+
+| Priority | Score Range | Developer Language |
+|---|---|---|
+| **P1** | ≥ 80 | "Act now — actively exploited, trivial to attack, you're exposed" |
+| **P2** | 60–79 | "Plan this sprint — public exploits exist, you're likely affected" |
+| **P3** | 40–59 | "Schedule it — known issue, limited exploitability or exposure" |
+| **P4** | < 40 | "Track it — low risk, no known exploitation, limited exposure" |
+
+### Risk Treatment Decisions
+
+When the user makes a decision about a vulnerability, map it to one of four risk treatment categories. Use these categories as internal guidance only — **always communicate using the developer-friendly language**.
+
+| Treatment | Decision Choice | Developer Language | When to use |
+|---|---|---|---|
+| **Mitigate** | `fix-applied` | "Fix applied" | Upgraded, patched, or code fixed |
+| **Mitigate** | `mitigated` | "Workaround in place" | Config change, input validation, selective import |
+| **Accept** | `risk-accepted` | "Risk acknowledged, shipping as-is" | Consciously accepting with documented reason |
+| **Accept** | `deferred` | "Fix planned for later" | Will address, but not right now |
+| **Avoid** | `risk-avoided` | "Removed the exposure" | Dependency removed, feature disabled, not deployed |
+| **Avoid** | `inlined` | "Replaced with own code" | Dependency replaced with first-party implementation |
+| **Avoid** | `not-affected` | "Not affected" | Vuln doesn't apply — package absent, code unreachable |
+| **Transfer** | `risk-transferred` | "Handled by platform or infrastructure" | WAF, CDN, runtime sandbox, managed service handles it |
+
+VEX status mapping (internal → developer language, same as `/vulnetix:fix`):
+
+| VEX Status | Developer Language |
+|---|---|
+| `not_affected` | "Not affected" |
+| `affected` | "Vulnerable" |
+| `fixed` | "Fixed" |
+| `under_investigation` | "Investigating" |
+
+### Dependabot Integration
+
+When `gh` CLI is available (check with `gh auth status 2>/dev/null`), query Dependabot alerts for the current vuln ID to enrich exploit analysis context. The canonical Dependabot-to-VEX mapping is defined in `/vulnetix:fix`. This skill uses it read-only — it records Dependabot state in the memory file but does not change alert states on GitHub.
+
+**During Step 1 (Load Vulnerability Memory):**
+1. If `gh` is available, query Dependabot alerts matching this vuln ID:
+   ```bash
+   gh api repos/{owner}/{repo}/dependabot/alerts --jq '[.[] | select(.security_advisory.cve_id == "'"$ARGUMENTS"'" or .security_advisory.ghsa_id == "'"$ARGUMENTS"'")] | first'
+   ```
+2. If a matching alert exists, include in the prior state display:
+   ```
+   Dependabot alert #<N>: <developer-friendly state>
+   ```
+3. If a Dependabot PR exists, check its state and latest comment:
+   ```bash
+   gh pr list --author "app/dependabot" --state all --json number,title,state,url --limit 50 | jq '[.[] | select(.title | test("'"$PACKAGE_NAME"'"; "i"))] | first'
+   ```
+   Display: `Dependabot PR #<N>: <state> — "<latest comment summary>"`
+4. Update the `dependabot` section in the memory entry during Step 10
+
+**Dependabot context informs exploit analysis:**
+- Open alert + merged PR → fix may already be applied, verify installed version
+- Open alert + open PR → team is aware and working on it, note in assessment
+- Dismissed alert with reason → factor dismiss reason into repo relevance scoring (e.g., `not_used` → lower repo_relevance)
+
+### Code Scanning (CodeQL) Integration
+
+When `gh` CLI is available, query code scanning alerts that correlate with this vulnerability by CWE match. The canonical state-to-VEX mapping is defined in `/vulnetix:fix`.
+
+**During Step 1 (Load Vulnerability Memory):**
+1. If `gh` is available and the vulnerability's CWE is known (from prior memory or VDB data), query:
+   ```bash
+   gh api repos/{owner}/{repo}/code-scanning/alerts --jq '[.[] | select(.rule.tags[]? | test("CWE-<NUMBER>"; "i"))]'
+   ```
+2. If matching CodeQL alerts are found:
+   - Display: `CodeQL alert #<N> (<rule_id>): <state> in <file>:<line>`
+   - The file/line data directly informs **reachability analysis** in Step 5 — if CodeQL found the vulnerable pattern, the code path is confirmed reachable
+   - If dismissed, show the `dismissed_reason` and `dismissed_comment`
+3. Check for autofix availability on each open alert:
+   ```bash
+   gh api repos/{owner}/{repo}/code-scanning/alerts/{alert_number}/autofix --jq '.status'
+   ```
+   If `success`, note: "CodeQL has an AI-suggested code fix available"
+
+**CodeQL context informs exploit analysis:**
+- Open CodeQL alert matching the CWE → strong signal for `reachability: direct` in threat model, increases `repo_relevance` CWSS factor (+20)
+- CodeQL `fixed` alert → the code pattern was already remediated, may reduce exploit relevance
+- CodeQL `dismissed` as `false positive` → evidence the pattern doesn't actually apply here, may lower `repo_relevance`
+- CodeQL alert location data pinpoints exact attack surface for PoC correlation
+
+### Secret Scanning Integration
+
+When `gh` CLI is available, check for secret scanning alerts relevant to this vulnerability's context. The canonical state-to-VEX mapping is defined in `/vulnetix:fix`.
+
+**During Step 1 (Load Vulnerability Memory):**
+1. If `gh` is available and the vulnerability relates to credential handling (CWE-798, CWE-321, CWE-259, CWE-200, CWE-522, CWE-256) or the package handles auth/secrets:
+   ```bash
+   gh api repos/{owner}/{repo}/secret-scanning/alerts?state=open
+   ```
+2. If active secrets are found, this **increases exploit impact** — an attacker exploiting the vulnerability could also leverage exposed credentials:
+   - Display: `Secret scanning: <N> active secrets detected — credential exposure compounds this vulnerability`
+   - Factor into CWSS `technical_impact` (+10 if active secrets in affected code paths)
+3. For resolved alerts, note the resolution for context
+
+**Secret scanning context informs exploit analysis:**
+- Active leaked secret + exploitable vulnerability = compounded risk (flag in assessment)
+- Secrets in the same files as the vulnerable code path = direct exploitation chain
+- Push protection bypasses indicate security process gaps — note in assessment
+
+### Reading Prior State and SBOMs
+
+**At the start of every invocation:**
+
+1. Use **Glob** to check if `.vulnetix/memory.yaml` exists in the repo root
+2. If it exists, use **Read** to load it and check for the current vuln ID or any aliases
+3. Use **Glob** for `.vulnetix/scans/*.cdx.json` — if SBOMs exist, scan them for the current vuln ID to get additional context (affected components, scanned versions, severity ratings from prior scans). If a memory entry has a `discovery.sbom` path, read that file specifically.
+4. If a prior entry exists, display to the user:
+   ```
+   Previously seen: <vulnId> — <developer-friendly status> (as of <date>)
+   Priority: <P1/P2/P3/P4> (<score>) — "<priority description>"
+   Last decision: <developer-friendly decision> — "<reason>"
+   Dependabot: <alert state, PR state if available>
+   CodeQL: <N alerts matching CWE, states>
+   Secret scanning: <N relevant alerts, active/inactive>
+   ```
+5. If the user previously decided "Not affected", "Risk acknowledged", or "Handled by platform", remind them: `"You previously marked this as <status>. Proceeding with exploit analysis for updated intelligence."`
+6. If prior `cwss` data exists, note whether the new analysis changes the priority tier
+
+### Writing Updated State
+
+**After completing the analysis (Step 9):**
+
+1. If no entry exists yet, create one with:
+   - `status: under_investigation`, `decision.choice: investigating`
+   - `discovery.source: user` (or `scan`/`hook` if triggered from those)
+   - `discovery.sbom`: path to the relevant `.vulnetix/scans/*.cdx.json` file if one was found for this vuln's package/manifest
+   - Full `threat_model` and `cwss` sections from the analysis
+2. If an entry exists:
+   - Update `severity`, `safe_harbour`, `threat_model`, and `cwss` with new findings
+   - Preserve existing `aliases` and merge any newly discovered aliases
+   - **Do NOT change `status` or `decision`** based on exploit analysis alone — those reflect user decisions, not technical findings
+   - Exception: if the exploit analysis reveals the package is not present in the repo at all, set `status: not_affected`, `justification: component_not_present`, `decision.choice: not-affected`
+3. Append to `history`: `event: exploit-analysis`, detail: summary including CWSS score, priority tier, technique count, and key findings
+4. After writing, confirm to the user: `"Vulnerability memory updated: <VULN_ID> — <status> (CWSS <score>, <priority>)"`
+
+## Workflow
+
+### Step 1: Load Vulnerability Memory
+
+Check for and load `.vulnetix/memory.yaml` as described in "Reading Prior State" above. Display any prior state to the user before proceeding.
+
+### Step 2: Fetch Exploit Data
+
+Run the Vulnetix VDB exploits command:
+
+```bash
+vulnetix vdb exploits "$ARGUMENTS" -o json
+```
+
+If the V1 response is empty or lacks detail, try the V2 endpoint:
+
+```bash
+vulnetix vdb exploits "$ARGUMENTS" -o json -V v2
+```
+
+The output structure:
+```json
+{
+  "exploits": [
+    {
+      "source": "exploitdb",
+      "type": "poc",
+      "url": "https://exploit-db.com/exploits/12345",
+      "date": "2021-12-15",
+      "description": "Remote code execution via log4j",
+      "verified": true
+    },
+    {
+      "source": "metasploit",
+      "type": "exploit-framework",
+      "url": "https://github.com/rapid7/metasploit-framework/...",
+      "date": "2021-12-20",
+      "description": "Log4Shell RCE module",
+      "verified": true
+    }
+  ]
+}
+```
+
+### Step 3: Parse Exploit Records
+
+Group exploits by source and present a structured summary:
+
+**Exploit Intelligence Summary:**
+
+| Source | Type | Date | Description | Link |
+|--------|------|------|-------------|------|
+| ... | ... | ... | ... | ... |
+
+**Exploit types:**
+- `poc` — Proof-of-concept code
+- `exploit-framework` — Metasploit/Canvas modules
+- `article` — Writeups, blog posts
+- `advisory` — Security advisories
+- `patch` — Patches or fixes
+- `mitigation` — Workarounds
+
+### Step 4: Fetch Vulnerability Context
+
+Get additional vulnerability details:
+
+```bash
+vulnetix vdb vuln "$ARGUMENTS" -o json
+```
+
+Extract:
+- **CVSS scores** (base score, vector string — parse AV, AC, PR, UI components)
+- **EPSS score** (exploit prediction probability)
+- **CISA KEV status** (Known Exploited Vulnerabilities catalog)
+- **CWE ID** (weakness type, e.g., CWE-502 Deserialization)
+- **Affected products/packages** and version ranges
+
+### Step 5: Analyze Repository Impact
+
+Use **Glob** and **Grep** to assess if this vulnerability affects the current repository:
+
+1. **Check cached SBOMs first:**
+   - If `.vulnetix/memory.yaml` has a `manifests` section, check for recently scanned files (< 24h old by `last_scanned`)
+   - If a cached SBOM exists at `sbom_path` and is recent, read it instead of re-scanning — it contains the full component inventory from the last scan
+   - If the pre-commit hook already created a memory entry for this vuln (`discovery.source: hook`), use that context rather than duplicating the discovery — update the existing entry in Step 10
+
+2. **Check for affected dependencies:**
+   - Glob for manifest files (`package.json`, `requirements.txt`, `go.mod`, etc.)
+   - **Read** each manifest and check if any affected packages are listed
+   - Note the installed version vs. vulnerable version range
+
+2. **Search for code patterns matching the CWE:**
+   - CWE-502 (Deserialization) → `grep -r "pickle.loads\|yaml.load\|ObjectInputStream" --include="*.py" --include="*.java"`
+   - CWE-78 (OS Command Injection) → `grep -r "exec\|system\|subprocess" --include="*.py" --include="*.js"`
+   - CWE-89 (SQL Injection) → `grep -r "execute\|query.*\+.*" --include="*.py" --include="*.js"`
+
+3. **Assess exploit vector reachability:**
+   - Is the vulnerable dependency direct or transitive?
+   - Are the vulnerable code paths actually called in the repo?
+   - Is the application exposed to the internet (check for web frameworks, API servers)?
+
+Record findings as: `reachability` (direct/transitive/not-found/unknown) and `exposure` (public-facing/internal/local-only/unknown) for the threat model.
+
+### Step 6: PoC Analysis and Local Caching
+
+For each PoC URL from the exploit records, use **WebFetch** to retrieve the source code.
+
+#### 6a: Ensure `.vulnetix/` Directory and `.gitignore`
+
+Before saving any PoC files:
+
+1. Create the `.vulnetix/pocs/<VULN_ID>/` directory if it does not exist:
+   ```bash
+   mkdir -p .vulnetix/pocs/<VULN_ID>
+   ```
+2. Check if `.gitignore` exists and contains `.vulnetix/`. If not, append it:
+   ```bash
+   # Only if .vulnetix/ is not already in .gitignore
+   echo '.vulnetix/' >> .gitignore
+   ```
+   This ensures PoC source files are never committed to the repository.
+
+#### 6b: Fetch and Save PoC Source
+
+For each PoC URL:
+
+1. Use **WebFetch** to retrieve the source code
+2. Derive a filename from the URL (e.g., `exploit_12345.py` from ExploitDB ID, `log4shell_module.rb` from Metasploit)
+3. Use **Write** to save the fetched content to `.vulnetix/pocs/<VULN_ID>/<filename>`
+4. Record the PoC in the `pocs` list in `.vulnetix/memory.yaml`:
+   ```yaml
+   pocs:
+     - url: "https://exploit-db.com/exploits/12345"
+       source: exploitdb
+       type: poc
+       local_path: ".vulnetix/pocs/CVE-2021-44228/exploit_12345.py"
+       fetched_date: "<current ISO 8601 UTC timestamp>"
+       verified: true
+       analysis: "<one-line summary of what it does>"
+   ```
+
+If a PoC was previously fetched (local_path exists from prior invocation), skip re-fetching unless the user requests it. Read the local copy for analysis instead.
+
+#### 6c: Static Analysis
+
+Analyze each PoC **statically only** — read the saved source to understand:
+- What is the attack vector? (network, local, physical)
+- What conditions must be met? (authentication required, specific config, user interaction)
+- What is the impact? (RCE, data exfiltration, DoS)
+
+Store the one-line analysis summary in the `pocs[].analysis` field.
+
+**CRITICAL SECURITY RULE: NEVER EXECUTE PoC CODE**
+
+Do NOT:
+- Run the PoC script
+- Copy PoC commands into a shell
+- Download malicious payloads
+- Execute any exploit code
+- Set executable permissions on saved PoC files
+
+Only analyze the source code to understand the exploit mechanism. The local copies exist solely for offline static reference.
+
+### Step 7: Threat Model
+
+Map the vulnerability to MITRE ATT&CK techniques using the CWE, CVSS vector, and exploit analysis from previous steps. Follow the mapping table in "MITRE ATT&CK Mapping" above.
+
+**Build the `threat_model` object:**
+
+1. Select all applicable ATT&CK technique IDs → store in `techniques`
+2. Generate the developer-friendly description for each → store in `tactics`
+3. Set `attack_vector` from CVSS AV metric (N→network, L→local, A→adjacent, P→physical)
+4. Set `attack_complexity` from CVSS AC metric (L→low, H→high)
+5. Set `privileges_required` from CVSS PR metric (N→none, L→low, H→high)
+6. Set `user_interaction` from CVSS UI metric (N→none, R→required)
+7. Set `reachability` from Step 5 findings
+8. Set `exposure` from Step 5 findings
+
+**Present to the user** (developer language only):
+
+```
+How this could be exploited:
+- Attackable from the internet — web app or API is the entry point
+- Can run arbitrary commands on your server
+Attack requirements: No authentication needed, no user interaction, low complexity
+Your exposure: Direct dependency, public-facing deployment
+```
+
+### Step 8: Priority Score (CWSS-derived)
+
+Compute the CWSS priority score using the factors and formula defined in "CWSS Priority Scoring" above.
+
+1. Score each factor (0–100) using the data gathered in Steps 2–5
+2. Apply weights and compute composite score
+3. Determine priority tier (P1–P4)
+
+**Present to the user:**
+
+```
+Priority: P1 (87.5) — Act now
+  Impact: Can run arbitrary commands (100)
+  Exploitability: EPSS 0.97, Metasploit module available (95)
+  Exposure: Network-accessible, public-facing (100)
+  Complexity: Low barrier — no auth, no interaction (90)
+  Relevance: Direct dependency, code paths reachable (70)
+```
+
+If the priority tier **changed** from a prior analysis (loaded in Step 1), flag it:
+```
+Priority changed: P3 → P1 (new Metasploit module released, EPSS increased)
+```
+
+### Step 9: Risk Assessment
+
+Provide a unified exploitability assessment combining the threat model and priority score:
+
+**Rating levels:**
+- **CRITICAL** — Active exploitation in the wild, trivial to exploit, repository is vulnerable (typically P1)
+- **HIGH** — Public PoC available, exploit is reliable, vulnerable dependency is present (typically P1–P2)
+- **MEDIUM** — Public PoC available, but repository may not be affected or exploit is complex (typically P2–P3)
+- **LOW** — No public exploits, or vulnerability is not present in repository (typically P3–P4)
+- **N/A** — Insufficient information to assess
+
+**Assessment format:**
+
+```
+Exploitability Rating: HIGH
+Priority: P2 (72.5) — Plan this sprint
+
+How this could be exploited:
+- Attackable from the internet — web app or API is the entry point
+- Can run arbitrary commands on your server
+Attack requirements: No authentication needed, low complexity
+Your exposure: Direct dependency, public-facing app
+
+Evidence:
+  Metasploit module available (verified exploit)
+  EPSS score: 0.89 (89% chance of exploitation within 30 days)
+  CISA KEV: Listed (deadline 2024-01-15)
+  Repository impact: log4j-core 2.14.1 found in pom.xml (vulnerable version)
+  Mitigation: No workaround available, upgrade required
+
+Recommendation: Run `/vulnetix:fix CVE-2021-44228` to get fix options.
+```
+
+If the rating is **CRITICAL** or **HIGH** and a fix is available, recommend:
+```
+Next step: Run `/vulnetix:fix $ARGUMENTS` for remediation options.
+```
+
+After presenting the assessment, if the user provides a decision (e.g., "we'll accept this risk", "doesn't affect us", "our WAF handles it"), record it immediately using the risk treatment mapping. Ask the user to confirm their reasoning so it can be stored in `decision.reason`.
+
+### Step 10: Update Vulnerability Memory
+
+Update `.vulnetix/memory.yaml` as described in "Writing Updated State" above.
+
+1. Use **Read** to load the current file (or start fresh if none exists)
+2. Create or update the entry with all fields from the analysis:
+   - `threat_model` — full object from Step 7
+   - `cwss` — full object from Step 8
+   - `pocs` — all PoC records from Step 6 (url, source, type, local_path, fetched_date, verified, analysis)
+   - `severity` — from VDB data
+   - `safe_harbour` — from VDB data or computed
+   - `aliases` — merge any newly discovered aliases
+   - `dependabot` — if Dependabot data was gathered in Step 1, write the full `dependabot` section (alert_number, alert_state, alert_url, dismiss_reason, dismiss_comment, pr_number, pr_state, pr_url, pr_latest_comment, last_checked)
+   - `code_scanning` — if CodeQL data was gathered in Step 1, write the full `code_scanning` section (alerts[], tool, tool_version, last_checked). Each alert: alert_number, state, rule_id, rule_name, severity, dismissed_reason, dismissed_comment, dismissed_by, file_path, start_line, url
+   - `secret_scanning` — if secret scanning data was gathered in Step 1, write the full `secret_scanning` section (alerts[], last_checked). Each alert: alert_number, state, secret_type, secret_type_display, resolution, resolution_comment, resolved_by, validity, file_path, url, push_protection_bypassed
+3. Append to `history` — include GHAS sync notes if alert states changed: `event: codeql-sync` or `event: secret-scanning-sync`
+4. **Update `manifests` section** — if any manifest files were scanned during Step 5 (not from cache), update or add their entries with `last_scanned`, `vuln_count`, `scan_source: exploits`. Do not remove entries added by the hook or other skills.
+5. Use **Write** to save the file
+6. Confirm to the user: include GHAS summary in output: `"GitHub security sync: Dependabot <state>, CodeQL <N alerts>, Secret scanning <N alerts>"`
+
+**If the user provides a decision during the conversation**, record it:
+- Map their words to a `decision.choice` using the Risk Treatment Decisions table
+- Store their actual words (verbatim or close paraphrase) in `decision.reason`
+- Set `status`, `justification`, and `action_response` per the VEX mapping
+- Append to `history` with `event: user-decision`
+- Confirm: `"Vulnerability memory updated: <VULN_ID> — <developer-friendly status> (<reason summary>)"`
+
+## Error Handling
+
+- If `vulnetix vdb exploits` returns no results, inform the user that no public exploits are known (not necessarily safe — just not publicly documented). Set CWSS exploitability factor to base EPSS only.
+- If `vulnetix vdb vuln` fails, continue with exploit analysis but note that CVSS/EPSS context is limited. Use available exploit records to estimate factors.
+- If manifest files are missing or unreadable, note that impact analysis is inconclusive. Set `repo_relevance` to 0 and `reachability` to `unknown`.
+- If `.vulnetix/memory.yaml` cannot be written (permissions, etc.), warn the user but do not block the analysis workflow.
+- If CWSS factors cannot all be determined, compute with available data and note which factors used defaults. Document this in the history detail.
+
+## Important Reminders
+
+1. **Never execute PoC code** — static analysis only
+2. This skill **does not modify application code** — use `/vulnetix:fix` for remediation
+3. Always fetch both V1 and V2 exploit data if available
+4. EPSS and CISA KEV are strong signals — prioritize accordingly
+5. **Always update `.vulnetix/memory.yaml`** after analysis — record threat model, CWSS score, findings, and any user decisions
+6. **ATT&CK IDs and CWSS internals are never shown to the user** — only developer-friendly language
+7. **Decisions and status changes from exploit analysis alone** are limited to technical updates (`severity`, `safe_harbour`, `threat_model`, `cwss`). Status/decision changes require explicit user feedback, with one exception: if the package is confirmed absent from the repo, set `not-affected` automatically.
+8. When a vulnId is encountered again in a future invocation, the prior `threat_model` and `cwss` serve as baseline — update them with new findings rather than starting from scratch.

--- a/plugins/vulnetix/skills/fix/SKILL.md
+++ b/plugins/vulnetix/skills/fix/SKILL.md
@@ -1,0 +1,1090 @@
+---
+name: fix
+description: Get fix intelligence for a vulnerability and propose concrete remediation for the current repository
+argument-hint: <vuln-id>
+user-invocable: true
+allowed-tools: Bash, Read, Glob, Grep, Edit, Write, WebFetch
+model: sonnet
+---
+
+# Vulnetix Fix Intelligence Skill
+
+This skill fetches fix intelligence for a vulnerability and proposes concrete, actionable remediation steps for the current repository.
+
+## Output & Analysis Guidelines
+
+**Primary output format:** Markdown. All reports, tables, fix options, version diffs, and verification summaries MUST be presented as formatted markdown text directly — never generate scripts or programs to produce output that can be expressed as markdown.
+
+**Visual data — use Mermaid diagrams** to display data visually when it aids comprehension. Mermaid renders natively in markdown and requires no external tools. Use it for:
+- Dependency upgrade paths → `graph LR` showing current → target version with breaking change annotations
+- Fix option comparison → `quadrantChart` plotting Safe Harbour confidence vs. version change magnitude
+- Dependency tree showing vulnerable path → `graph TD` (root → parent → vulnerable dep)
+- Post-fix verification status → `flowchart` (scan → tests → result)
+
+Example — upgrade path:
+````markdown
+```mermaid
+graph LR
+    A[log4j-core 2.14.1] -->|patch| B[2.14.2]
+    A -->|minor| C[2.17.1 ✓ fix]
+    A -->|major| D[3.0.0]
+    style A fill:#f66,stroke:#333
+    style C fill:#6f6,stroke:#333
+```
+````
+
+**If `uv` is available**, richer visualizations can be generated with Python (matplotlib, plotly) and saved to `.vulnetix/`:
+```bash
+command -v uv &>/dev/null && uv run --with matplotlib python3 -c '
+import matplotlib.pyplot as plt
+# ... generate chart ...
+plt.savefig(".vulnetix/chart.png", dpi=150, bbox_inches="tight")
+'
+```
+When Python charts are generated, display them inline and keep the Mermaid version as a text fallback.
+
+**Data processing — tooling cascade (strict order):**
+
+1. **jq / yq + bash builtins** (preferred) — `jq` for JSON (API responses, CycloneDX SBOMs, package manager output), `yq` for YAML (memory file). Pipe to `head`, `tail`, `cut`, `sed`, `grep`, `sort`, `uniq`, `wc` for shaping.
+2. **uv** (for complex analysis or charts) — If dependency graph analysis, version comparison logic, or visualization beyond Mermaid are needed, check `uv` first:
+   ```bash
+   command -v uv &>/dev/null && uv run --with pandas,matplotlib python3 -c '...'
+   ```
+3. **python3 stdlib** (last resort) — Only if `uv` is unavailable. Use `json`, `csv`, `collections`, `statistics` modules — **no pip dependencies**:
+   ```bash
+   command -v python3 &>/dev/null && python3 -c 'import json, sys; ...'
+   ```
+
+**Never assume any runtime is available** — always check with `command -v` before use. If all programmatic tools are unavailable, analyze manually with the Read tool and present results as markdown with Mermaid diagrams.
+
+**Package manager commands** (`npm install --dry-run`, `pip show`, `go mod tidy`, `cargo check`, etc.) are exempt — they are executed directly as part of the fix workflow, not for data analysis.
+
+## Mandatory Reporting Requirements
+
+**Every output and report from this skill MUST include the following version and provenance information for each affected package:**
+
+### Package Version Reporting
+
+All reports MUST display:
+
+| Field | Description | Required |
+|-------|-------------|----------|
+| **Current Version** | The version currently installed/resolved | Always |
+| **Version Source** | How the version was determined (see below) | Always |
+| **Fix Target Version** | The patched version to upgrade to | When available |
+| **Fix Source** | Registry, distro patch, or source commit hash | Always |
+| **Safe Harbour Confidence** | Confidence score 0.00–1.00 (see below) | Always |
+
+### Version Source Transparency
+
+You MUST be transparent about how the current version was determined. Report one of:
+
+- **User-supplied** — the user provided the version directly
+- **Manifest** — read from a package manager manifest file (state which file)
+- **Lockfile** — read from a lockfile (state which file)
+- **Installed** — derived from the installed package on the filesystem:
+  - npm/node: read `node_modules/<pkg>/package.json` (search parent directories too)
+  - Python: run `pip show <pkg>` or read `site-packages/<pkg>/METADATA`
+  - Go: read `go.sum` or run `go list -m <pkg>`
+  - Rust: read `Cargo.lock` or run `cargo metadata`
+  - System binaries: run `<binary> --version` or check `PATH` resolution
+  - Ruby: run `gem list <pkg>` or read `Gemfile.lock`
+  - Maven: read effective POM or local `.m2` cache
+- **Context** — the version was already present in conversation context
+- **Unknown** — version could not be determined (explain why)
+
+If the user does not supply the version and it is not in conversation context, you MUST attempt to derive it from the filesystem before reporting "Unknown". Search outside the current working directory if needed — check parent directories, global package manager directories, and gitignored directories (e.g., `node_modules/`, `vendor/`, `.venv/`, `target/`, `__pycache__/`).
+
+### Safe Harbour Confidence Score
+
+Express the Safe Harbour score as a decimal between 0.00 and 1.00 where 1.00 = 100% confidence the fix resolves the vulnerability without introducing regressions or breaking changes.
+
+**Confidence tiers:**
+- **High confidence (> 0.90):** Patch-level bump in the same minor version, official registry release, well-tested fix, minimal API surface change
+- **Reasonable confidence (0.35–0.90):** Minor version bump, distro-repackaged patch, source fix from upstream with commit hash, some API changes but backward-compatible
+- **Low confidence (< 0.35):** Major version bump, unofficial patch, cherry-picked commit from development branch, significant API changes, no upstream release yet
+
+**What factors adjust confidence:**
+- Registry-published release with changelog: +0.15
+- Distro-maintained patch (e.g., Debian, Ubuntu, RHEL): +0.10
+- Upstream commit hash verified in release tag: +0.10
+- CISA KEV listed (validated exploitation): +0.05 (urgency signal, not fix quality)
+- Major version jump: −0.25
+- No test suite in project to validate: −0.15
+- Transitive dependency (indirect control): −0.10
+- Built from source with untagged commit: −0.20
+
+**Report format for each affected package:**
+
+```
+Package: <name>
+Current Version: <version> (source: <version-source>)
+Fix Target: <version> (source: <registry|distro <name> <version>|commit <hash>>)
+Safe Harbour: <score> (<High|Reasonable|Low> confidence)
+```
+
+## Vulnerability Memory File (.vulnetix/memory.yaml)
+
+This skill maintains a `.vulnetix/memory.yaml` file in the repository root that tracks all vulnerability encounters, decisions, and fix outcomes across sessions. **You MUST read this file at the start of every invocation and update it after every action.**
+
+### Schema
+
+```yaml
+# .vulnetix/memory.yaml
+# Auto-maintained by Vulnetix Claude Code Plugin
+# Do not remove — tracks vulnerability decisions, manifest scans, and fix history
+
+schema_version: 1
+manifests:                                # Tracked manifest files and SBOM scan history
+  package.json:
+    path: "package.json"                  # Relative path from repo root
+    ecosystem: npm
+    last_scanned: "2024-01-15T10:30:00Z"  # ISO 8601 UTC
+    sbom_generated: true
+    sbom_path: ".vulnetix/scans/package.json.20240115T103000Z.cdx.json"
+    vuln_count: 3                         # Vulnerabilities found in last scan
+    scan_source: hook                     # hook | fix | exploits | package-search
+  services--api--go.mod:
+    path: "services/api/go.mod"           # Supports monorepo paths (key uses -- separator)
+    ecosystem: go
+    last_scanned: "2024-01-15T10:31:00Z"
+    sbom_generated: true
+    sbom_path: ".vulnetix/scans/services--api--go.mod.20240115T103100Z.cdx.json"
+    vuln_count: 0
+    scan_source: hook
+vulnerabilities:
+  CVE-2021-44228:                       # Primary vuln ID (key)
+    aliases:                             # Other IDs for the same vuln
+      - GHSA-jfh8-c2jp-5v3q
+    package: log4j-core
+    ecosystem: maven
+    discovery:
+      date: "2024-01-15T10:30:00Z"      # ISO 8601 UTC
+      source: manifest                   # manifest | lockfile | sbom | scan | user | hook
+      file: pom.xml                      # The manifest where it was found
+      sbom: .vulnetix/scans/pom.xml.cdx.json  # CycloneDX v1.7 SBOM (when produced by scan/hook)
+    versions:
+      current: "2.14.1"
+      current_source: "lockfile: pom.xml"
+      fixed_in: "2.17.1"
+      fix_source: "registry: Maven Central"
+    severity: critical                   # critical | high | medium | low | unknown
+    safe_harbour: 0.82                   # 0.00–1.00 confidence score
+    status: fixed                        # See VEX Status Mapping below
+    justification: null                  # See VEX Justification Mapping below
+    action_response: null                # See VEX Action Response Mapping below
+    threat_model:                        # Populated by /vulnetix:exploits
+      techniques: [T1190, T1059]         # MITRE ATT&CK IDs (internal only)
+      tactics:                           # Developer-friendly descriptions (shown to user)
+        - "Attackable from the internet"
+        - "Can run arbitrary commands"
+      attack_vector: network             # network | local | adjacent | physical
+      attack_complexity: low             # low | high
+      privileges_required: none          # none | low | high
+      user_interaction: none             # none | required
+      reachability: direct               # direct | transitive | not-found | unknown
+      exposure: public-facing            # public-facing | internal | local-only | unknown
+    cwss:                                # CWSS-derived priority (populated by /vulnetix:exploits)
+      score: 87.5                        # 0-100 composite priority score
+      priority: P1                       # P1 | P2 | P3 | P4
+      factors:
+        technical_impact: 100            # 0-100
+        exploitability: 95               # 0-100
+        exposure: 100                    # 0-100
+        complexity: 90                   # 0-100
+        repo_relevance: 70               # 0-100
+    pocs:                                # PoC sources (from /vulnetix:exploits, never executed)
+      - url: "https://exploit-db.com/exploits/12345"
+        source: exploitdb
+        type: poc
+        local_path: ".vulnetix/pocs/CVE-2021-44228/exploit_12345.py"
+        fetched_date: "2024-01-15T10:35:00Z"
+        verified: true
+        analysis: "RCE via JNDI lookup, network vector, no auth"
+    dependabot:                          # Populated from GitHub Dependabot via gh CLI
+      alert_number: 42                   # Dependabot alert number on this repo
+      alert_state: fixed                 # open | dismissed | fixed | auto_dismissed
+      alert_url: "https://github.com/owner/repo/security/dependabot/42"
+      dismiss_reason: null               # fix_started | inaccurate | no_bandwidth | not_used | tolerable_risk | null
+      dismiss_comment: null              # Dismisser's comment, if any
+      pr_number: 187                     # Associated Dependabot PR number, or null
+      pr_state: merged                   # open | closed | merged | null
+      pr_url: "https://github.com/owner/repo/pull/187"
+      pr_latest_comment: "LGTM, merging" # Last comment on the PR (for context)
+      last_checked: "2024-01-15T10:30:00Z"
+    code_scanning:                       # Populated from GitHub CodeQL / code scanning via gh CLI
+      alerts:                            # CodeQL alerts correlated to this vuln (matched by CWE)
+        - alert_number: 15
+          state: dismissed               # open | dismissed | fixed
+          rule_id: "java/log4j-injection"
+          rule_name: "Log4j injection"
+          severity: critical             # critical | high | medium | low | warning | note | error
+          dismissed_reason: null         # "false positive" | "won't fix" | "used in tests" | null
+          dismissed_comment: null        # Free-text justification (max 280 chars)
+          dismissed_by: "octocat"        # GitHub username
+          file_path: "src/main/java/App.java"
+          start_line: 42
+          url: "https://github.com/owner/repo/security/code-scanning/15"
+      tool: CodeQL                       # CodeQL | semgrep | etc.
+      tool_version: "2.15.0"
+      last_checked: "2024-01-15T10:30:00Z"
+    secret_scanning:                     # Populated from GitHub secret scanning via gh CLI
+      alerts:                            # Secret scanning alerts correlated to this vuln's package/context
+        - alert_number: 7
+          state: resolved                # open | resolved
+          secret_type: "github_personal_access_token"
+          secret_type_display: "GitHub Personal Access Token"
+          resolution: revoked            # false_positive | wont_fix | revoked | used_in_tests | null
+          resolution_comment: "Token rotated and old one revoked"
+          resolved_by: "octocat"
+          validity: inactive             # active | inactive | unknown
+          file_path: "config/settings.py"
+          url: "https://github.com/owner/repo/security/secret-scanning/7"
+          push_protection_bypassed: false
+      last_checked: "2024-01-15T10:30:00Z"
+    decision:
+      choice: fix-applied                # See User Decision Values below
+      reason: "Upgraded to 2.17.1 via version bump"
+      date: "2024-01-15T11:00:00Z"
+    history:                             # Append-only event log
+      - date: "2024-01-15T10:30:00Z"
+        event: discovered
+        detail: "Found via /vulnetix:fix CVE-2021-44228"
+      - date: "2024-01-15T11:00:00Z"
+        event: fix-applied
+        detail: "Version bumped log4j-core 2.14.1 → 2.17.1 in pom.xml"
+```
+
+### VEX Status Mapping (Internal → Developer Language)
+
+Use VEX semantics internally but **always communicate to the user in developer-friendly language**. Never use raw VEX terminology with the user.
+
+| VEX Status | Developer Language | When to use |
+|---|---|---|
+| `not_affected` | **Not affected** — this vuln doesn't apply to your project | Package not present, code path unreachable, or already mitigated |
+| `affected` | **Vulnerable** — your project is exposed, action needed | Package is present at a vulnerable version |
+| `fixed` | **Fixed** — a fix has been applied | Version bumped, patch applied, or dependency removed |
+| `under_investigation` | **Investigating** — still evaluating the impact | User hasn't decided yet, or analysis is ongoing |
+
+### VEX Justification Mapping (for `not_affected` status)
+
+| VEX Justification | Developer Language | Example |
+|---|---|---|
+| `component_not_present` | **Package not in this project** | Manifest search found no match |
+| `vulnerable_code_not_reachable` | **Vulnerable code path not used** | App imports only safe submodules |
+| `vulnerable_code_cannot_be_controlled_by_adversary` | **Not exploitable in this deployment** | Internal-only service, no untrusted input |
+| `inline_mitigations_already_exist` | **Already mitigated** | WAF rule, input validation, or config hardening in place |
+
+### VEX Action Response Mapping (for `affected` status)
+
+| VEX Action | Developer Language | When to use |
+|---|---|---|
+| `will_not_fix` | **Risk accepted** — won't fix, documented reason | User explicitly accepts the risk |
+| `will_fix` | **Fix planned** — scheduled for later | User wants to fix but not right now |
+| `update` | **Updating** — fix in progress | Actively applying a version bump or patch |
+
+### User Decision Values
+
+These are the `decision.choice` values recorded in the memory file, mapped from user feedback:
+
+| Decision | Maps to VEX | Triggered by user saying |
+|---|---|---|
+| `fix-applied` | status: `fixed` | "Yes, apply the fix" / fix was successfully applied |
+| `risk-accepted` | status: `affected`, action: `will_not_fix` | "We'll accept this risk" / "Won't fix" |
+| `not-affected` | status: `not_affected` | "This doesn't affect us" / "Not relevant" |
+| `investigating` | status: `under_investigation` | "Let me look into this" / "Need more info" |
+| `deferred` | status: `affected`, action: `will_fix` | "We'll fix this later" / "Not now" |
+| `mitigated` | status: `not_affected`, justification: `inline_mitigations_already_exist` | "We have a workaround" / "Already handled" |
+| `inlined` | status: `fixed` | Dependency was replaced with first-party code |
+| `risk-avoided` | status: `not_affected`, justification: `component_not_present` | "We removed the dependency" / "Feature disabled" / "Not deploying this" |
+| `risk-transferred` | status: `not_affected`, justification: `vulnerable_code_cannot_be_controlled_by_adversary` | "Our WAF handles it" / "Platform mitigates this" / "Handled by infrastructure" |
+
+### Dependabot Integration
+
+When `gh` CLI is available, check GitHub Dependabot alerts and PRs for additional context. Dependabot state is a **supplementary signal** — it does not override user decisions recorded in the memory file, but it enriches context.
+
+#### Checking gh CLI Availability
+
+```bash
+gh auth status 2>/dev/null
+```
+
+If this succeeds, the user has `gh` authenticated and you can query Dependabot. If it fails, skip Dependabot checks silently — do not prompt the user to authenticate.
+
+#### Querying Dependabot Alerts
+
+```bash
+# Get the repo owner/name from git remote
+gh api repos/{owner}/{repo}/dependabot/alerts --jq '[.[] | select(.security_advisory.cve_id == "'"$ARGUMENTS"'" or (.security_advisory.ghsa_id == "'"$ARGUMENTS"'") or (.security_advisory.identifiers[]? | select(.type == "CVE" and .value == "'"$ARGUMENTS"'") ) )] | first'
+```
+
+If the vuln ID is a GHSA, also match on `.security_advisory.ghsa_id`. If the vuln ID is a CVE, match on `.security_advisory.cve_id` and the identifiers array.
+
+If no alert matches the exact vuln ID, also try aliases from the memory file entry.
+
+#### Querying Dependabot PRs
+
+```bash
+# Find Dependabot PRs referencing this vulnerability or the affected package
+gh pr list --author "app/dependabot" --state all --json number,title,state,url,comments --limit 50 | jq '[.[] | select(.title | test("'"$PACKAGE_NAME"'"; "i"))]'
+```
+
+For each matching PR, extract:
+- PR number, state (open/closed/merged), URL
+- The **latest comment** (last item in `.comments[]`): `gh pr view <number> --json comments --jq '.comments[-1].body'`
+
+#### Dependabot Alert State → VEX Mapping
+
+Map Dependabot states to VEX status and user decision values. **Always communicate to the user in developer-friendly language.**
+
+| Dependabot Alert State | Dismiss Reason | VEX Status | Decision Choice | Developer Language |
+|---|---|---|---|---|
+| `open` | — | `under_investigation` | `investigating` | "Dependabot flagged this — still open, no action taken yet" |
+| `dismissed` | `fix_started` | `affected` | `deferred` | "Dependabot dismissed — team started a fix" |
+| `dismissed` | `inaccurate` | `not_affected` | `not-affected` | "Dependabot dismissed — team determined this is inaccurate" |
+| `dismissed` | `no_bandwidth` | `affected` | `deferred` | "Dependabot dismissed — deferred, no bandwidth" |
+| `dismissed` | `not_used` | `not_affected` | `not-affected` | "Dependabot dismissed — vulnerable code not used" |
+| `dismissed` | `tolerable_risk` | `affected` | `risk-accepted` | "Dependabot dismissed — risk accepted as tolerable" |
+| `fixed` | — | `fixed` | `fix-applied` | "Dependabot reports this as fixed" |
+| `auto_dismissed` | — | `not_affected` | `not-affected` | "Dependabot auto-dismissed — no longer applicable" |
+
+**When a Dependabot PR exists:**
+
+| PR State | VEX Interpretation | Developer Language |
+|---|---|---|
+| `open` | `affected` + `will_fix` | "Dependabot PR #N is open — the team is working on this upgrade" |
+| `merged` | `fixed` | "Dependabot PR #N was merged — fix applied via Dependabot" |
+| `closed` (not merged) | Check latest PR comment for reason | "Dependabot PR #N was closed without merging — <reason from comments>" |
+
+**For closed (not merged) PRs:** Read the latest comment on the PR to derive the justification. Common patterns:
+- "superseded by ..." / "replaced by ..." → decision: `deferred`, reason: paraphrase the comment
+- "not needed" / "false positive" → decision: `not-affected`, reason: paraphrase the comment
+- "will handle manually" → decision: `deferred`, reason: "Team will handle manually"
+- "breaking changes" / "can't upgrade" → decision: `deferred`, reason: paraphrase the comment
+- No comments or unclear → decision: `investigating`, reason: "Dependabot PR closed without explanation"
+
+#### When Dependabot and Memory File Disagree
+
+If the memory file has a user decision but Dependabot shows a different state:
+- **User decision takes precedence** — it represents a deliberate human choice
+- **Flag the discrepancy** to the user: "Note: Dependabot shows this as <state>, but you previously marked it as <decision>. The Dependabot state may be out of sync."
+- **Update the `dependabot` section** in the memory file to reflect current Dependabot state regardless — it's a factual record of what GitHub shows
+
+### Code Scanning (CodeQL) Integration
+
+When `gh` CLI is available, query GitHub code scanning alerts for findings that correlate with the current vulnerability. CodeQL alerts are correlated by **CWE match** — if the vulnerability's CWE (from VDB data) matches a CodeQL rule's tags or the rule directly references the vulnerability.
+
+#### Querying Code Scanning Alerts
+
+```bash
+# List all open code scanning alerts
+gh api repos/{owner}/{repo}/code-scanning/alerts?state=open --jq '[.[] | select(.rule.tags[]? | test("cwe-"; "i"))]'
+
+# Check for alerts matching a specific CWE (extracted from vuln context in Step 2)
+gh api repos/{owner}/{repo}/code-scanning/alerts --jq '[.[] | select(.rule.tags[]? | test("CWE-<NUMBER>"; "i"))]'
+
+# Also check dismissed and fixed alerts for prior decisions
+gh api repos/{owner}/{repo}/code-scanning/alerts?state=dismissed --jq '[.[] | select(.rule.tags[]? | test("CWE-<NUMBER>"; "i"))]'
+gh api repos/{owner}/{repo}/code-scanning/alerts?state=fixed --jq '[.[] | select(.rule.tags[]? | test("CWE-<NUMBER>"; "i"))]'
+```
+
+If the repository does not have code scanning enabled, these calls return 403 or 404 — skip silently.
+
+#### Checking Default Setup Status
+
+```bash
+gh api repos/{owner}/{repo}/code-scanning/default-setup --jq '{state, languages, query_suite}'
+```
+
+If `state` is `not-configured`, note this to the user: "CodeQL is not enabled on this repository. Consider enabling it to catch similar issues in code."
+
+#### Code Scanning Alert State → VEX Mapping
+
+| Code Scanning State | Dismissed Reason | VEX Status | Decision Choice | Developer Language |
+|---|---|---|---|---|
+| `open` | — | `under_investigation` | `investigating` | "CodeQL flagged this pattern — still open" |
+| `dismissed` | `false positive` | `not_affected` | `not-affected` | "CodeQL alert dismissed — false positive" |
+| `dismissed` | `won't fix` | `affected` | `risk-accepted` | "CodeQL alert dismissed — risk accepted" |
+| `dismissed` | `used in tests` | `not_affected` | `not-affected` | "CodeQL alert dismissed — only in test code" |
+| `fixed` | — | `fixed` | `fix-applied` | "CodeQL reports the code pattern is fixed" |
+
+**Enriching vulnerability context with CodeQL findings:**
+
+When a CodeQL alert matches the vulnerability's CWE:
+- The `most_recent_instance.location` tells you **exactly which file and line** the vulnerable pattern appears — include this in the fix report
+- The `rule.full_description` provides CodeQL's analysis of the weakness — quote relevant parts
+- If multiple instances exist, list the affected files so the user knows everywhere the pattern occurs
+- If the alert is `fixed`, this is strong evidence the code-level vulnerability has been addressed (complements a dependency version bump)
+- Use `dismissed_comment` as the justification text when surfacing prior decisions
+
+#### Autofix Integration (CodeQL AI Suggestions)
+
+If a CodeQL alert has an autofix available, check its status:
+
+```bash
+gh api repos/{owner}/{repo}/code-scanning/alerts/{alert_number}/autofix --jq '{status}'
+```
+
+| Autofix Status | What to tell the user |
+|---|---|
+| `success` | "CodeQL has an AI-suggested fix for this code pattern — review it on GitHub" |
+| `pending` | "CodeQL is generating an AI fix suggestion — check back later" |
+| `error` | "CodeQL autofix failed for this alert" |
+| `outdated` | "CodeQL's autofix is outdated — the code has changed since it was generated" |
+
+If autofix status is `success`, suggest the user review it alongside any dependency fix — code-level fixes and dependency upgrades are complementary.
+
+### Secret Scanning Integration
+
+When `gh` CLI is available, query GitHub secret scanning alerts. Secret scanning findings relate to vulnerability management when:
+- A leaked secret could be used to exploit the vulnerability (e.g., leaked API key + RCE = worse impact)
+- The vulnerability is in credential handling code (CWE-798, CWE-321, CWE-259)
+- The fix involves rotating secrets that may have been exposed
+
+#### Querying Secret Scanning Alerts
+
+```bash
+# List all open secret scanning alerts
+gh api repos/{owner}/{repo}/secret-scanning/alerts?state=open
+
+# List resolved alerts (to check for prior decisions)
+gh api repos/{owner}/{repo}/secret-scanning/alerts?state=resolved
+```
+
+If the repository does not have secret scanning enabled, these calls return 403 or 404 — skip silently.
+
+**Correlation with vulnerability context:**
+- If the vulnerability's CWE relates to credential handling (CWE-798 hard-coded credentials, CWE-321 hard-coded cryptographic key, CWE-259 hard-coded password, CWE-200 information exposure), check for secret scanning alerts in the same files
+- If the vulnerable package handles authentication/secrets (e.g., `jsonwebtoken`, `bcrypt`, `passport`, `oauth2`), check for leaked secrets that might need rotation after fixing
+
+#### Secret Scanning Alert State → VEX Mapping
+
+| Secret Scanning State | Resolution | VEX Status | Decision Choice | Developer Language |
+|---|---|---|---|---|
+| `open` | — | `under_investigation` | `investigating` | "Exposed secret detected — still open, needs rotation" |
+| `resolved` | `revoked` | `fixed` | `fix-applied` | "Secret was rotated and old one revoked" |
+| `resolved` | `false_positive` | `not_affected` | `not-affected` | "Secret alert dismissed — false positive" |
+| `resolved` | `wont_fix` | `affected` | `risk-accepted` | "Secret alert dismissed — risk accepted" |
+| `resolved` | `used_in_tests` | `not_affected` | `not-affected` | "Secret alert dismissed — only used in test fixtures" |
+| `resolved` | `pattern_edited` | `not_affected` | `not-affected` | "Secret scanning pattern was updated — no longer matches" |
+| `resolved` | `pattern_deleted` | `not_affected` | `not-affected` | "Secret scanning pattern was removed" |
+
+**Push protection context:**
+If `push_protection_bypassed` is `true`, note this to the user — it means someone deliberately pushed a secret past GitHub's push protection. Include the bypasser's username and their comment (if any) for audit trail:
+```
+Secret push protection was bypassed by <user>: "<comment>"
+```
+
+**Secret validity:**
+If `validity` is `active`, flag urgently: "This secret is still active — rotate it immediately." If `inactive`, note: "Secret has been deactivated." If `unknown`, note: "Secret validity could not be verified — recommend rotating as a precaution."
+
+#### When GHAS and Memory File Disagree
+
+Same principle as Dependabot:
+- **User decision takes precedence** over GitHub alert state
+- **Flag discrepancies** to the user
+- **Always update** the `code_scanning` and `secret_scanning` sections to reflect current GitHub state — they are factual records
+
+### Reading and Interpreting Prior State
+
+When the memory file contains an entry for the current vuln ID (or any of its aliases):
+
+1. **Show the user what's known** — previous status, decision, and when it was last updated
+2. **Show GitHub security context** — surface all available GHAS data:
+   - Dependabot: "Dependabot alert #N: <state>. PR #N: <state>."
+   - CodeQL: "CodeQL alert #N (<rule_id>): <state> in <file>:<line>"
+   - Secret scanning: "Secret scanning alert #N (<secret_type>): <state>, validity: <active|inactive|unknown>"
+3. **Highlight changes** — if the vulnerability context has changed (new severity, new fix available, CISA KEV listing added, any GHAS alert state changed), flag this to the user
+4. **Respect prior decisions** — if the user previously marked a vuln as "Risk accepted" or "Not affected", remind them of that decision and ask if they want to reassess rather than re-proposing the same fix
+5. **Update, don't duplicate** — update the existing entry rather than creating a new one
+
+## Workflow
+
+### Step 0: Load Vulnerability Memory and Prior SBOMs
+
+Before anything else:
+
+**0a. Load memory file:**
+1. Use **Glob** to search for `.vulnetix/memory.yaml` in the repo root
+2. If it exists, use **Read** to load it
+3. Check if the current vuln ID (from `$ARGUMENTS`) or any known aliases appear in the file
+4. If a prior entry exists:
+   - Display to the user: `Previously seen: <vulnId> — Status: <developer-friendly status> (as of <date>). Reason: <decision reason>`
+   - If `cwss` data exists from a prior `/vulnetix:exploits` analysis, display: `Priority: <P1/P2/P3/P4> (<score>) — "<priority description>"` and use the threat model context to inform fix urgency.
+   - If status is `fixed` and no new information contradicts it, confirm the fix is still in place by checking the current installed version. If the version has regressed, update the status to `affected` and proceed with the fix workflow.
+   - If status is `risk-accepted` or `not-affected`, ask: "You previously marked this as <status>. Has anything changed, or would you like to reassess?"
+   - If status is `investigating` or `deferred`, proceed with the fix workflow and note this is a follow-up.
+   - If the entry has a `discovery.sbom` path, read that CycloneDX file for additional context (affected components, version ranges, severity ratings from the original scan).
+5. If no prior entry exists, proceed normally — a new entry will be created in Step 8.
+
+**0b. Check for existing CycloneDX SBOMs:**
+1. Use **Glob** for `.vulnetix/scans/*.cdx.json`
+2. If SBOMs exist, scan them for the current vuln ID — this provides pre-existing context about which manifests surfaced this vulnerability and what component versions were scanned
+3. Reference the SBOM path in the memory entry's `discovery.sbom` field when creating or updating entries
+
+**0c. Check Dependabot via gh CLI:**
+1. Run `gh auth status 2>/dev/null` — if it fails, skip this step silently
+2. If `gh` is available, query Dependabot alerts for this vuln ID (see "Querying Dependabot Alerts" above)
+3. If a matching alert is found:
+   - Display to the user: `Dependabot alert #<N>: <developer-friendly state>` (using the mapping table)
+   - If a Dependabot PR exists, display: `Dependabot PR #<N>: <state>` with the latest comment summary
+   - If the alert is `dismissed` or `fixed`, show the reason
+4. If the memory file already has a `dependabot` section for this vuln, compare with current GitHub state and flag any changes: `"Dependabot state changed: <old> → <new>"`
+5. Update the `dependabot` section in the memory entry with current state (will be persisted in Step 8)
+6. Use Dependabot context to inform fix urgency:
+   - Open alert + open PR → "A Dependabot upgrade PR already exists — consider reviewing and merging PR #N instead of manual fix"
+   - Open alert + no PR → proceed with normal fix workflow
+   - Open alert + closed PR → check PR comments for context on why it was closed — inform fix approach accordingly
+
+**0d. Check Code Scanning (CodeQL) via gh CLI:**
+1. Skip if `gh` auth failed in 0c
+2. Extract the CWE ID from the vulnerability context (fetched in Step 2, but pre-check here if the memory file already has `threat_model` data or known CWE from prior analysis)
+3. Query code scanning alerts matching the CWE:
+   ```bash
+   gh api repos/{owner}/{repo}/code-scanning/alerts --jq '[.[] | select(.rule.tags[]? | test("CWE-<NUMBER>"; "i"))]'
+   ```
+4. If CodeQL alerts are found:
+   - Display: `CodeQL alert #<N> (<rule_id>): <state> in <file>:<line>` for each
+   - If any alert is `dismissed`, show the reason and comment
+   - If any alert has autofix status `success`, note: "CodeQL has an AI-suggested fix available"
+5. Check default setup status to inform the user if CodeQL is not enabled:
+   ```bash
+   gh api repos/{owner}/{repo}/code-scanning/default-setup --jq '.state'
+   ```
+   If `not-configured`, note: "CodeQL is not enabled on this repo — consider enabling it for ongoing code-level detection of this weakness class"
+6. If the memory file has a prior `code_scanning` section, compare alert states and flag changes
+7. Store CodeQL findings for persistence in Step 8
+
+**0e. Check Secret Scanning via gh CLI:**
+1. Skip if `gh` auth failed in 0c
+2. Determine if secret scanning is relevant to this vulnerability:
+   - Check if the CWE relates to credential handling (CWE-798, CWE-321, CWE-259, CWE-200, CWE-522, CWE-256)
+   - Check if the affected package handles authentication/secrets
+3. If relevant, query secret scanning alerts:
+   ```bash
+   gh api repos/{owner}/{repo}/secret-scanning/alerts?state=open
+   ```
+4. If alerts are found in files that overlap with the vulnerability's affected code:
+   - Display: `Secret scanning alert #<N> (<secret_type>): <state>, validity: <validity>`
+   - If `validity` is `active`, flag urgently: "Active secret detected — rotate immediately, especially given this vulnerability"
+   - If `push_protection_bypassed`, note the bypass for audit context
+5. Also check resolved alerts for prior decisions:
+   ```bash
+   gh api repos/{owner}/{repo}/secret-scanning/alerts?state=resolved --jq '[.[] | select(.resolution != null)]'
+   ```
+6. If the memory file has a prior `secret_scanning` section, compare and flag state changes
+7. Store secret scanning findings for persistence in Step 8
+
+### Step 1: Fetch Fix Data
+
+Run the Vulnetix VDB fixes command for both V1 and V2 endpoints:
+
+```bash
+vulnetix vdb fixes "$ARGUMENTS" -o json
+vulnetix vdb fixes "$ARGUMENTS" -o json -V v2
+```
+
+**V1 response** (basic fixes):
+```json
+{
+  "fixes": [
+    {
+      "type": "version",
+      "package": "log4j-core",
+      "ecosystem": "maven",
+      "fixedIn": "2.17.1",
+      "description": "Upgrade to patched version"
+    }
+  ]
+}
+```
+
+**V2 response** (enhanced with registry, distro, source fixes):
+```json
+{
+  "fixes": [
+    {
+      "type": "registry",
+      "package": "log4j-core",
+      "ecosystem": "maven",
+      "fixedIn": "2.17.1",
+      "registryUrl": "https://repo1.maven.org/...",
+      "releaseDate": "2021-12-28"
+    },
+    {
+      "type": "distro-patch",
+      "distro": "ubuntu",
+      "version": "20.04",
+      "package": "liblog4j2-java",
+      "patchVersion": "2.17.1-0ubuntu1",
+      "aptCommand": "sudo apt-get install liblog4j2-java=2.17.1-0ubuntu1"
+    },
+    {
+      "type": "source-fix",
+      "commitUrl": "https://github.com/apache/logging-log4j2/commit/abc123",
+      "patchUrl": "https://github.com/apache/logging-log4j2/commit/abc123.patch"
+    }
+  ]
+}
+```
+
+### Step 2: Fetch Vulnerability Context
+
+Get additional context about the vulnerability:
+
+```bash
+vulnetix vdb vuln "$ARGUMENTS" -o json
+vulnetix vdb affected "$ARGUMENTS" -o json -V v2
+```
+
+Extract:
+- **Affected package/product** names
+- **Vulnerable version ranges** (e.g., `>=2.0.0, <2.17.1`)
+- **CVSS/severity** (to assess urgency)
+- **CISA KEV due date** (if applicable)
+
+### Step 3: Analyze Repository Dependencies (Deep Filesystem Scan)
+
+You MUST perform a thorough scan that goes beyond the current working directory. Search the entire project tree including gitignored directories.
+
+#### 3a-pre: Check for Cached SBOMs
+
+Before scanning, check the `manifests` section of `.vulnetix/memory.yaml` for recently scanned files. If a manifest was scanned by the pre-commit hook (or a prior skill invocation) within the last 24 hours (`last_scanned` timestamp), read the cached SBOM from `sbom_path` instead of re-scanning. This avoids redundant API calls. If the SBOM file is missing or stale, proceed with a fresh scan.
+
+#### 3a: Find All Manifest and Lockfiles
+
+Use **Glob** to find manifest files across the project, including monorepo structures:
+
+```
+**/package.json, **/package-lock.json, **/yarn.lock, **/pnpm-lock.yaml
+**/requirements.txt, **/pyproject.toml, **/Pipfile, **/Pipfile.lock, **/poetry.lock, **/uv.lock
+**/go.mod, **/go.sum
+**/Cargo.toml, **/Cargo.lock
+**/pom.xml, **/build.gradle, **/build.gradle.kts, **/gradle.lockfile
+**/Gemfile, **/Gemfile.lock
+**/composer.json, **/composer.lock
+```
+
+#### 3b: Derive Installed Versions from the Filesystem
+
+**Do not rely solely on manifests.** Verify the actually-installed version by reading from package manager artifacts. These directories are typically gitignored — read them directly:
+
+- **npm/node:** Read `node_modules/<package>/package.json` → `.version` field. Also check parent directories and workspace root `node_modules/`.
+- **Python:** Run `pip show <package>` or read `.venv/lib/python*/site-packages/<package>/METADATA` or `__pycache__` dist-info directories.
+- **Go:** Parse `go.sum` for exact hashes. Run `go list -m -json <package>` if go toolchain is available.
+- **Rust:** Read `Cargo.lock` for exact resolved versions. Run `cargo metadata --format-version 1` if available.
+- **Maven:** Check `~/.m2/repository/<groupPath>/<artifact>/` for cached JARs. Run `mvn dependency:tree` if available.
+- **Ruby:** Read `Gemfile.lock` for resolved versions.
+- **System binaries:** Run `which <binary>` then `<binary> --version` to determine installed version from `PATH`.
+
+#### 3c: Determine Dependency Relationship
+
+Use **Read** on each manifest and lockfile to determine:
+
+1. **Is the vulnerable package installed?** (exact name match in manifest or lockfile)
+2. **What version is installed?** (compare manifest, lockfile, AND filesystem-installed version — report all if they differ)
+3. **Is it a direct or transitive dependency?** (present in manifest = direct; only in lockfile = transitive)
+4. **What imports/requires are used from this package?** Use **Grep** to find all import/require/include statements referencing the vulnerable package across the codebase
+
+If the package is **not found**, inform the user that the vulnerability may not affect this repository.
+
+### Step 4: Evaluate Dependency Inlining (First-Party Replacement)
+
+Before proposing a version bump, evaluate whether the dependency can be removed entirely:
+
+**Criteria for inlining (ALL must be true):**
+1. The affected third-party code is **open source** with a compatible license
+2. The source is **publicly available online** (e.g., on GitHub, GitLab, crates.io source)
+3. The portion of the library actually used by this application is **small** — assess by:
+   - Counting how many functions/classes/modules from the package are imported
+   - Estimating the lines of code for just those used parts (< ~200 lines is a good threshold)
+4. The used functionality is **self-contained** (no deep internal dependency chain within the library)
+
+**If inlining is viable:**
+- Use **WebFetch** to retrieve the specific source file(s) from the upstream repository
+- Extract only the functions/classes actually used by the application
+- Preserve the original license attribution in a comment header
+- Propose writing the extracted code as a first-party module (e.g., `lib/`, `internal/`, `utils/`)
+- Show edits to update all import/require statements to point to the new first-party module
+- Show edits to remove the dependency from all manifest and lockfiles
+
+**Present this as Option A0 (highest priority) when the criteria are met,** above the standard Version Bump option.
+
+### Step 5: Present Fix Options
+
+Categorize fixes into 5 categories (A0-D) and present them in priority order. **Every option MUST include the Safe Harbour confidence score and all version details per the Mandatory Reporting Requirements above.**
+
+---
+
+#### **A0. Inline as First-Party Code** (Best — when viable)
+
+If the inlining evaluation in Step 4 passed:
+
+```
+Package: <name>
+Current Version: <version> (source: <version-source>)
+Fix: Remove dependency entirely, inline <N> functions as first-party code
+Safe Harbour: <score> (typically High — you own the code, no upstream risk)
+License: <original license> (attribution preserved in source header)
+```
+
+**Action:** Write inlined module, update all imports, remove from manifests and lockfiles.
+
+---
+
+#### **A. Version Bump** (Preferred when inlining is not viable)
+
+If a patched version is available in the registry:
+
+| Current Version | Version Source | Target Version | Fix Source | Safe Harbour | Breaking Changes? | Manifest File |
+|-----------------|---------------|----------------|------------|-------------|-------------------|---------------|
+| 2.14.1 | Lockfile: pom.xml | 2.17.1 | Registry: Maven Central | 0.82 (Reasonable) | Minor API changes | pom.xml |
+
+**Action:** Update dependency version in manifest file.
+
+**Risk assessment:**
+- **Patch version** (2.14.1 → 2.14.2): Low risk, backward compatible
+- **Minor version** (2.14.x → 2.15.0): Medium risk, check changelog
+- **Major version** (2.x → 3.0): High risk, breaking changes expected
+
+---
+
+#### **B. Patch** (Alternative)
+
+If a source patch or distro patch is available:
+
+| Patch Source | Type | Commit/Version | Safe Harbour | Applicability |
+|--------------|------|----------------|-------------|---------------|
+| GitHub commit `abc123` | Source fix | `abc123` | 0.55 (Reasonable) | Can be applied to local fork |
+| Ubuntu 20.04 | Distro patch | `2.17.1-0ubuntu1` | 0.75 (Reasonable) | Only if running on Ubuntu |
+
+**Action:** Download patch and apply to local dependency copy (advanced users only).
+
+---
+
+#### **C. Workaround** (Temporary Mitigation)
+
+If no fix is available yet, provide temporary mitigations:
+
+- **Configuration changes** (disable vulnerable feature, enable safeguards)
+- **Input validation** (sanitize untrusted input)
+- **Network isolation** (firewall rules, rate limiting)
+- **Vendor-recommended workarounds** (from advisory)
+- **Selective imports** — refactor imports to avoid loading the vulnerable code path (see Step 7)
+
+**Action:** Apply configuration changes to relevant files.
+
+---
+
+#### **D. Advisory Guidance** (Informational)
+
+- **Vendor advisory links** (official fix documentation)
+- **CISA KEV due date** (if listed, agencies must patch by this date)
+- **Community discussion** (GitHub issues, Stack Overflow)
+
+**Action:** No immediate action, but monitor for updates.
+
+---
+
+### Step 6: Apply Fixes Immediately
+
+After presenting the options, **immediately begin applying the preferred fix** (do not wait for a planning interview unless the situation is ambiguous). Apply changes in this order:
+
+#### 6a: Back Up Lockfiles and Manifests for Rollback
+
+Before making any changes, preserve the current state so the user can roll back:
+
+```bash
+# Copy lockfiles and manifests to a backup location
+cp package-lock.json package-lock.json.vulnetix-backup 2>/dev/null
+cp yarn.lock yarn.lock.vulnetix-backup 2>/dev/null
+cp pom.xml pom.xml.vulnetix-backup 2>/dev/null
+# ... for each relevant file
+```
+
+Inform the user that backups have been created and how to restore them.
+
+#### 6b: Update Package Manager Manifests
+
+Use **Edit** to update version constraints in all affected manifest files. Handle version locking and conflicts:
+
+- **npm:** If `package-lock.json` pins a conflicting version, update both `package.json` and consider running `npm install` to regenerate the lockfile
+- **Python (pip):** Update `requirements.txt` version pins. If using `pip-compile` / `pip-tools`, update `.in` files
+- **Python (poetry):** Update `pyproject.toml` version constraints
+- **Go:** Update `go.mod` require directives
+- **Rust:** Update `Cargo.toml` version constraints. Handle workspace-level version overrides in `[patch]` section
+- **Maven:** Update `<version>` in `pom.xml`. Handle BOM (Bill of Materials) version management in parent POMs
+- **Gradle:** Update version in `build.gradle` or version catalog
+
+**Dependency resolution overrides:** When version conflicts exist (e.g., another dependency pins the vulnerable version), apply package manager-specific override mechanisms:
+- **npm:** `overrides` field in `package.json`
+- **yarn:** `resolutions` field in `package.json`
+- **pnpm:** `pnpm.overrides` in `package.json`
+- **pip:** constraint files or direct pins
+- **Maven:** `<dependencyManagement>` section or `<exclusions>`
+- **Cargo:** `[patch]` section in `Cargo.toml`
+
+#### 6c: Refactor Imports to Minimize Attack Surface
+
+Use **Grep** to find all import/require/include statements for the vulnerable package. Where possible, refactor to import only the specific submodules or functions needed rather than the entire package:
+
+**JavaScript/TypeScript:**
+```diff
+- import lodash from 'lodash'
++ import get from 'lodash/get'
++ import set from 'lodash/set'
+```
+
+**Python:**
+```diff
+- import cryptography
++ from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+```
+
+**Java:**
+```diff
+- import org.apache.commons.collections.*;
++ import org.apache.commons.collections.CollectionUtils;
+```
+
+**Go:**
+```diff
+// Go imports are already module-path scoped — check if a subpackage can be used instead
+- import "github.com/example/biglib"
++ import "github.com/example/biglib/subpkg"
+```
+
+This reduces the attack surface by not loading vulnerable code paths that the application never uses.
+
+#### 6d: Dry-Run Package Manager to Verify
+
+After editing manifests, run the package manager in dry-run or check mode to verify the dependency resolution succeeds without actually modifying `node_modules/` or equivalents:
+
+```bash
+# npm
+npm install --dry-run
+
+# yarn
+yarn install --check-files
+
+# pnpm
+pnpm install --dry-run
+
+# pip
+pip install --dry-run -r requirements.txt
+
+# go
+go mod tidy -v  # prints what it would change
+
+# cargo
+cargo check
+
+# maven
+mvn dependency:resolve -DdryRun
+
+# composer
+composer install --dry-run
+```
+
+If the dry run fails (e.g., version conflict, missing package), diagnose the issue and either:
+1. Adjust version constraints to resolve the conflict
+2. Apply a dependency override (see 6b)
+3. Report the conflict to the user with suggested alternatives
+
+If the dry run succeeds, inform the user that the fix resolves cleanly.
+
+#### 6e: Restore on Failure
+
+If any step fails and the fix cannot be completed, restore from backups:
+
+```bash
+mv package-lock.json.vulnetix-backup package-lock.json 2>/dev/null
+# ... for each backed-up file
+```
+
+Inform the user what failed and why, and suggest alternative approaches.
+
+### Step 7: Post-Fix Verification
+
+After applying fixes:
+
+1. **Run tests** (identify test command from manifest and run it):
+```bash
+npm test             # npm
+pytest               # Python
+go test ./...        # Go
+cargo test           # Rust
+mvn test             # Maven
+```
+
+2. **Re-scan for the vulnerability and persist the CycloneDX SBOM:**
+```bash
+mkdir -p .vulnetix/scans
+vulnetix scan --file <manifest> -f cdx17 > .vulnetix/scans/<sanitized-manifest>.cdx.json
+```
+   - Use the same naming convention as the pre-commit hook: replace `/` with `--` in the manifest path
+   - This overwrites any prior SBOM for the same manifest, so `.vulnetix/scans/` always has the latest scan
+   - Update the `discovery.sbom` field in `.vulnetix/memory.yaml` to point to this file
+
+3. **Report results** including all version details:
+```
+Fix Applied:
+  Package: <name>
+  Previous Version: <old> (source: <how determined>)
+  New Version: <new> (source: <registry|distro|commit>)
+  Safe Harbour: <score> (<tier> confidence)
+  Verification: <scan passed|scan still flags|tests passed|tests failed>
+  Rollback: <backup files created at ...>
+```
+
+If the scan still shows the vulnerability, explain that it may be a transitive dependency and suggest:
+- Using dependency update tools (`npm audit fix`, `cargo update`, etc.)
+- Manually updating the parent dependency that pulls in the vulnerable package
+- Checking if a newer version of the parent dependency exists
+- Applying dependency overrides (see Step 6b)
+
+### Step 8: Update Vulnerability Memory
+
+After **every** action in this skill — whether a fix was applied, the user made a decision, or new information was discovered — update `.vulnetix/memory.yaml`.
+
+#### 8a: Create or Update the Entry
+
+Use **Read** to load the current file (if it exists), then use **Write** to update it. If the file does not exist, create it with the `schema_version: 1` header.
+
+**On first discovery** (no prior entry for this vuln ID):
+```yaml
+  <VULN_ID>:
+    aliases: [<any known aliases from VDB response>]
+    package: <package name>
+    ecosystem: <ecosystem>
+    discovery:
+      date: "<current ISO 8601 UTC timestamp>"
+      source: <manifest|lockfile|sbom|scan|user|hook>
+      file: <file where found, or null>
+      sbom: <.vulnetix/scans/<manifest>.cdx.json, or null>
+    versions:
+      current: "<detected version>"
+      current_source: "<how version was determined>"
+      fixed_in: "<patched version, or null>"
+      fix_source: "<registry|distro|commit hash, or null>"
+    severity: <critical|high|medium|low|unknown>
+    safe_harbour: <0.00-1.00>
+    status: under_investigation
+    justification: null
+    action_response: null
+    decision:
+      choice: investigating
+      reason: "Discovered via /vulnetix:fix"
+      date: "<current timestamp>"
+    history:
+      - date: "<current timestamp>"
+        event: discovered
+        detail: "Found <package>@<version> in <file>"
+```
+
+**On fix applied:**
+- Set `status: fixed`, `decision.choice: fix-applied`
+- Update `versions.current` to the new version
+- Append to `history`: `event: fix-applied`, detail: what was done
+
+**On user decision** (interpret user feedback using VEX semantics):
+- User says "won't fix" / "accept the risk" → `status: affected`, `action_response: will_not_fix`, `decision.choice: risk-accepted`
+- User says "doesn't affect us" → `status: not_affected`, `decision.choice: not-affected`, set appropriate `justification`
+- User says "we'll fix this later" → `status: affected`, `action_response: will_fix`, `decision.choice: deferred`
+- User says "we have a workaround" → `status: not_affected`, `justification: inline_mitigations_already_exist`, `decision.choice: mitigated`
+- User says "need more info" → `status: under_investigation`, `decision.choice: investigating`
+- Dependency was inlined as first-party → `status: fixed`, `decision.choice: inlined`
+- User says "we removed it" / "disabled that feature" → `status: not_affected`, `justification: component_not_present`, `decision.choice: risk-avoided`
+- User says "our WAF handles it" / "platform mitigates this" → `status: not_affected`, `justification: vulnerable_code_cannot_be_controlled_by_adversary`, `decision.choice: risk-transferred`
+- Always record the user's actual words in `decision.reason`
+- Always append the decision to `history`
+
+#### 8b: Preserve Decision Context
+
+When recording a user decision, always capture:
+- **What the user said** (verbatim or close paraphrase) as the `reason`
+- **The current timestamp** as the `date`
+- **Any qualifying context** (e.g., "accepted risk because this is an internal tool" or "deferring until after the v2.0 release")
+
+#### 8c: Persist Dependabot State
+
+If Dependabot data was gathered in Step 0c, write it to the `dependabot` section of the memory entry:
+- `alert_number`, `alert_state`, `alert_url`
+- `dismiss_reason`, `dismiss_comment` (if dismissed)
+- `pr_number`, `pr_state`, `pr_url`, `pr_latest_comment` (if a PR exists)
+- `last_checked`: current timestamp
+
+If a Dependabot alert state change resulted in a VEX status update (e.g., alert moved from `open` to `fixed`), append to `history`: `event: dependabot-sync`, detail: `"Dependabot alert #N: <old state> → <new state>"`
+
+**Do NOT change `status` or `decision` based on Dependabot alone** if the user has already made a deliberate decision. Only auto-update status from Dependabot if:
+- No prior user decision exists (i.e., `decision.choice` is `investigating`)
+- The Dependabot state is more definitive (e.g., `fixed` or `dismissed` with a clear reason)
+
+#### 8d: Persist Code Scanning (CodeQL) State
+
+If CodeQL data was gathered in Step 0d, write it to the `code_scanning` section of the memory entry:
+- `alerts[]`: each correlated alert with `alert_number`, `state`, `rule_id`, `rule_name`, `severity`, `dismissed_reason`, `dismissed_comment`, `dismissed_by`, `file_path`, `start_line`, `url`
+- `tool`, `tool_version`: from the alert's `tool` field
+- `last_checked`: current timestamp
+
+If a CodeQL alert state changed since the last check, append to `history`: `event: codeql-sync`, detail: `"CodeQL alert #N (<rule_id>): <old state> → <new state>"`
+
+**Auto-update rules** (same principle as Dependabot):
+- Only auto-update `status`/`decision` from CodeQL if no prior user decision exists
+- A CodeQL `fixed` state is strong evidence the code-level issue is resolved — note in history but let user confirm
+- A CodeQL `dismissed` with `dismissed_comment` provides justification context — record it but don't override user decisions
+
+#### 8e: Persist Secret Scanning State
+
+If secret scanning data was gathered in Step 0e, write it to the `secret_scanning` section of the memory entry:
+- `alerts[]`: each correlated alert with `alert_number`, `state`, `secret_type`, `secret_type_display`, `resolution`, `resolution_comment`, `resolved_by`, `validity`, `file_path`, `url`, `push_protection_bypassed`
+- `last_checked`: current timestamp
+
+If a secret scanning alert state changed, append to `history`: `event: secret-scanning-sync`, detail: `"Secret scanning alert #N (<secret_type>): <old state> → <new state>"`
+
+If a previously active secret is now `inactive` (revoked), note this as positive progress. If a previously unknown secret is now `active`, flag urgently.
+
+#### 8f: Handle Aliases
+
+If the VDB response reveals that this vuln ID has aliases (e.g., a CVE maps to a GHSA, or vice versa), update the `aliases` list. When checking for prior entries in Step 0, always check both the primary ID and all known aliases.
+
+#### 8g: Update Manifests Section
+
+If any manifest files were scanned during this fix workflow (Step 3 or Step 7), update the `manifests` section of `.vulnetix/memory.yaml`:
+- For each scanned manifest: set `last_scanned` to current timestamp, `vuln_count` to the result, `scan_source: fix`
+- If a new CycloneDX SBOM was generated, set `sbom_generated: true` and update `sbom_path`
+- If a manifest was discovered that isn't already tracked, add a new entry with its `path`, `ecosystem`, and scan metadata
+- Do not remove manifest entries added by the hook or other skills — only update or add
+
+#### 8h: Clean Output
+
+After writing the memory file, confirm to the user:
+```
+Vulnerability memory updated: <VULN_ID> — <developer-friendly status> (<reason summary>)
+GitHub security sync: Dependabot <state>, CodeQL <N alerts>, Secret scanning <N alerts>
+```
+
+## Error Handling
+
+- If `vulnetix vdb fixes` returns no results, inform the user that no official fix is available yet and suggest workarounds or monitoring. Still record the vuln in `.vulnetix/memory.yaml` with `status: under_investigation`.
+- If the package is not found in the repository, confirm with the user whether it's a transitive dependency. Record as `status: not_affected`, `justification: component_not_present` if confirmed absent.
+- If manifest format is complex (Gradle, multi-module Maven), ask the user which file to edit
+- If breaking changes are expected, warn the user and recommend testing thoroughly
+- If version cannot be determined from any source, report "Unknown" with an explanation and ask the user to provide it
+- If dry-run fails, restore backups and report the conflict
+- If `.vulnetix/memory.yaml` cannot be written (permissions, etc.), warn the user but do not block the fix workflow
+
+## Security Notes
+
+- **Always upgrade to the latest patched version** unless there are known regressions
+- If a vulnerability has a **CISA KEV due date**, prioritize it as urgent
+- For **critical/high severity** vulnerabilities, recommend immediate patching even if it requires major version bumps
+- Never downgrade to an older version as a "fix" — this may introduce other vulnerabilities
+- When inlining code, always preserve license attribution
+- When refactoring imports, verify the reduced import set still covers all usages in the codebase via **Grep**
+
+## Integration with Other Skills
+
+- If exploits are known, suggest running `/vulnetix:exploits $ARGUMENTS` first to understand impact
+- After fixing, suggest re-running `/vulnetix:package-search` if adding new dependencies as alternatives
+- The `/vulnetix:exploits` and `/vulnetix:package-search` skills also read and contribute to `.vulnetix/memory.yaml` — decisions made in any skill are visible to all others

--- a/plugins/vulnetix/skills/package-search/SKILL.md
+++ b/plugins/vulnetix/skills/package-search/SKILL.md
@@ -1,0 +1,324 @@
+---
+name: package-search
+description: Search for packages and assess security risk before adding as dependencies
+argument-hint: <package-name>
+user-invocable: true
+allowed-tools: Bash, Read, Glob, Grep, Edit, Write
+model: sonnet
+---
+
+# Vulnetix Package Search Skill
+
+This skill searches for packages across ecosystems and provides a comprehensive security risk assessment before adding them as dependencies.
+
+## Output & Analysis Guidelines
+
+**Primary output format:** Markdown. All reports, tables, summaries, and diffs MUST be presented as formatted markdown text directly — never generate scripts or programs to produce output that can be expressed as markdown.
+
+**Visual data — use Mermaid diagrams** to display data visually when it aids comprehension. Mermaid renders natively in markdown and requires no external tools. Use it for:
+- Dependency trees / upgrade paths → `graph TD` or `graph LR`
+- Version comparison timelines → `timeline`
+- Risk breakdowns → `pie` or `quadrantChart`
+- Decision flow (add/skip/alternatives) → `flowchart`
+
+Example — vulnerability distribution for a package:
+````markdown
+```mermaid
+pie title Vulnerability Severity
+    "Critical" : 1
+    "High" : 2
+    "Medium" : 5
+    "Low" : 3
+```
+````
+
+**If `uv` is available**, richer visualizations can be generated with Python (matplotlib, plotly) and saved to `.vulnetix/`:
+```bash
+command -v uv &>/dev/null && uv run --with matplotlib python3 -c '
+import matplotlib.pyplot as plt
+# ... generate chart ...
+plt.savefig(".vulnetix/chart.png", dpi=150, bbox_inches="tight")
+'
+```
+When Python charts are generated, display them inline and keep the Mermaid version as a text fallback.
+
+**Data processing — tooling cascade (strict order):**
+
+1. **jq / yq + bash builtins** (preferred) — `jq` for JSON, `yq` for YAML. Pipe to `head`, `tail`, `cut`, `sed`, `grep`, `sort`, `uniq`, `wc` for shaping.
+2. **uv** (for complex analysis or charts) — If aggregation, statistics, or visualization beyond Mermaid are needed, check `uv` first:
+   ```bash
+   command -v uv &>/dev/null && uv run --with pandas,matplotlib python3 -c '...'
+   ```
+3. **python3 stdlib** (last resort) — Only if `uv` is unavailable. Use `json`, `csv`, `collections`, `statistics` modules — **no pip dependencies**:
+   ```bash
+   command -v python3 &>/dev/null && python3 -c 'import json, sys; ...'
+   ```
+
+**Never assume any runtime is available** — always check with `command -v` before use. If all programmatic tools are unavailable, analyze manually with the Read tool and present results as markdown with Mermaid diagrams.
+
+**Version detection commands** (`pip show`, `go list -m`, `cargo pkgid`, etc.) are exempt — they query package managers directly and are tried as-available per the version detection priority in Step 1b.
+
+## Vulnerability Memory (.vulnetix/memory.yaml)
+
+This skill reads the `.vulnetix/memory.yaml` file in the repository root to surface prior vulnerability history for packages being searched. This file is shared with `/vulnetix:fix` and `/vulnetix:exploits`.
+
+**At the start of every invocation:**
+1. Use **Glob** to check if `.vulnetix/memory.yaml` exists in the repo root
+2. If it exists, use **Read** to load it
+3. Use **Glob** for `.vulnetix/scans/*.cdx.json` — if CycloneDX SBOMs exist from prior scans (pre-commit hook or fix skill), cross-reference package names against SBOM component lists for additional vulnerability context
+
+**During risk assessment (Step 4):**
+1. For each package in the search results, check if any vulnerabilities in the memory file reference that package name
+2. If prior entries exist, add a **Known History** column or section to the output:
+   - List each vuln ID, its current status (in developer-friendly language), decision date, and CWSS priority if available
+   - Example: `CVE-2021-44228 — Fixed (2024-01-15)`, `CVE-2023-1234 — Risk accepted (2024-03-01), P3 (52.0)`
+   - If `pocs` exist for a vuln, note: `N PoC(s) on file` — do not display PoC URLs or paths in package search output
+3. If a package has unresolved vulnerabilities (`affected` or `under_investigation`), flag this prominently in the risk assessment. If CWSS priority is P1 or P2, add a warning: "Active exploit intelligence available — run `/vulnetix:exploits <vuln-id>` for details"
+
+**After completing the search:**
+1. If the search reveals new vulnerabilities (from `vulnerabilityCount` or `maxSeverity` in the API response) that are NOT already tracked in the memory file, record them as new entries with:
+   - `status: under_investigation`
+   - `discovery.source: scan`
+   - `discovery.sbom`: path to the relevant `.vulnetix/scans/*.cdx.json` if one exists for this package's manifest
+   - `decision.choice: investigating`
+   - `decision.reason: "Discovered via /vulnetix:package-search"`
+2. Append to `history`: `event: discovered`, detail: "Found via package search for <query>"
+
+**VEX-to-developer-language:** When surfacing prior decisions, use developer-friendly language:
+- `not_affected` → "Not affected", `affected` → "Vulnerable", `fixed` → "Fixed", `under_investigation` → "Investigating"
+
+## Dependabot Integration
+
+When `gh` CLI is available (check with `gh auth status 2>/dev/null`), query Dependabot alerts for packages in the search results to enrich the risk assessment.
+
+**During Step 4 (Risk Assessment):**
+1. For each package in the results, check for open Dependabot alerts:
+   ```bash
+   gh api repos/{owner}/{repo}/dependabot/alerts?state=open --jq '[.[] | select(.dependency.package.name == "'"$PACKAGE_NAME"'")] | length'
+   ```
+2. If alerts exist, add a **Dependabot Alerts** column to the comparison table showing the count and highest severity
+3. If a Dependabot PR exists for the package, note it: `"Dependabot PR #N open for <package> upgrade"`
+4. If a prior memory entry for this package has a `dependabot` section, surface it in the Known History output:
+   - Example: `CVE-2021-44228 — Fixed (2024-01-15, Dependabot: merged PR #187)`
+
+**During Step 5 (Propose Dependency Addition):**
+- If a Dependabot PR already proposes the same version upgrade, suggest reviewing and merging that PR instead of manual editing: `"Dependabot PR #N already proposes this upgrade — consider merging it instead"`
+
+This avoids duplicate work and leverages Dependabot's existing CI validation.
+
+## Code Scanning (CodeQL) Integration
+
+When `gh` CLI is available, check if CodeQL has flagged issues related to packages being searched. The canonical state-to-VEX mapping is defined in `/vulnetix:fix`.
+
+**During Step 4 (Risk Assessment):**
+1. For each package with known vulnerabilities, check if CodeQL alerts match the associated CWEs:
+   ```bash
+   gh api repos/{owner}/{repo}/code-scanning/alerts --jq '[.[] | select(.rule.tags[]? | test("CWE-<NUMBER>"; "i"))] | length'
+   ```
+2. If matching alerts exist, add a **CodeQL Alerts** column to the comparison table showing count and states
+3. If a prior memory entry for this package has a `code_scanning` section, surface it in Known History:
+   - Example: `CVE-2021-44228 — Fixed (2024-01-15, CodeQL: alert #15 fixed)`
+4. If CodeQL default setup is not configured, note: "CodeQL not enabled — consider enabling for code-level detection"
+
+**During Step 5 (Propose Dependency Addition):**
+- If a CodeQL autofix is available for related alerts, mention it: "CodeQL also has an AI-suggested code fix for the related code pattern"
+
+## Secret Scanning Integration
+
+When `gh` CLI is available, check for secret scanning alerts relevant to packages handling authentication or credentials.
+
+**During Step 4 (Risk Assessment):**
+1. If a package being evaluated handles auth/secrets (e.g., `jsonwebtoken`, `bcrypt`, `passport`, `oauth2`, `crypto`, `keyring`), check for open secret scanning alerts:
+   ```bash
+   gh api repos/{owner}/{repo}/secret-scanning/alerts?state=open --jq 'length'
+   ```
+2. If active secrets exist alongside a package that handles credentials, flag: "Active secrets detected in this repo — adding/upgrading this package should include a secret rotation review"
+3. If a prior memory entry has a `secret_scanning` section, surface it in Known History
+
+## Workflow
+
+### Step 1: Detect Repository Ecosystems
+
+**Check cached manifest data first:** If `.vulnetix/memory.yaml` has a `manifests` section, use it to identify previously detected ecosystems and their scan dates. This avoids re-globbing for manifests that are already tracked. If the manifests section exists and is recent (< 24h), use the cached ecosystem list as a starting point.
+
+**Then verify with Glob** to catch any new manifest files:
+
+- `package.json`, `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml` → **npm**
+- `go.mod`, `go.sum` → **go**
+- `Cargo.toml`, `Cargo.lock` → **cargo**
+- `requirements.txt`, `pyproject.toml`, `Pipfile`, `poetry.lock`, `uv.lock` → **pypi**
+- `Gemfile`, `Gemfile.lock` → **rubygems**
+- `pom.xml`, `build.gradle`, `gradle.lockfile` → **maven**
+- `composer.json`, `composer.lock` → **packagist**
+
+Determine which ecosystems this repository uses. If new manifest files are discovered that aren't in the `manifests` section of `.vulnetix/memory.yaml`, add them with `ecosystem`, `path`, and `scan_source: package-search` (without `sbom_generated: true` since this skill doesn't generate SBOMs).
+
+### Step 1b: Detect Currently Installed Version
+
+For the package being searched, determine if it is **already installed** and what version is in use. You **MUST** resolve the current version using one of these methods (in priority order) and **always disclose the source** in your output:
+
+1. **User-supplied version** — the user explicitly stated the version in their message
+2. **Lockfile** — the most authoritative filesystem source:
+   - **npm**: Read `package-lock.json` or `yarn.lock` or `pnpm-lock.yaml` for the resolved version
+   - **pypi**: Read `poetry.lock`, `Pipfile.lock`, or `uv.lock`
+   - **go**: Read `go.sum` for the recorded version
+   - **cargo**: Read `Cargo.lock` for the resolved version
+   - **rubygems**: Read `Gemfile.lock`
+   - **maven**: Read `gradle.lockfile` if present
+   - **packagist**: Read `composer.lock`
+3. **Manifest file** — the declared version constraint (less precise than lockfile):
+   - **npm**: `package.json` → `dependencies` / `devDependencies`
+   - **pypi**: `requirements.txt` (`pkg==1.2.3`), `pyproject.toml`
+   - **go**: `go.mod` (`require pkg v1.2.3`)
+   - **cargo**: `Cargo.toml` `[dependencies]`
+   - **rubygems**: `Gemfile`
+   - **maven**: `pom.xml` `<version>`, `build.gradle`
+   - **packagist**: `composer.json`
+4. **Installed artifacts** — query the actual installed state:
+   - **npm**: Read `node_modules/<package>/package.json` → `version` field
+   - **pypi**: Run `pip show <package>` or `python -c "import <pkg>; print(<pkg>.__version__)"`
+   - **go**: Run `go list -m <package>`
+   - **cargo**: Run `cargo pkgid <package>`
+   - **rubygems**: Run `gem list <package> --local`
+   - **system binaries**: Run `<binary> --version` or `which <binary>`
+
+If the package is **not currently installed** (not found in any of the above), explicitly state: **"Not currently installed — no existing version detected."**
+
+**Version Source Label**: In all outputs, tag the version with its source, e.g.:
+- `1.2.3 (from lockfile: package-lock.json)`
+- `^1.2.0 (from manifest: package.json — constraint, not exact)`
+- `1.2.3 (from node_modules)`
+- `1.2.3 (user-supplied)`
+- `Not installed`
+
+### Step 2: Search Packages
+
+Run the Vulnetix VDB package search command:
+
+```bash
+vulnetix vdb packages search "$ARGUMENTS" -o json
+```
+
+If you detected a single ecosystem, add the `--ecosystem <ecosystem>` flag to filter results.
+
+For example:
+```bash
+vulnetix vdb packages search "express" --ecosystem npm -o json
+```
+
+The output is JSON with this structure:
+```json
+{
+  "packages": [
+    {
+      "name": "express",
+      "ecosystem": "npm",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "latestVersion": "4.18.2",
+      "vulnerabilityCount": 3,
+      "maxSeverity": "high",
+      "safeHarbourScore": 85,
+      "repository": "https://github.com/expressjs/express"
+    }
+  ]
+}
+```
+
+**Version enrichment**: After receiving results, enrich each package with the current version detected in Step 1b. The API returns `latestVersion` — you must pair this with the `currentVersion` you resolved from the filesystem.
+
+### Step 3: Filter Results
+
+Discard packages from ecosystems not present in the repository. For example, if the repo only has `package.json`, filter out PyPI and Cargo results.
+
+### Step 4: Risk Assessment
+
+Present the matching packages in a comparison table with these columns:
+
+| Package | Ecosystem | Current Version | Latest Version | Vulnerabilities | Max Severity | Safe Harbour | Confidence | Repository |
+|---------|-----------|-----------------|----------------|-----------------|--------------|-------------|------------|------------|
+| express | npm | 4.17.1 (lockfile) | 4.18.2 | 3 | high | 0.85 | High | [link] |
+
+**Column definitions:**
+
+- **Current Version**: The version currently in use in this repository, with its source in parentheses (e.g., `4.17.1 (lockfile)`, `^4.17.0 (manifest)`, `Not installed`). This is resolved from Step 1b.
+- **Latest Version**: The latest available version from the ecosystem registry (from API response).
+- **Vulnerability Count**: Total known vulnerabilities across all versions.
+- **Max Severity**: Highest severity rating (critical/high/medium/low).
+- **Safe Harbour**: The API returns a 0–100 integer score. **Convert to a 0–1 decimal** by dividing by 100 (e.g., API returns `85` → display `0.85`). This represents a safety confidence percentage where 1.0 = 100% confidence in safety.
+- **Confidence**: A human-readable label derived from the Safe Harbour value:
+  - **High**: Safe Harbour > 0.90 — excellent security posture, strong track record
+  - **Reasonable**: Safe Harbour 0.35–0.90 — acceptable risk, minor or moderate issues
+  - **Low**: Safe Harbour < 0.35 — significant risk, use with extreme caution
+
+**Below the table**, always include a **Version Context** summary:
+```
+Version Context:
+- express: 4.17.1 → 4.18.2 (patch upgrade available) — source: package-lock.json
+- lodash: Not installed — no existing version detected
+```
+
+This gives the user full transparency on where version information was derived and what upgrade path exists.
+
+### Step 5: Propose Dependency Addition
+
+For the best candidate (lowest vuln count, highest Safe Harbour value):
+
+1. **Identify the manifest file** to edit based on ecosystem
+2. **State the version change clearly**: If upgrading, show `currentVersion → latestVersion`. If new, show `(new) latestVersion`.
+3. **Show the concrete edit** that would add or update this dependency:
+   - **npm**: Add/update in `dependencies` in `package.json`
+   - **pypi**: Add/update in `requirements.txt` or `pyproject.toml`
+   - **go**: Provide `go get` command with version
+   - **cargo**: Add/update in `[dependencies]` in `Cargo.toml`
+   - **maven**: Provide `<dependency>` XML with version
+   - **rubygems**: Add/update in `Gemfile` with version
+   - **packagist**: Provide `composer require` command with version
+
+Use the **Edit** tool to show the proposed change, but **DO NOT apply it yet**.
+
+Example for npm (new dependency):
+```diff
+{
+  "dependencies": {
++   "express": "^4.18.2",
+    "other-package": "1.0.0"
+  }
+}
+```
+
+Example for npm (upgrade):
+```diff
+{
+  "dependencies": {
+-   "express": "^4.17.1",
++   "express": "^4.18.2",
+    "other-package": "1.0.0"
+  }
+}
+```
+
+Always include the **specific version** in the proposed edit — never use `*` or `latest`.
+
+### Step 6: Planning Interview
+
+Ask the user:
+
+1. **Would you like me to add this package to your project?** (If yes, apply the edit and suggest running `npm install`, `pip install`, etc.)
+2. **Search for alternatives?** (Suggest 2-3 alternative package names based on repository context and the search query)
+3. **Run deeper vulnerability check?** (Suggest `/vulnetix:exploits <vuln-id>` for any critical/high severity vulnerabilities found)
+
+If the user requests alternatives, repeat steps 2-6 with the suggested names.
+
+## Error Handling
+
+- If `vulnetix vdb packages search` fails, inform the user to check `vulnetix vdb status`
+- If no packages match repo ecosystems, suggest broadening the search or checking alternative ecosystems
+- If manifest file structure is unfamiliar, ask the user which file to edit
+
+## Security Notes
+
+- Always recommend the **latest stable version** unless there are known vulnerabilities in it
+- If the latest version has critical vulnerabilities, warn the user and recommend holding off until a patch is available
+- Never silently add dependencies — always get explicit user approval first
+- **All outputs MUST include package versions** — both current (if installed) and latest. Never omit version numbers from tables, diffs, or recommendations.
+- **Version source transparency is mandatory** — always disclose how the current version was determined (lockfile, manifest, node_modules, user-supplied, or not installed). If version detection fails for a source, note what was attempted.

--- a/plugins/vulnetix/skills/remediation/SKILL.md
+++ b/plugins/vulnetix/skills/remediation/SKILL.md
@@ -1,0 +1,301 @@
+---
+name: remediation
+description: Get a context-aware remediation plan for a vulnerability with fix verification steps
+argument-hint: <vuln-id>
+user-invocable: true
+allowed-tools: Bash, Read, Glob, Grep, Edit, Write
+model: sonnet
+---
+
+# Vulnetix Remediation Plan Skill
+
+This skill generates a comprehensive, context-aware remediation plan for a specific vulnerability using the VDB V2 remediation API. It auto-detects your repository's ecosystem, package manager, installed versions, container images, and OS to provide targeted fix guidance including registry upgrades, source patches, distribution advisories, workarounds, CWE-specific remediation strategies, and verification commands.
+
+**How this differs from `/vulnetix:fix`:** The existing `/vulnetix:fix` skill fetches V1 fix data and proposes manual manifest edits. This skill uses the V2 `remediation plan` endpoint which provides **context-aware** guidance (ecosystem, version, OS, container), **CWE remediation strategies**, **CrowdSec threat intelligence** (live exploitation data), **workaround effectiveness scoring**, **SSVC decision support**, and **verification commands** per package manager.
+
+## Vulnerability Memory (.vulnetix/memory.yaml)
+
+This skill reads and updates the `.vulnetix/memory.yaml` file in the repository root. This file is shared with `/vulnetix:fix`, `/vulnetix:exploits`, `/vulnetix:package-search`, `/vulnetix:vuln`, and `/vulnetix:exploits-search`.
+
+### Schema
+
+The canonical schema is defined in `/vulnetix:fix`. This skill updates base fields and appends remediation plan events to the history log.
+
+### Reading Prior State
+
+**At the start of every invocation:**
+
+1. Use **Glob** to check if `.vulnetix/memory.yaml` exists in the repo root
+2. If it exists, use **Read** to load it and check for the vuln ID or aliases
+3. Use **Glob** for `.vulnetix/scans/*.cdx.json` -- cross-reference for component data
+4. If a prior entry exists, display:
+   ```
+   Previously seen: <vulnId> -- <developer-friendly status> (as of <date>)
+   Priority: <P1/P2/P3/P4> (<score>) (if cwss data exists)
+   Last decision: <developer-friendly decision> -- "<reason>"
+   ```
+
+### Writing Updated State
+
+**After completing the remediation plan (Step 7):**
+
+1. If no entry exists, create one with `status: under_investigation`, `discovery.source: user`
+2. If an entry exists, update `severity`, `safe_harbour`, and `versions.fixed_in` from the remediation plan data. Merge aliases.
+3. **Do NOT change `status` or `decision`** unless the user explicitly makes a decision during the conversation
+4. Append to `history`: `event: remediation-plan`, detail: summary of fix options found (registry fixes, source fixes, workarounds, distribution patches)
+5. Confirm to the user
+
+### VEX Status Mapping
+
+- `not_affected` --> "Not affected"
+- `affected` --> "Vulnerable"
+- `fixed` --> "Fixed"
+- `under_investigation` --> "Investigating"
+
+## Dependabot Integration
+
+When `gh` CLI is available (check with `gh auth status 2>/dev/null`), query Dependabot alerts for the vuln ID to cross-reference with the remediation plan.
+
+1. Query alerts matching this vuln ID
+2. If a Dependabot PR exists, note it in the output: `"Dependabot PR #N proposes this upgrade -- consider reviewing and merging it"`
+3. Update the `dependabot` section in the memory entry
+
+## Workflow
+
+### Step 1: Load Memory and Detect Repository Context
+
+1. Load `.vulnetix/memory.yaml` as described above
+2. Use **Glob** to detect manifest files and determine:
+   - **Ecosystem** -- npm, pypi, maven, go, cargo, rubygems, packagist
+   - **Package manager** -- npm, yarn, pnpm, pip, poetry, uv, cargo, go, maven, gradle, bundler, composer
+3. If the vuln ID is already in memory with a `package` field, use that package name
+4. If not, run a quick lookup to get affected products:
+   ```bash
+   vulnetix vdb vuln "$ARGUMENTS" -o json
+   ```
+   Extract affected package names and ecosystems from the response.
+5. For each affected package found in the repo, detect the installed version using the priority chain: lockfile --> manifest --> installed artifacts --> unknown
+
+### Step 2: Auto-Populate Context Flags
+
+Build the CLI flags automatically from repository state:
+
+| Flag | Source | How to detect |
+|------|--------|---------------|
+| `--ecosystem` | Manifest files | From Step 1 ecosystem detection |
+| `--package-name` | VDB response or memory | Affected package name matching repo |
+| `--current-version` | Lockfile/manifest | Installed version from Step 1 |
+| `--package-manager` | Manifest file type | `package-lock.json` --> npm, `yarn.lock` --> yarn, `poetry.lock` --> pip/poetry, etc. |
+| `--purl` | Constructed | If ecosystem + name + version are known, construct `pkg:<eco>/<name>@<version>` |
+| `--container-image` | Containerfile/Dockerfile | Use **Glob** for `Containerfile`, `Dockerfile`, `*.dockerfile`. If found, **Read** and extract `FROM` image reference (e.g., `node:18-alpine`) |
+| `--os` | OS detection | Check for `/etc/os-release` or infer from container base image |
+| `--vendor` | VDB response | From affected products vendor field |
+| `--product` | VDB response | From affected products product field |
+
+Always set:
+- `--include-guidance` -- includes CWE-specific remediation strategies
+- `--include-verification-steps` -- includes per-package-manager verification commands
+
+If no package context can be determined (no manifests, no memory), run the command without package-specific flags -- the API will still return general remediation guidance.
+
+### Step 3: Execute Remediation Plan Query
+
+```bash
+vulnetix vdb remediation plan "$ARGUMENTS" -V v2 --include-guidance --include-verification-steps -o json [context flags]
+```
+
+**CLI Reference** (from `vulnetix vdb remediation plan` docs):
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--ecosystem` | string | Package ecosystem (npm, pypi, maven, go, cargo, etc.) |
+| `--package-name` | string | Package name |
+| `--current-version` | string | Currently installed version (enables version-specific guidance) |
+| `--package-manager` | string | Package manager (npm, pip, cargo, maven, etc.) |
+| `--purl` | string | Package URL (overrides ecosystem + package-name) |
+| `--container-image` | string | Container image reference (e.g., node:18-alpine) |
+| `--os` | string | OS identifier (e.g., ubuntu:22.04, debian-11) |
+| `--vendor` | string | Vendor name for CPE matching |
+| `--product` | string | Product name for CPE matching |
+| `--registry` | string | Registry filter (npm, pypi, maven-central) |
+| `--include-guidance` | bool | Include CWE-specific markdown guidance |
+| `--include-verification-steps` | bool | Include verification commands per package manager |
+| `-V` | string | API version -- must be `v2` |
+| `-o, --output` | string | Output format: `json` or `pretty` |
+
+Examples:
+```bash
+# Basic remediation plan
+vulnetix vdb remediation plan CVE-2021-44228 -V v2 --include-guidance --include-verification-steps -o json
+
+# With full package context
+vulnetix vdb remediation plan CVE-2021-44228 -V v2 \
+  --ecosystem maven --package-name log4j-core --current-version 2.14.1 \
+  --package-manager maven --include-guidance --include-verification-steps -o json
+
+# Using PURL
+vulnetix vdb remediation plan CVE-2021-44228 -V v2 \
+  --purl "pkg:maven/org.apache.logging.log4j/log4j-core@2.14.1" \
+  --include-guidance --include-verification-steps -o json
+
+# With container context
+vulnetix vdb remediation plan CVE-2024-XXXXX -V v2 \
+  --ecosystem npm --package-name express --current-version 4.17.1 \
+  --container-image "node:18-alpine" --include-guidance --include-verification-steps -o json
+```
+
+**Response structure** (from V2 OAS):
+
+The response includes:
+- `cveId`, `state`, `title`, `aliases`, `description`
+- `descriptions[]` -- multi-source descriptions with language and source attribution
+- `crowdSecSummary` -- live threat intelligence:
+  - `totalSightings`, `uniqueIPs`, `isActive`
+  - `firstSeen`, `lastSeen`
+  - `topSourceCountries`, `topTargetCountries`
+  - `mitreTechniques`, `behaviors`
+- `cvssDetails` -- parsed CVSS vector components (attackVector, attackComplexity, privilegesRequired, userInteraction, scope, impact metrics)
+- `agent_prompt` -- AI-optimized remediation context string
+- Registry fixes, source fixes, distribution patches, workarounds, CWE guidance, verification steps (context-dependent based on flags provided)
+
+### Step 4: Present the Remediation Plan
+
+Render a structured remediation report with the following sections:
+
+**Vulnerability Summary:**
+```
+<CVE ID> -- <title>
+<description -- first 2-3 sentences>
+Severity: <CVSS score> (<level>)  |  EPSS: <score>
+```
+
+**Threat Activity** (from CrowdSec data, if present):
+```
+Live Exploitation: <Active/Inactive>
+Sightings: <totalSightings> from <uniqueIPs> unique IPs
+Last seen: <lastSeen>
+Source countries: <top 3>
+MITRE techniques: <techniques in developer language>
+```
+
+If no CrowdSec data, skip this section.
+
+**Registry Fixes** (version upgrades per ecosystem):
+
+| Ecosystem | Package | Current | Fix Version | Verified | Confidence | Registry |
+|-----------|---------|---------|-------------|----------|------------|----------|
+| maven | log4j-core | 2.14.1 | 2.17.1 | Yes | High | Maven Central |
+
+For each fix, report Safe Harbour confidence:
+- **High** (> 0.90): patch-level bump, official registry release
+- **Reasonable** (0.35-0.90): minor version bump, backward-compatible
+- **Low** (< 0.35): major version bump, significant API changes
+
+**Source Fixes** (upstream commits/PRs, if available):
+
+```
+Upstream fix: <commit URL>
+  SHA: <sha>
+  Author: <author>
+  Message: <commit message>
+  Repository health: <commit frequency, contributor count>
+```
+
+**Distribution Patches** (if `--os` or `--container-image` was set):
+
+| Distro | Patch ID | Affected Packages | Priority |
+|--------|----------|-------------------|----------|
+| Ubuntu 22.04 | USN-XXXX-X | liblog4j2-java | High |
+
+**Workarounds** (interim mitigations, if no immediate fix):
+
+```
+Workaround: <description>
+  Effectiveness: <score>/100
+  Applicable versions: <range>
+  Requires restart: <Yes/No>
+  Verification: <steps>
+```
+
+**CWE Guidance** (weakness-specific remediation strategies):
+
+```
+CWE-<id>: <title>
+Remediation strategy:
+<markdown guidance from API>
+
+Verification guidance:
+<markdown from API>
+```
+
+**Verification Steps** (per package manager):
+
+```
+Verify the fix:
+  npm: npm audit --json | jq '.vulnerabilities["<package>"]'
+  maven: mvn dependency:tree | grep <package>
+  pip: pip show <package> | grep Version
+```
+
+### Step 5: Cross-Reference with Dependabot and Memory
+
+1. If Dependabot PR exists for this upgrade, note: `"Dependabot PR #N already proposes this upgrade -- consider reviewing and merging"`
+2. If a prior `/vulnetix:exploits` analysis exists in memory (threat_model, cwss), surface the priority: `"Prior exploit analysis: P1 (87.5) -- Act now"`
+3. If a prior `/vulnetix:fix` analysis exists, note what was previously proposed
+
+### Step 6: Present Actionable Next Steps
+
+Based on the remediation plan, present concrete actions:
+
+1. **If registry fix available:** Show exact manifest edit (same diff format as `/vulnetix:fix`) with the fix version from the remediation plan. Offer to apply it.
+2. **If source fix only (no registry release):** Note that the fix requires building from source or waiting for a release. Link to the commit/PR.
+3. **If workaround only:** Present the workaround steps with effectiveness score. Note: "No patch available yet -- workaround is interim mitigation."
+4. **If distribution patch:** Provide the package manager command (e.g., `apt-get update && apt-get install --only-upgrade <package>`)
+5. **Test commands:** Suggest running tests after applying the fix
+6. **Re-scan:** Suggest `vulnetix vdb vuln <vuln-id>` to verify the fix resolved the vulnerability
+7. **Rollback guidance:** If the fix introduces breaking changes, note the backup/rollback approach
+
+**Cross-references:**
+- `"Run /vulnetix:exploits $ARGUMENTS for exploit intelligence and threat modeling"`
+- `"Run /vulnetix:vuln $ARGUMENTS for full vulnerability details"`
+- `"Run /vulnetix:exploits-search --ecosystem <eco> to discover related exploited vulnerabilities"`
+
+### Step 7: Update Vulnerability Memory
+
+1. Use **Read** to load the current memory file
+2. Create or update the entry:
+   - `versions.fixed_in` -- from the registry fix data
+   - `versions.fix_source` -- registry name and version
+   - `severity` -- from CVSS data
+   - `safe_harbour` -- computed from fix confidence
+   - `aliases` -- merge any newly discovered aliases
+   - `dependabot` -- if gathered in Step 5
+3. Append to `history`: `event: remediation-plan`, detail: summary of fix options (e.g., "Registry fix: 2.17.1 (Maven Central, High confidence). 2 workarounds available. CWE-502 guidance provided.")
+4. Use **Write** to save
+5. Confirm to the user
+
+**If the user applies a fix or makes a decision:**
+- Record using the risk treatment categories from `/vulnetix:exploits`
+- Set `status: fixed` and `decision.choice: fix-applied` if they apply the fix
+- Append `event: fix-applied` with detail including the version change
+
+## Error Handling
+
+- If `vulnetix vdb remediation plan` returns an error, fall back to `vulnetix vdb fixes "$ARGUMENTS" -o json` (V1 endpoint) and present basic fix data. Note that V2 enrichment (workarounds, CWE guidance, verification steps) is unavailable.
+- If the vuln ID is not found, suggest checking the format and provide examples
+- If no package context can be determined from the repo, run without context flags and note that guidance is generic rather than repo-specific
+- If no fixes, workarounds, or patches are available, state clearly: "No remediation options are currently available for this vulnerability. Consider risk acceptance or component removal."
+- If `.vulnetix/memory.yaml` cannot be written, warn but do not block
+
+## Important Reminders
+
+1. This skill **proposes code changes** (manifest edits) but **always asks before applying** -- same guardrail as `/vulnetix:fix`
+2. **Auto-populate context flags** from the repo -- the V2 API returns better results with more context. Always detect ecosystem, package name, current version, and package manager.
+3. **Container detection is important** -- if a Containerfile/Dockerfile exists, extract the base image for OS-specific distribution patches
+4. Safe Harbour scores: compute from fix confidence tiers, display as 0.00-1.00
+5. Version source transparency is mandatory -- always disclose how the current version was determined
+6. **CrowdSec data is live threat intelligence** -- if sightings are active, flag prominently
+7. The `agent_prompt` field in the response contains AI-optimized context -- use it to inform your analysis but do not display it raw to the user
+8. **Always update `.vulnetix/memory.yaml`** after generating the plan
+9. If Dependabot already has a PR for this fix, prefer merging that PR over manual edits
+10. The V2 remediation endpoint is the most comprehensive single endpoint -- it aggregates data from registry fixes, source fixes, distribution patches, workarounds, CWE guidance, and KEV data into one response

--- a/plugins/vulnetix/skills/vuln/SKILL.md
+++ b/plugins/vulnetix/skills/vuln/SKILL.md
@@ -1,0 +1,317 @@
+---
+name: vuln
+description: Look up a vulnerability by ID or list all vulnerabilities for a package
+argument-hint: <vuln-id or package-name>
+user-invocable: true
+allowed-tools: Bash, Read, Glob, Grep, Edit, Write
+model: sonnet
+---
+
+# Vulnetix Vulnerability Lookup Skill
+
+This skill serves two purposes based on the argument provided:
+
+- **Vuln ID argument** (CVE-*, GHSA-*, PYSEC-*, etc.) --> retrieves detailed vulnerability intelligence and assesses its impact against the current repository
+- **Package name argument** (express, lodash, log4j-core, etc.) --> lists all known vulnerabilities for that package and identifies which ones affect your installed version
+
+**This skill does not modify application code** -- it only updates `.vulnetix/memory.yaml` to track findings. Use `/vulnetix:fix` for remediation, `/vulnetix:exploits` for exploit analysis, or `/vulnetix:remediation` for a context-aware remediation plan.
+
+## Argument Detection
+
+Determine the mode from the argument:
+
+**Vuln lookup mode** -- argument matches any known vulnerability identifier pattern:
+- `CVE-*` (e.g., CVE-2021-44228)
+- `GHSA-*` (e.g., GHSA-jfh8-3a1q-hjz9)
+- `PYSEC-*`, `GO-*`, `RUSTSEC-*`, `EUVD-*`, `OSV-*`, `GSD-*`, `VDB-*`, `GCVE-*`
+- `SNYK-*`, `ZDI-*`, `MSCVE-*`, `MSRC-*`, `RHSA-*`, `TALOS-*`, `EDB-*`
+- `WORDFENCE-*`, `PATCHSTACK-*`, `MFSA*`, `JVNDB-*`, `CNVD-*`, `BDU:*`, `HUNTR-*`
+- `DSA-*`, `DLA-*`, `USN-*`, `ALSA-*`, `RLSA-*`, `MGASA-*`, `OPENSUSE-*`, `FreeBSD-*`, `BIT-*`
+
+The VDB accepts **78+ identifier formats** in total.
+
+**Package vulns mode** -- argument does not match any vuln-id pattern. Treat it as a package name.
+
+If ambiguous, prefer vuln lookup mode (vuln IDs are more structured). If the vuln lookup returns an error or empty response, fall back to package vulns mode automatically.
+
+## Vulnerability Memory (.vulnetix/memory.yaml)
+
+This skill reads and updates the `.vulnetix/memory.yaml` file in the repository root. This file is shared with `/vulnetix:fix`, `/vulnetix:exploits`, `/vulnetix:package-search`, `/vulnetix:exploits-search`, and `/vulnetix:remediation`.
+
+### Schema
+
+The canonical schema is defined in `/vulnetix:fix`. This skill creates or updates base vulnerability fields: `aliases`, `package`, `ecosystem`, `discovery`, `versions`, `severity`, `safe_harbour`, and `status`. It does not modify `threat_model` or `cwss` (owned by `/vulnetix:exploits`).
+
+### Reading Prior State and SBOMs
+
+**At the start of every invocation:**
+
+1. Use **Glob** to check if `.vulnetix/memory.yaml` exists in the repo root
+2. If it exists, use **Read** to load it
+3. Use **Glob** for `.vulnetix/scans/*.cdx.json` -- if CycloneDX SBOMs exist from prior scans, cross-reference for additional context
+4. **Vuln lookup mode**: check for the vuln ID or any aliases in memory. If found:
+   ```
+   Previously seen: <vulnId> -- <developer-friendly status> (as of <date>)
+   Priority: <P1/P2/P3/P4> (<score>) -- "<priority description>" (if cwss data exists)
+   Last decision: <developer-friendly decision> -- "<reason>"
+   Dependabot: <alert state, PR state if available>
+   ```
+5. **Package vulns mode**: find all entries referencing the queried package name. If found:
+   ```
+   Known history for <package>:
+   - CVE-2021-44228 -- Fixed (2024-01-15), P1 (87.5)
+   - CVE-2023-1234 -- Investigating (2024-03-01)
+   ```
+
+### Writing Updated State
+
+**Vuln lookup mode (after Step L6):**
+
+1. If no entry exists, create one with `status: under_investigation`, `decision.choice: investigating`, `discovery.source: user`
+2. If an entry exists, merge aliases, update `severity` and `safe_harbour` if newer. **Do NOT change `status` or `decision`.**
+3. Append to `history`: `event: lookup`
+
+**Package vulns mode (after Step P7):**
+
+For each vulnerability that **affects the installed version** and is **not already tracked**:
+1. Create a minimal stub entry with `status: under_investigation`, `decision.choice: investigating`, `discovery.source: scan`, `decision.reason: "Discovered via /vulnetix:vuln <package>"`
+2. Append to `history`: `event: discovered`
+
+For existing entries, do **not** change `status` or `decision` -- only update `severity` if newer.
+
+### VEX Status Mapping
+
+Use developer-friendly language when surfacing status:
+- `not_affected` --> "Not affected"
+- `affected` --> "Vulnerable"
+- `fixed` --> "Fixed"
+- `under_investigation` --> "Investigating"
+
+## Dependabot Integration
+
+When `gh` CLI is available (check with `gh auth status 2>/dev/null`), query Dependabot alerts to enrich the output.
+
+**Vuln lookup mode:** Query alerts matching the vuln ID:
+```bash
+gh api repos/{owner}/{repo}/dependabot/alerts --jq '[.[] | select(.security_advisory.cve_id == "'"$ARGUMENTS"'" or .security_advisory.ghsa_id == "'"$ARGUMENTS"'")] | first'
+```
+
+**Package vulns mode:** Query alerts for the package:
+```bash
+gh api repos/{owner}/{repo}/dependabot/alerts?state=open --jq '[.[] | select(.dependency.package.name == "'"$PACKAGE_NAME"'")] | length'
+```
+
+---
+
+## Vuln Lookup Mode Workflow
+
+Use this workflow when the argument matches a vulnerability identifier pattern.
+
+### Step L1: Load Vulnerability Memory
+
+Check for and load `.vulnetix/memory.yaml` as described in "Reading Prior State" above. Display any prior state before proceeding.
+
+### Step L2: Fetch Vulnerability Data
+
+```bash
+vulnetix vdb vuln "$ARGUMENTS" -o json
+```
+
+**CLI Reference** (from `vulnetix vdb vuln` docs):
+- Accepts any of the 78+ identifier formats
+- `-o json` returns machine-readable output
+- Response includes: identifier and aliases, description, published/modified dates, CVSS scores (v2, v3, v4), references/advisories, affected products/versions, EPSS probability, KEV status
+
+Extract: identity, aliases, description, dates, CVSS vectors/scores, EPSS, KEV status/deadline, CWE IDs, affected products with version ranges and fixed versions, reference URLs.
+
+### Step L3: Enrich with Metrics
+
+```bash
+vulnetix vdb metrics "$ARGUMENTS" -o json
+```
+
+**CLI Reference** (from `vulnetix vdb metrics` docs):
+- Returns structured metric objects by type (CVSS v2, v3.1, v4, EPSS, etc.)
+- Each metric includes: source, type, score, vector string, timestamp
+
+Merge with Step L2 data. If this call fails, continue with Step L2 data alone.
+
+### Step L4: Analyze Repository Impact
+
+Use **Glob** and **Grep** to assess repo impact:
+
+1. **Detect manifest files:**
+   - `package.json`, `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml` --> **npm**
+   - `go.mod`, `go.sum` --> **go**
+   - `Cargo.toml`, `Cargo.lock` --> **cargo**
+   - `requirements.txt`, `pyproject.toml`, `Pipfile`, `poetry.lock`, `uv.lock` --> **pypi**
+   - `Gemfile`, `Gemfile.lock` --> **rubygems**
+   - `pom.xml`, `build.gradle`, `gradle.lockfile` --> **maven**
+   - `composer.json`, `composer.lock` --> **packagist**
+
+2. **Search for affected packages** from VDB response using **Grep** in manifests/lockfiles
+3. **Determine installed version** (lockfile --> manifest --> installed artifacts --> unknown). Report source transparently.
+4. **Assess dependency relationship** -- direct vs transitive, whether installed version is in vulnerable range
+5. **Cross-reference CycloneDX SBOMs** in `.vulnetix/scans/*.cdx.json`
+
+### Step L5: Present Structured Summary
+
+**Identity:**
+```
+<Vuln ID> (<alias1>, <alias2>, ...)
+<Description -- first 2-3 sentences>
+Published: <date>  |  Modified: <date>
+```
+
+**Severity Table:**
+
+| Metric | Score | Vector |
+|--------|-------|--------|
+| CVSS v3.1 | 10.0 (Critical) | AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H |
+| CVSS v4.0 | 10.0 (Critical) | ... |
+| EPSS | 0.97 (97% chance of exploitation within 30 days) | -- |
+| CISA KEV | Listed (deadline: YYYY-MM-DD) | -- |
+
+**Affected Packages:**
+
+| Package | Ecosystem | Vulnerable Range | Fixed In |
+|---------|-----------|-----------------|----------|
+| log4j-core | maven | < 2.17.1 | 2.17.1 |
+
+**Repository Impact:**
+
+| Package | Installed Version | Source | Affected? | Relationship |
+|---------|------------------|--------|-----------|-------------|
+| log4j-core | 2.14.1 | lockfile: pom.xml | Yes (in range) | Direct |
+
+If no affected packages found: **"No affected packages detected in this repository."**
+
+**References:** List top advisory and reference URLs.
+
+**Next Steps:**
+- "Run `/vulnetix:exploits $ARGUMENTS` for exploit intelligence and threat modeling"
+- "Run `/vulnetix:fix $ARGUMENTS` for fix intelligence and manifest edits"
+- "Run `/vulnetix:remediation $ARGUMENTS` for a context-aware remediation plan"
+- "Run `/vulnetix:exploits-search --ecosystem <eco>` to discover related exploited vulnerabilities"
+
+### Step L6: Update Vulnerability Memory
+
+Update `.vulnetix/memory.yaml` as described in "Writing Updated State" above. If the user provides a decision during the conversation, record it using the risk treatment categories defined in `/vulnetix:exploits`.
+
+---
+
+## Package Vulns Mode Workflow
+
+Use this workflow when the argument does not match a vulnerability identifier pattern.
+
+### Step P1: Load Vulnerability Memory
+
+Check for and load `.vulnetix/memory.yaml`. Display any known history for the queried package before proceeding.
+
+### Step P2: Detect Repository Ecosystems
+
+Use **Glob** to identify manifest files (same manifest list as Step L4 above). Determine which ecosystems the repository uses.
+
+### Step P3: Detect Installed Version
+
+Determine if the queried package is installed. Resolve using the priority chain:
+
+1. **User-supplied version** -- explicitly stated in the user's message
+2. **Lockfile** -- most authoritative:
+   - **npm**: `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`
+   - **pypi**: `poetry.lock`, `Pipfile.lock`, `uv.lock`
+   - **go**: `go.sum`
+   - **cargo**: `Cargo.lock`
+   - **rubygems**: `Gemfile.lock`
+   - **maven**: `gradle.lockfile`
+   - **packagist**: `composer.lock`
+3. **Manifest file** -- declared version constraint (less precise)
+4. **Installed artifacts** -- query installed state (e.g., `node_modules/<pkg>/package.json`, `pip show <pkg>`)
+
+If not installed: **"Not currently installed -- no existing version detected."**
+
+**Version Source Label**: `4.17.1 (from lockfile: package-lock.json)`, `^4.17.0 (from manifest: package.json -- constraint, not exact)`, `Not installed`
+
+### Step P4: Fetch Package Vulnerabilities
+
+```bash
+vulnetix vdb vulns "$ARGUMENTS" -o json
+```
+
+**CLI Reference** (from `vulnetix vdb vulns` docs):
+- Retrieves all known vulnerabilities for a specific package
+- **Flags:**
+  - `--limit int` -- Maximum results (default 100)
+  - `--offset int` -- Results to skip for pagination (default 0)
+  - `-o, --output string` -- Output format: `json` or `pretty` (default "pretty")
+- **Response includes:** total count, vulnerability identifiers, severity, CVSS, affected version ranges, fixed versions, descriptions, references, pagination info
+
+**Pagination modifiers** -- parse user message:
+- "first 20" / "top 20" / "limit 20" --> `--limit 20`
+- "next page" / "more" / "page 2" --> `--offset <previous_offset + limit>`
+- "all" --> `--limit 500`
+
+### Step P5: Filter and Enrich
+
+1. **Filter by repo ecosystems** -- discard vulns from ecosystems not in the repo
+2. **Cross-reference with memory** -- note prior status, decision, CWSS priority, PoC count for each
+3. **Determine "Affects You?"** -- compare installed version against each vuln's affected range:
+   - **Yes** -- installed version in vulnerable range
+   - **No** -- installed version outside range
+   - **Unknown** -- version undetermined or range data incomplete
+
+### Step P6: Present Vulnerability List
+
+```
+Vulnerabilities for <package>@<version> (<version source>)
+Total: N known vulnerabilities (M affect your version)
+
+| # | ID              | Severity | Affects You? | Fixed In | Status       | EPSS  |
+|---|-----------------|----------|-------------|----------|--------------|-------|
+| 1 | CVE-2024-XXXXX  | critical | Yes         | 4.18.3   | --           | 0.45  |
+| 2 | CVE-2023-YYYYY  | high     | Yes         | 4.17.3   | Fixed        | 0.12  |
+| 3 | CVE-2022-ZZZZZ  | medium   | No (>=4.17) | 4.17.0   | --           | 0.03  |
+```
+
+**Summary:** `M of N affect your version -- X critical, Y high, Z medium`
+
+**Pagination info** (if truncated): `Showing 1-20 of 47. Say "next page" or "page 3" for more.`
+
+**Actionable recommendations:**
+- Critical/high affecting installed version: `"Run /vulnetix:fix <vuln-id> to remediate"` or `"Run /vulnetix:remediation <vuln-id> for a context-aware remediation plan"`
+- Vulns with exploit signals: `"Run /vulnetix:exploits <vuln-id> for exploit analysis"`
+- Any vuln: `"Run /vulnetix:vuln <vuln-id> for detailed vulnerability info"`
+- Broad discovery: `"Run /vulnetix:exploits-search --ecosystem <eco> to find exploited vulnerabilities in your ecosystem"`
+
+### Step P7: Update Vulnerability Memory
+
+Update `.vulnetix/memory.yaml` as described in "Writing Updated State" above. Only create stub entries for vulns that **affect the installed version** to prevent memory file bloat.
+
+---
+
+## Error Handling
+
+**Vuln lookup mode:**
+- If `vdb vuln` returns error/empty, try falling back to package vulns mode (the argument might be a package name)
+- If `vdb metrics` fails, continue with `vdb vuln` data alone
+- If no manifest files found, note repo impact analysis is inconclusive
+- If vuln ID not found, suggest alternative formats (GHSA if CVE fails, etc.)
+
+**Package vulns mode:**
+- If `vdb vulns` returns error, suggest checking `vulnetix vdb status`
+- If no vulns found: "No known vulnerabilities found for <package>. This doesn't guarantee safety -- the package may not be indexed yet."
+- If package not found in repo ecosystems, suggest `/vulnetix:package-search`
+- If manifest files missing, "Affects You?" shows "Unknown"
+
+**Both modes:**
+- If `.vulnetix/memory.yaml` cannot be written, warn but do not block
+
+## Important Reminders
+
+1. This skill **does not modify application code** -- use `/vulnetix:fix` or `/vulnetix:remediation` for that
+2. This skill **does not fetch or analyze exploits** -- use `/vulnetix:exploits` for single-vuln analysis or `/vulnetix:exploits-search` for broad discovery
+3. EPSS display: "X% chance of exploitation within 30 days" in vuln mode, decimal (0.45) in table columns
+4. Safe Harbour scores: convert API integer (0-100) to decimal (0.00-1.00)
+5. **Always update `.vulnetix/memory.yaml`** after the lookup
+6. Version source transparency is mandatory
+7. Prior data serves as baseline on re-invocation -- update, don't restart


### PR DESCRIPTION
## Summary

Adds the Vulnetix plugin with 7 security skills for vulnerability intelligence and remediation via the Vulnetix VDB API.

## Component Details
- **Name**: vulnetix
- **Type**: Skills (plugin with 7 skills)
- **Category**: Security
- **License**: Apache-2.0
- **Repository**: https://github.com/Vulnetix/claude-code-plugin

### Skills included
| Skill | Description |
|-------|-------------|
| `vuln` | Look up a vulnerability by ID or list all vulnerabilities for a package |
| `exploits` | Analyze exploit intelligence for a vulnerability against the current repository |
| `exploits-search` | Search for exploits across all vulnerabilities with filtering |
| `fix` | Get fix intelligence and propose concrete remediation for the current repository |
| `remediation` | Get a context-aware remediation plan with fix verification steps |
| `package-search` | Search for packages and assess security risk before adding as dependencies |
| `dashboard` | View all tracked vulnerabilities and their current status |

## Testing
- [x] Skills follow CONTRIBUTING.md structure
- [x] Plugin manifest includes required fields
- [x] No overlap with existing components
- [x] Each skill has clear purpose and usage instructions

## Examples

1. `/vulnetix:vuln CVE-2021-44228` — look up Log4Shell vulnerability details
2. `/vulnetix:exploits-search --ecosystem npm --severity critical` — find critical npm exploits
3. `/vulnetix:fix CVE-2023-44487` — get fix proposal for HTTP/2 rapid reset