### PR TITLE
Add immich-photo-manager skill

### DIFF
--- a/plugins/all-skills/skills/immich-photo-manager/SKILL.md
+++ b/plugins/all-skills/skills/immich-photo-manager/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: immich-photo-manager
+description: "Manage your self-hosted Immich photo library through conversation — natural language search, geographic album curation, duplicate detection, library health audits, and interactive HTML galleries. Install: claude plugin install immich-photo-manager"
+---
+
+# Immich Photo Manager
+
+> Claude Code plugin for intelligent photo management with self-hosted [Immich](https://immich.app).
+
+## Overview
+
+When your Immich library has grown past the point of manual management, this plugin gives Claude direct access to your instance through 21 MCP tools and 11 specialized skills. Search with natural language, create geographic albums from GPS data, find duplicates across import sources, and browse results in interactive HTML galleries.
+
+## Key Features
+
+- **Natural language search** — Find photos using CLIP visual search ("sunset at the beach", "birthday cake")
+- **Geographic albums** — Create albums organized by place using GPS clustering + temporal matching
+- **Duplicate detection** — Cross-source analysis with perceptual hashing (catches re-encoded copies from Apple Photos, Google Takeout)
+- **Library health** — Full audit of metadata completeness, storage breakdown, and recommendations
+- **Interactive galleries** — Self-contained HTML files with embedded thumbnails, 3 themes, slideshow mode
+- **Safety first** — Never deletes without explicit user confirmation
+
+## Installation
+
+```bash
+git clone https://github.com/drolosoft/immich-photo-manager.git
+cd immich-photo-manager
+claude plugin marketplace add .
+claude plugin install immich-photo-manager
+```
+
+## Usage
+
+```
+"How healthy is my photo library?"
+"Show me my photos from Italy"
+"Create albums for everywhere I've traveled"
+"Find duplicates in my library"
+/cleanup — scan for screenshots and junk
+/my-travels — discover all travel destinations
+```
+
+## Links
+
+- **Repository**: https://github.com/drolosoft/immich-photo-manager
+- **Author**: [Drolosoft](https://drolosoft.com)
+- **License**: MIT


### PR DESCRIPTION
## Summary
Claude Code plugin that connects to self-hosted Immich photo libraries for AI-powered management — search, album curation, duplicate detection, and health audits through natural conversation.

## Component Details
- **Name**: immich-photo-manager
- **Type**: Skill
- **Category**: specialized-domains

## Testing
- [x] Ran validation (`npm test`) — all passed
- [x] Tested functionality with live Immich instance
- [x] No overlap with existing components
- [x] Plugin scanner: 100/100 (A - Excellent)

## Examples

```
"How healthy is my photo library?"
→ Scans 28,000 assets, reports metadata coverage, storage breakdown, recommendations

"Create albums for everywhere I've traveled"
→ GPS clustering creates dozens of geographic albums automatically

"Find duplicates"
→ Perceptual hashing catches re-encoded copies across Apple Photos and Google Takeout imports
```