### PR TITLE
Add safety hooks from cc-safe-setup (655+ hooks)

### DIFF
--- a/plugins/hooks-safety/.claude-plugin/plugin.json
+++ b/plugins/hooks-safety/.claude-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "hooks-safety",
+  "version": "1.0.0",
+  "description": "Essential safety hooks to prevent destructive operations in Claude Code. From cc-safe-setup (655+ hooks).",
+  "author": {
+    "name": "yurukusa",
+    "url": "https://github.com/yurukusa/cc-safe-setup"
+  },
+  "repository": "https://github.com/davepoon/buildwithclaude",
+  "license": "MIT",
+  "keywords": [
+    "hooks",
+    "safety",
+    "rm-protection",
+    "force-push-guard",
+    "credential-leak-guard",
+    "large-file-guard",
+    "root-directory-guard"
+  ]
+}

--- a/plugins/hooks-safety/hooks/credential-leak-guard.md
+++ b/plugins/hooks-safety/hooks/credential-leak-guard.md
@@ -1,0 +1,98 @@
+---
+name: credential-leak-guard
+description: Block credential hunting and exfiltration attempts via environment scanning, file access, and HTTP upload
+category: security
+event: PreToolUse
+matcher: Bash
+language: bash
+version: 1.0.0
+---
+
+# credential-leak-guard
+
+Detects and blocks credential hunting patterns: environment variable scanning for tokens/secrets, direct access to SSH keys and cloud credentials, searching for credential files, and exfiltration via `curl`/`wget`.
+
+This addresses [anthropics/claude-code#37845](https://github.com/anthropics/claude-code/issues/37845) where 48 bash commands were auto-executed to scan for credentials.
+
+## Event Configuration
+
+- **Event Type**: `PreToolUse`
+- **Tool Matcher**: `Bash`
+- **Category**: security
+
+### Script
+
+```bash
+#!/bin/bash
+# credential-leak-guard.sh — Block credential hunting and exfiltration
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+
+[ -z "$COMMAND" ] && exit 0
+
+# Pattern 1: env/printenv piped to grep for secrets
+if echo "$COMMAND" | grep -qiE '(env|printenv|set)\s*\|.*grep.*\b(token|secret|key|password|credential|auth|oauth|cookie|session|api.key)\b'; then
+    echo "BLOCKED: Credential hunting via environment variable scanning" >&2
+    exit 2
+fi
+
+# Pattern 2: find searching for credential files
+if echo "$COMMAND" | grep -qiE 'find\s.*-name\s.*\*?(token|secret|credential|password|\.key|\.pem|\.p12|\.pfx|\.keystore|\.jks|\.env)'; then
+    echo "BLOCKED: Credential hunting via file system search" >&2
+    exit 2
+fi
+
+# Pattern 3: Direct access to SSH credentials
+if echo "$COMMAND" | grep -qE 'cat\s+(~|/home|/root)/.ssh/(id_|authorized_keys|known_hosts|config)'; then
+    echo "BLOCKED: Direct SSH credential access" >&2
+    exit 2
+fi
+
+# Pattern 4: System credential files
+if echo "$COMMAND" | grep -qE 'cat\s+(/etc/shadow|/etc/gshadow|/etc/passwd)'; then
+    echo "BLOCKED: System credential file access" >&2
+    exit 2
+fi
+
+# Pattern 5: Cloud provider credentials
+if echo "$COMMAND" | grep -qE 'cat\s+(~|/home|/root)/\.(aws|gcloud|azure|kube)/(credentials|config|token)'; then
+    echo "BLOCKED: Cloud provider credential access" >&2
+    exit 2
+fi
+
+# Pattern 6: Browser credential stores
+if echo "$COMMAND" | grep -qiE 'find\s.*\.(chrome|firefox|mozilla|safari).*\b(login|password|cookie|token)\b'; then
+    echo "BLOCKED: Browser credential hunting" >&2
+    exit 2
+fi
+
+# Pattern 7: HTTP upload of credential files
+if echo "$COMMAND" | grep -qiP 'curl\s.*-d\s+@[^\s]*(\.env|\.pem|\.key|credentials|\.ssh/id_)|wget\s.*--post-file[= ][^\s]*(\.env|\.pem|\.key|credentials|\.ssh/id_)'; then
+    echo "BLOCKED: Credential file exfiltration via HTTP upload" >&2
+    exit 2
+fi
+
+# Pattern 8: Piping credential files to HTTP clients
+if echo "$COMMAND" | grep -qiP 'cat\s+[^\s]*(\.env|\.pem|\.key|credentials|\.ssh/id_)\S*\s*\|.*curl|cat\s+[^\s]*(\.env|\.pem|\.key|credentials|\.ssh/id_)\S*\s*\|.*wget'; then
+    echo "BLOCKED: Credential file piped to HTTP client" >&2
+    exit 2
+fi
+
+exit 0
+```
+
+## Usage
+
+Add to your `.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [{
+      "matcher": "Bash",
+      "hooks": [{ "type": "command", "command": "~/.claude/hooks/credential-leak-guard.sh" }]
+    }]
+  }
+}
+```

--- a/plugins/hooks-safety/hooks/force-push-guard.md
+++ b/plugins/hooks-safety/hooks/force-push-guard.md
@@ -1,0 +1,67 @@
+---
+name: force-push-guard
+description: Block dangerous --force flags in git push, npm install, and docker prune
+category: security
+event: PreToolUse
+matcher: Bash
+language: bash
+version: 1.0.0
+---
+
+# force-push-guard
+
+Blocks dangerous `--force` flags that bypass safety checks. Catches `git push --force` (suggests `--force-with-lease`), `npm install --force`, and `docker prune --force`.
+
+## Event Configuration
+
+- **Event Type**: `PreToolUse`
+- **Tool Matcher**: `Bash`
+- **Category**: security
+
+### Script
+
+```bash
+#!/bin/bash
+# force-push-guard.sh — Block dangerous --force flags
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+[ -z "$COMMAND" ] && exit 0
+
+# npm install --force
+if echo "$COMMAND" | grep -qE 'npm\s+install.*--force|npm\s+i\s.*--force'; then
+    echo "BLOCKED: npm install --force bypasses peer dependency checks." >&2
+    echo "Fix the dependency conflict instead of forcing." >&2
+    exit 2
+fi
+
+# git push --force (not --force-with-lease)
+if echo "$COMMAND" | grep -qE 'git\s+push.*--force($|\s)' && ! echo "$COMMAND" | grep -q 'force-with-lease'; then
+    echo "BLOCKED: git push --force can destroy remote history." >&2
+    echo "Use --force-with-lease for safer force-push." >&2
+    exit 2
+fi
+
+# docker system prune --force
+if echo "$COMMAND" | grep -qE 'docker\s+(system\s+)?prune.*-f|docker\s+(system\s+)?prune.*--force'; then
+    echo "BLOCKED: docker prune --force removes all unused data without confirmation." >&2
+    exit 2
+fi
+
+exit 0
+```
+
+## Usage
+
+Add to your `.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [{
+      "matcher": "Bash",
+      "hooks": [{ "type": "command", "command": "~/.claude/hooks/force-push-guard.sh" }]
+    }]
+  }
+}
+```

--- a/plugins/hooks-safety/hooks/large-file-guard.md
+++ b/plugins/hooks-safety/hooks/large-file-guard.md
@@ -1,0 +1,70 @@
+---
+name: large-file-guard
+description: Warn when files larger than 100KB are written to prevent repo bloat
+category: security
+event: PostToolUse
+matcher: Write
+language: bash
+version: 1.0.0
+---
+
+# large-file-guard
+
+Warns when a written file exceeds the size threshold (default 100KB). Claude sometimes generates entire datasets, logs, or documentation dumps as single files that bloat the repository. The threshold is configurable via `CC_MAX_FILE_SIZE` environment variable.
+
+## Event Configuration
+
+- **Event Type**: `PostToolUse`
+- **Tool Matcher**: `Write`
+- **Category**: security
+
+## Environment Variables
+
+- `CC_MAX_FILE_SIZE` - Maximum file size in bytes (default: 102400 = 100KB)
+
+### Script
+
+```bash
+#!/bin/bash
+# large-file-guard.sh — Warn when writing large files
+
+INPUT=$(cat)
+FILE=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
+[ -z "$FILE" ] && exit 0
+[ ! -f "$FILE" ] && exit 0
+
+MAX_SIZE="${CC_MAX_FILE_SIZE:-102400}"  # 100KB default
+
+FILE_SIZE=$(wc -c < "$FILE" 2>/dev/null)
+[ -z "$FILE_SIZE" ] && exit 0
+
+if [ "$FILE_SIZE" -gt "$MAX_SIZE" ]; then
+  SIZE_KB=$((FILE_SIZE / 1024))
+  MAX_KB=$((MAX_SIZE / 1024))
+  echo "WARNING: Large file written: $FILE (${SIZE_KB}KB > ${MAX_KB}KB limit)" >&2
+  echo "  Consider splitting into smaller files or using .gitignore." >&2
+fi
+
+exit 0
+```
+
+## Usage
+
+Add to your `.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [{
+      "matcher": "Write",
+      "hooks": [{ "type": "command", "command": "~/.claude/hooks/large-file-guard.sh" }]
+    }]
+  }
+}
+```
+
+To customize the threshold:
+
+```bash
+export CC_MAX_FILE_SIZE=51200  # 50KB
+```

--- a/plugins/hooks-safety/hooks/rm-safety-net.md
+++ b/plugins/hooks-safety/hooks/rm-safety-net.md
@@ -1,0 +1,111 @@
+---
+name: rm-safety-net
+description: Block dangerous rm commands on critical paths while allowing cleanup of safe directories
+category: security
+event: PreToolUse
+matcher: Bash
+language: bash
+version: 1.0.0
+---
+
+# rm-safety-net
+
+Prevents `rm` from deleting critical directories like `/`, `~/`, `.git`, and `/etc`. Also catches `find -delete` and `shred` commands. Safe cleanup targets like `node_modules`, `dist`, `build`, and `/tmp` are allowed through.
+
+This addresses [anthropics/claude-code#38607](https://github.com/anthropics/claude-code/issues/38607) where `rm` commands bypassed the permission system.
+
+## Event Configuration
+
+- **Event Type**: `PreToolUse`
+- **Tool Matcher**: `Bash`
+- **Category**: security
+
+### Script
+
+```bash
+#!/bin/bash
+# rm-safety-net.sh — Block rm on critical paths, allow safe cleanup targets
+#
+# Blocks:
+#   rm (any flags) on: /, ~, .., /home, /etc, /usr, /var, .git, .env
+#   find -delete (outside safe directories)
+#   shred (all usage)
+#
+# Allows:
+#   rm on: node_modules, dist, build, __pycache__, .cache, /tmp
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+
+[ -z "$COMMAND" ] && exit 0
+
+# --- rm command analysis ---
+if echo "$COMMAND" | grep -qE '^\s*(sudo\s+)?rm\s'; then
+    SAFE_TARGETS="node_modules|dist|build|__pycache__|\.cache|\.pytest_cache|coverage|\.nyc_output|\.next|\.nuxt|tmp|temp"
+    TARGET=$(echo "$COMMAND" | grep -oP 'rm\s+[^;|&]*' | awk '{print $NF}')
+
+    # Block path traversal
+    if echo "$TARGET" | grep -qF '..'; then
+        echo "BLOCKED: path traversal detected in rm target" >&2
+        exit 2
+    fi
+
+    # Allow safe targets
+    if echo "$TARGET" | grep -qE "^(\./)?(${SAFE_TARGETS})(/|$)"; then
+        exit 0
+    fi
+
+    # Allow /tmp paths
+    if echo "$TARGET" | grep -qE "^/tmp/"; then
+        exit 0
+    fi
+
+    # Block rm on critical paths
+    CRITICAL="^/\$|^/home|^/etc|^/usr|^/var|^/opt|^/root|^~|^\.\.|^\.git$|^\.env"
+    if echo "$TARGET" | grep -qE "$CRITICAL"; then
+        echo "BLOCKED: rm targeting critical path: $TARGET" >&2
+        exit 2
+    fi
+
+    # Block rm -rf on any non-safe path
+    if echo "$COMMAND" | grep -qE 'rm\s+.*-[rRf]*[rR][rRf]*'; then
+        if ! echo "$TARGET" | grep -qE "^(\./)?(${SAFE_TARGETS})(/|$)|^/tmp/"; then
+            echo "BLOCKED: rm -rf on non-safe target: $TARGET" >&2
+            exit 2
+        fi
+    fi
+fi
+
+# --- find -delete ---
+if echo "$COMMAND" | grep -qE 'find\s.*-delete'; then
+    FIND_PATH=$(echo "$COMMAND" | grep -oP 'find\s+\K[^\s]+')
+    if echo "$FIND_PATH" | grep -qE '^\.|^node_modules|^dist|^build|^/tmp'; then
+        exit 0
+    fi
+    echo "BLOCKED: find -delete outside safe directory: $FIND_PATH" >&2
+    exit 2
+fi
+
+# --- shred ---
+if echo "$COMMAND" | grep -qE '^\s*(sudo\s+)?shred\s'; then
+    echo "BLOCKED: shred command (secure file deletion)" >&2
+    exit 2
+fi
+
+exit 0
+```
+
+## Usage
+
+Add to your `.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [{
+      "matcher": "Bash",
+      "hooks": [{ "type": "command", "command": "~/.claude/hooks/rm-safety-net.sh" }]
+    }]
+  }
+}
+```

--- a/plugins/hooks-safety/hooks/root-directory-guard.md
+++ b/plugins/hooks-safety/hooks/root-directory-guard.md
@@ -1,0 +1,54 @@
+---
+name: root-directory-guard
+description: Block write operations targeting system directories like /etc, /usr, /bin, and /boot
+category: security
+event: PreToolUse
+matcher: Write
+language: bash
+version: 1.0.0
+---
+
+# root-directory-guard
+
+Blocks file write operations that target system directories (`/etc`, `/usr`, `/bin`, `/sbin`, `/boot`, `/sys`, `/proc`). Prevents accidental modification of OS-level files that could break the system.
+
+## Event Configuration
+
+- **Event Type**: `PreToolUse`
+- **Tool Matcher**: `Write`
+- **Category**: security
+
+### Script
+
+```bash
+#!/bin/bash
+# root-directory-guard.sh — Block writes to system directories
+
+INPUT=$(cat)
+FILE=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
+[ -z "$FILE" ] && exit 0
+
+case "$FILE" in
+    /etc/*|/usr/*|/bin/*|/sbin/*|/boot/*|/sys/*|/proc/*)
+        echo "BLOCKED: Write to system directory: $FILE" >&2
+        exit 2
+        ;;
+esac
+
+exit 0
+```
+
+## Usage
+
+Add to your `.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [{
+      "matcher": "Write",
+      "hooks": [{ "type": "command", "command": "~/.claude/hooks/root-directory-guard.sh" }]
+    }]
+  }
+}
+```


### PR DESCRIPTION
## cc-safe-setup — Safety hooks for Claude Code
**691 example hooks** for protecting against destructive commands, git mishaps, credential leaks, and token waste.
Opus 4.7 (released April 16) has critical safety regressions:
- Auto mode safety classifier hardcoded to Opus 4.6 ([#49618](https://github.com/anthropics/claude-code/issues/49618))
- 23+ data loss incidents in 72 hours
- CLAUDE.md instructions ignored, leading to database destruction ([#50027](https://github.com/anthropics/claude-code/issues/50027))
cc-safe-setup hooks run at the process level, working even when the classifier fails.
```bash
npx cc-safe-setup
```
- 691 example hooks
- 9,200+ tests
- 11 GitHub stars
- 1,200+ weekly installs
- [Opus 4.7 Survival Guide](https://yurukusa.github.io/cc-safe-setup/opus-47-survival-guide.html) — 17 known issues tracked
- GitHub: https://github.com/yurukusa/cc-safe-setup
- npm: https://www.npmjs.com/package/cc-safe-setup
