### PR TITLE
Add codex-hud plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1362,7 +1362,7 @@
     },
     {
       "name": "shipwright",
-      "description": "Describe your app in plain English \u2014 Shipwright builds, tests, and deploys it autonomously. 9-phase pipeline, 4 stacks, enterprise-grade safety hooks.",
+      "description": "Describe your app in plain English — Shipwright builds, tests, and deploys it autonomously. 9-phase pipeline, 4 stacks, enterprise-grade safety hooks.",
       "version": "1.0.0",
       "author": {
         "name": "Nate Nelson",
@@ -1381,6 +1381,28 @@
       ],
       "category": "app-builder",
       "source": "./plugins/shipwright"
+    },
+    {
+      "name": "codex-hud",
+      "description": "Display OpenAI Codex usage and rate limits inside Claude Code. Real-time statusline integration with claude-hud.",
+      "version": "0.1.0",
+      "author": {
+        "name": "Haenara Shin",
+        "url": "https://github.com/haenara-shin"
+      },
+      "repository": "https://github.com/haenara-shin/codex-hud",
+      "license": "MIT",
+      "keywords": [
+        "codex",
+        "openai",
+        "usage",
+        "rate-limits",
+        "monitoring",
+        "statusline",
+        "hud"
+      ],
+      "category": "monitoring",
+      "source": "./plugins/codex-hud"
     }
   ]
 }

--- a/plugins/codex-hud/.claude-plugin/plugin.json
+++ b/plugins/codex-hud/.claude-plugin/plugin.json
@@ -1,0 +1,23 @@
+{
+  "name": "codex-hud",
+  "version": "0.1.0",
+  "description": "Display OpenAI Codex usage and rate limits inside Claude Code. Real-time statusline integration with claude-hud, slash commands for usage/costs/summary, and local Codex CLI session log parsing.",
+  "author": {
+    "name": "Haenara Shin",
+    "url": "https://github.com/haenara-shin"
+  },
+  "repository": "https://github.com/haenara-shin/codex-hud",
+  "homepage": "https://github.com/haenara-shin/codex-hud",
+  "license": "MIT",
+  "keywords": [
+    "codex",
+    "openai",
+    "usage",
+    "rate-limits",
+    "costs",
+    "hud",
+    "statusline",
+    "monitoring",
+    "claude-hud"
+  ]
+}

--- a/plugins/codex-hud/README.md
+++ b/plugins/codex-hud/README.md
@@ -1,0 +1,51 @@
+# codex-hud
+
+A Claude Code plugin that displays OpenAI Codex usage and rate limits — right inside your Claude Code session.
+
+## Features
+
+- **Real-time statusline**: Integrates with [claude-hud](https://github.com/jarrodwatts/claude-hud) to show Codex Usage/Weekly rate limits alongside Claude Code's own statusline
+- **Slash commands**: `usage-today/week/month`, `costs-today/week/month`, `summary`, `setup`
+- **Dual data sources**: Local Codex CLI session logs (no API key needed) + OpenAI Usage API (optional, for dollar costs)
+- **Zero npm runtime dependencies**: Only uses Node.js built-in modules
+- **Graceful degradation**: Works with just local logs if no API key is configured
+
+## Statusline Integration
+
+When paired with claude-hud, codex-hud adds Codex rate limits below the Claude Code statusline:
+
+```
+[Opus 4.6 (1M context)]              <- claude-hud
+Context ██░░░░░░░░ 19%
+Usage   █░░░░░░░░░ 14% (resets in 4h 37m)
+Weekly  ██░░░░░░░░ 22% (resets in 5d 18h)
+── Codex team ──                      <- codex-hud
+Usage   █░░░░░░░░░ 1% (resets in 5h)
+Weekly  ░░░░░░░░░░ 0% (resets in 7d)
+1 session | team
+```
+
+## Installation
+
+```bash
+git clone https://github.com/haenara-shin/codex-hud.git
+cd codex-hud
+npm install && npm run build
+```
+
+Then in Claude Code:
+
+```
+/plugin marketplace add haenara-shin/codex-hud
+/plugin install codex-hud@codex-hud
+```
+
+## Links
+
+- [Repository](https://github.com/haenara-shin/codex-hud)
+- [Full documentation (English)](https://github.com/haenara-shin/codex-hud/blob/main/README.md)
+- [Full documentation (Korean)](https://github.com/haenara-shin/codex-hud/blob/main/README_KR.md)
+
+## License
+
+MIT


### PR DESCRIPTION
## Summary

Add **codex-hud** — a Claude Code plugin that displays OpenAI Codex usage and rate limits inside Claude Code.

## Component Details

- **Name**: codex-hud
- **Type**: Plugin
- **Category**: monitoring

## Features

- Real-time statusline integration with [claude-hud](https://github.com/jarrodwatts/claude-hud) — shows Codex Usage/Weekly rate limits below Claude Code's statusline
- Slash commands: `usage-today/week/month`, `costs-today/week/month`, `summary`, `setup`
- Parses local Codex CLI session logs (`~/.codex/sessions/`) — no API key needed
- Optional OpenAI Usage API integration for dollar cost tracking
- Zero npm runtime dependencies

## Testing

- [x] Ran validation (`npm test`) — all passed
- [x] Tested functionality locally with real Codex session logs
- [x] Verified statusline integration with claude-hud
- [x] No overlap with existing components

## Examples

```
/codex-hud:usage-week     — Show last 7 days token usage
/codex-hud:costs-today    — Show today's cost breakdown
/codex-hud:summary        — Quick one-line summary
```

## Links

- [Repository](https://github.com/haenara-shin/codex-hud)
- [README (English)](https://github.com/haenara-shin/codex-hud/blob/main/README.md)
- [README (Korean)](https://github.com/haenara-shin/codex-hud/blob/main/README_KR.md)