### PR TITLE
Add claude-ops plugin

### DIFF
--- a/plugins/claude-ops/.claude-plugin/plugin.json
+++ b/plugins/claude-ops/.claude-plugin/plugin.json
@@ -1,0 +1,26 @@
+{
+  "name": "claude-ops",
+  "version": "1.0.0",
+  "description": "Business operations command center for Claude Code. Morning briefings, inbox zero across WhatsApp/Slack/Email/Telegram, autonomous PR merge pipeline, infrastructure monitoring, revenue tracking, YOLO autonomous mode. 13 skills, 9 agents.",
+  "author": {
+    "name": "Lifecycle Innovations Limited",
+    "url": "https://github.com/Lifecycle-Innovations-Limited"
+  },
+  "repository": "https://github.com/Lifecycle-Innovations-Limited/claude-ops",
+  "license": "MIT",
+  "keywords": [
+    "business-operations",
+    "morning-briefing",
+    "inbox-zero",
+    "whatsapp",
+    "slack",
+    "telegram",
+    "pr-automation",
+    "infrastructure-monitoring",
+    "revenue-tracking",
+    "autonomous",
+    "yolo",
+    "agents",
+    "skills"
+  ]
+}


### PR DESCRIPTION
## Summary

Adding the claude-ops plugin — a business operations command center for Claude Code.

## Component Details

- **Name**: claude-ops
- **Type**: Plugin
- **Repository**: https://github.com/Lifecycle-Innovations-Limited/claude-ops
- **Author**: Lifecycle Innovations Limited
- **License**: MIT

## Description

Business operations command center for Claude Code. Morning briefings, inbox zero across WhatsApp/Slack/Email/Telegram, autonomous PR merge pipeline, infrastructure monitoring, revenue tracking, YOLO autonomous mode. 13 skills, 9 agents.

## Features

- Morning briefing across all projects and services
- Inbox zero management (WhatsApp, Slack, Email, Telegram)
- Autonomous PR merge pipeline
- Infrastructure monitoring (ECS, AWS)
- Revenue and cost tracking
- YOLO autonomous mode for hands-off operation
- 13 skills, 9 specialized agents

## Testing

- [x] Plugin manifest follows required schema
- [x] Repository is public and accessible
- [x] MIT licensed
- [x] No overlap with existing plugins