### PR TITLE
Add budgetclaw plugin

### DIFF
--- a/plugins/budgetclaw/.claude-plugin/plugin.json
+++ b/plugins/budgetclaw/.claude-plugin/plugin.json
@@ -1,0 +1,15 @@
+{
+  "name": "budgetclaw",
+  "version": "0.1.0",
+  "description": "Local spend monitor for Claude Code. Per-project, per-branch budget caps with SIGTERM enforcement and phone alerts via ntfy.",
+  "author": {
+    "name": "RoninForge",
+    "url": "https://github.com/RoninForge"
+  },
+  "homepage": "https://roninforge.org",
+  "repository": "https://github.com/RoninForge/budgetclaw",
+  "license": "MIT",
+  "keywords": ["spend-monitor", "budget", "cost", "claude-code", "telemetry"],
+  "skills": "./skills/",
+  "hooks": "./hooks/hooks.json"
+}

--- a/plugins/budgetclaw/README.md
+++ b/plugins/budgetclaw/README.md
@@ -1,0 +1,23 @@
+# BudgetClaw
+
+Local spend monitor for Claude Code. Watches `~/.claude/projects/*.jsonl`, tracks cost per project and git branch, enforces budget caps via SIGTERM, and pushes phone alerts via ntfy.
+
+**Zero keys. Zero prompts. Zero latency added.**
+
+## Install
+
+```sh
+curl -fsSL roninforge.org/get | sh
+budgetclaw init
+```
+
+## Plugin features
+
+- `/spend` slash command: shows current spend by project/branch, active limits, and breach locks
+- Session-start hook: prints a spend summary when you open a new Claude Code session
+
+## Links
+
+- Homepage: https://roninforge.org
+- Source: https://github.com/RoninForge/budgetclaw
+- License: MIT

--- a/plugins/budgetclaw/hooks/hooks.json
+++ b/plugins/budgetclaw/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "command -v budgetclaw >/dev/null 2>&1 && budgetclaw status 2>/dev/null || echo '[budgetclaw not installed - run: curl -fsSL https://roninforge.org/get | sh]'",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/budgetclaw/skills/spend/SKILL.md
+++ b/plugins/budgetclaw/skills/spend/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: spend
+description: Show current Claude Code spend by project and branch via BudgetClaw
+user-invocable: true
+allowed-tools: Bash(budgetclaw *)
+---
+
+Show the current spend status:
+
+!`budgetclaw status`
+
+If the user asks about budget limits, also show:
+
+!`budgetclaw limit list`
+
+If there are active breach locks, show:
+
+!`budgetclaw locks list`


### PR DESCRIPTION
## Summary

BudgetClaw is a local spend monitor for Claude Code. It watches `~/.claude/projects/*.jsonl`, tracks cost per project and git branch, enforces budget caps via SIGTERM, and pushes phone alerts via ntfy. Zero keys, zero prompts, zero latency.

## Component Details

- **Name**: budgetclaw
- **Type**: Plugin
- **Category**: specialized-domains (cost monitoring / budget)

## Features

- `/spend` slash command: shows current spend, active limits, breach locks
- Session-start hook: prints spend summary on new session
- Requires BudgetClaw CLI: `curl -fsSL roninforge.org/get | sh`

## Links

- Repository: https://github.com/RoninForge/budgetclaw
- Homepage: https://roninforge.org
- License: MIT

## Testing

- [x] Plugin manifest validates
- [x] Skill and hook definitions follow standard format
- [x] No overlap with existing plugins