### PR TITLE
Update project-boundary to v1.1.0

### DIFF
--- a/plugins/project-boundary/.claude-plugin/plugin.json
+++ b/plugins/project-boundary/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-boundary",
-  "version": "1.0.0",
-  "description": "Security hook that blocks destructive commands and file operations outside the project directory",
+  "version": "1.1.0",
+  "description": "Blocks destructive commands outside the project directory. Allows file operations within the project (refactoring, cleanup) but prevents accidental damage outside it.",
   "author": {
     "name": "Justyna Wojtczak",
     "url": "https://github.com/justi"
@@ -9,10 +9,13 @@
   "repository": "https://github.com/justi/claude-code-project-boundary",
   "license": "MIT",
   "keywords": [
-    "security",
-    "hooks",
     "safety",
-    "guard",
-    "project-boundary"
+    "boundary",
+    "protection",
+    "destructive-commands",
+    "rm",
+    "delete",
+    "project-scope",
+    "dangerously-skip-permissions"
   ]
 }

--- a/plugins/project-boundary/README.md
+++ b/plugins/project-boundary/README.md
@@ -1,6 +1,6 @@
 # Project Boundary — Claude Code Plugin
 
-Allows destructive operations **within your project** but blocks them **outside** the project directory. Built for `dangerouslySkipPermissions` mode where Claude doesn't ask — this plugin is your safety net.
+Allows destructive operations **within your project** but blocks them **outside** the project directory. Built for `--dangerously-skip-permissions` mode where Claude doesn't ask — this plugin is your safety net.
 
 ## How it differs from existing plugins
 
@@ -9,20 +9,6 @@ Allows destructive operations **within your project** but blocks them **outside*
 - **[claude-code-damage-control](https://github.com/disler/claude-code-damage-control)** — requires manually listing protected paths; Project Boundary automatically protects everything outside the project.
 
 ## What it does
-
-### Always blocked (regardless of location)
-
-| Command | Example |
-|---------|---------|
-| `git push --force` / `-f` | `git push --force origin main` |
-| `git reset --hard` | `git reset --hard HEAD~1` |
-| `git checkout .` | `git checkout .` |
-| `git clean -f` | `git clean -fd` |
-| `DROP TABLE` / `TRUNCATE TABLE` | `DROP TABLE users;` |
-| `rails db:drop` / `db:reset` | `rails db:drop` |
-| `rake db:drop` / `db:reset` | `rake db:drop` |
-| `mkfs.*` | `mkfs.ext4 /dev/sda1` |
-| `dd if=` | `dd if=/dev/zero of=/dev/sda` |
 
 ### Boundary-checked (allowed inside project, blocked outside)
 
@@ -38,6 +24,14 @@ Allows destructive operations **within your project** but blocks them **outside*
 | `curl -o` / `curl --output` | Allowed | **Blocked** |
 | `wget -O` / `wget --output-document` | Allowed | **Blocked** |
 | `find -delete` / `find -exec rm` | Allowed | **Blocked** |
+| `dd of=` | Allowed | **Blocked** |
+| `install` (source and destination) | Allowed | **Blocked** |
+| `rsync` (source and destination) | Allowed | **Blocked** |
+| `tar -C` / `--directory=` | Allowed | **Blocked** |
+| `unzip -d` / `cpio -D` | Allowed | **Blocked** |
+| **Edit** tool (file edits) | Allowed | **Blocked** |
+| **MultiEdit** tool (multi-file edits) | Allowed | **Blocked** |
+| **Write** tool (file creation) | Allowed | **Blocked** |
 
 ### Always blocked (unsafe to inspect)
 
@@ -47,21 +41,26 @@ Allows destructive operations **within your project** but blocks them **outside*
 | `eval '...'` | Cannot safely parse evaluated code |
 | Piping to `sh` / `bash` | Inner commands invisible to guard |
 | `xargs rm/mv/cp/...` | Arguments cannot be validated |
+| `$(...)` / backticks (outside single quotes) | Command substitution target is uninspectable. Single-quoted forms like `'$(cmd)'` and arithmetic expansion `$((2+2))` are allowed. |
 
 ### Additional protections
 
 - **Chained commands** — splits on `;`, `&&`, `||`, `|` and checks each sub-command independently
-- **`cd` tracking** — `cd /tmp && rm -rf something` is blocked because `cd` left the project
+- **`cwd` awareness** — uses `cwd` from the hook event, so commands run outside the project (without an explicit `cd`) are also guarded
+- **`cd` tracking** — `cd /tmp && rm -rf something` is blocked because `cd` left the project; `cd $PROJECT && rm file` is allowed even if the event `cwd` was outside
+- **Destructive subcommands outside project** — when running outside the project (via event `cwd` or `cd`), these are blocked: `git clean -f`, `git checkout .`, `git restore .`, `git reset --hard`, `git push --force`, `git stash drop/clear`, `git branch -D`, `git reflog expire`, `rails db:drop/reset`, `rake db:drop/reset`. Safe commands like `git status`, `git log`, `rails routes` remain allowed.
 - **`sudo` prefix** — stripped before checking, so `sudo rm /etc/passwd` is still blocked
 - **`find` options** — handles `-L`, `-H`, `-P` before the search path
 - **Path traversal** — `..` segments are resolved before boundary check
 - **`~` and `$HOME` expansion** — `rm ~/file` and `rm $HOME/file` are correctly detected as outside-project
-- **Symlink resolution** — handles macOS `/var` → `/private/var` and similar
+- **Symlink resolution** — handles macOS `/var` → `/private/var`, dereferences symlink chains in Edit/Write/MultiEdit (fail-closed after 20 hops)
 
 ### Known limitations
 
-- Paths with spaces in project directory name are not fully supported (space-based argument splitting)
-- `$()` subshells and backtick substitution inside arguments are not expanded
+- Paths with spaces work when properly quoted (single or double quotes). Unquoted paths with spaces are not supported.
+- Heredoc body contents are not inspected (only the first line of the command, where redirects are handled normally)
+- Brace expansion (`{a,b,c}`) is not enumerated — literal match only
+- `~user/` (home of another user) is not expanded; only `~/` (current user) is handled
 
 ## Install
 
@@ -70,18 +69,23 @@ Direct:
 claude --plugin-dir /path/to/claude-code-project-boundary
 ```
 
-From marketplace (after adding cc-marketplace or buildwithclaude):
+From marketplace:
 ```
-/plugin install project-boundary@cc-marketplace
+/plugin marketplace add davepoon/buildwithclaude
+/plugin install project-boundary@buildwithclaude
 ```
 
 ## How it works
 
-A pure-bash PreToolUse hook. Splits chained commands, resolves target paths (handling symlinks, `..`, `~`, `$HOME`), and compares against `$CLAUDE_PROJECT_DIR`. Dependencies: bash + jq.
+Pure-bash PreToolUse hooks for Bash, Edit, MultiEdit, and Write tools. The Bash hook splits chained commands and resolves target paths (handling symlinks, `..`, `~`, `$HOME`); the Edit, MultiEdit, and Write hooks perform file path boundary checks against `$CLAUDE_PROJECT_DIR`. Dependencies: bash + jq.
 
 ## Testing
 
-125 tests and CI (Ubuntu + macOS) in the [source repository](https://github.com/justi/claude-code-project-boundary).
+```
+bash tests/test_guard.sh
+```
+
+Full test suite covering all guard scenarios. CI runs on Ubuntu and macOS.
 
 ## License
 

--- a/plugins/project-boundary/hooks/guard.sh
+++ b/plugins/project-boundary/hooks/guard.sh
@@ -100,7 +100,7 @@ strip_quotes() {
     p="${p#\'}"
     p="${p%\'}"
   fi
-  echo "$p"
+  printf '%s\n' "$p"
 }
 
 # --- Expand ~ and $HOME in a command argument ---
@@ -121,7 +121,7 @@ expand_path() {
   p="${p/\$HOME/$HOME}"
   # Expand ${HOME}
   p="${p/\$\{HOME\}/$HOME}"
-  echo "$p"
+  printf '%s\n' "$p"
 }
 
 # --- Quote-aware argument tokenizer ---
@@ -159,7 +159,7 @@ tokenize_args() {
   fi
 
   for t in "${tokens[@]}"; do
-    echo "$t"
+    printf '%s\n' "$t"
   done
 }
 
@@ -448,7 +448,7 @@ check_single_command() {
   if echo "$CMD" | grep -qE '^(/bin/)?(sh|bash)[[:space:]]+-'; then
     # Check if all args are flags (start with -), not a script path
     local shell_args
-    shell_args=$(echo "$CMD" | sed -E 's|^(/bin/)?(sh\|bash)[[:space:]]+||')
+    shell_args=$(echo "$CMD" | sed -E 's/^(\/bin\/)?(sh|bash)[[:space:]]+//')
     local has_script=0
     for shell_token in $shell_args; do
       case "$shell_token" in

--- a/plugins/project-boundary/hooks/guard.sh
+++ b/plugins/project-boundary/hooks/guard.sh
@@ -3,9 +3,19 @@ set -euo pipefail
 
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+EVENT_CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
 
-if [ -z "$COMMAND" ]; then
+if [ -z "$COMMAND" ] && [ -z "$FILE_PATH" ]; then
   exit 0
+fi
+
+# Use cwd from the hook event if provided, so relative paths resolve correctly.
+# EFFECTIVE_CWD is used to resolve relative paths in commands.
+if [ -n "$EVENT_CWD" ]; then
+  EFFECTIVE_CWD="$EVENT_CWD"
+else
+  EFFECTIVE_CWD=""
 fi
 
 # If CLAUDE_PROJECT_DIR is not set, fall back to pwd with a warning.
@@ -17,6 +27,12 @@ fi
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
 # Ensure PROJECT_DIR has no trailing slash for consistent comparison
 PROJECT_DIR="${PROJECT_DIR%/}"
+
+# EFFECTIVE_CWD: where relative paths in commands resolve to.
+# Uses cwd from hook event if provided, otherwise PROJECT_DIR.
+if [ -z "$EFFECTIVE_CWD" ]; then
+  EFFECTIVE_CWD="$PROJECT_DIR"
+fi
 
 # --- Portable realpath in pure bash ---
 # macOS realpath does not support -m (non-existent path resolution).
@@ -40,7 +56,12 @@ resolve_path() {
     fi
   done
   local IFS='/'
-  local normalized="/${parts[*]}"
+  local normalized
+  if [[ ${#parts[@]} -eq 0 ]]; then
+    normalized="/"
+  else
+    normalized="/${parts[*]}"
+  fi
   # Walk up to find the nearest existing ancestor directory and resolve symlinks
   local check="$normalized"
   local tail=""
@@ -59,6 +80,28 @@ resolve_path() {
 
 # Resolve PROJECT_DIR itself so symlinks (e.g. /var -> /private/var on macOS) match
 PROJECT_DIR=$(resolve_path "$PROJECT_DIR")
+
+# Check if the effective working directory is outside the project
+EFFECTIVE_CWD_RESOLVED=$(resolve_path "$EFFECTIVE_CWD")
+CWD_OUTSIDE_PROJECT=0
+if [[ "$EFFECTIVE_CWD_RESOLVED/" != "$PROJECT_DIR/"* ]]; then
+  CWD_OUTSIDE_PROJECT=1
+fi
+
+# --- Strip one layer of surrounding quotes (single or double) ---
+# Used before matching option flags like `-o` / `--output` against tokens,
+# since tokenize_args preserves quotes: `curl "-o" file` → token `"-o"`.
+strip_quotes() {
+  local p="$1"
+  if [[ "$p" == \"*\" ]]; then
+    p="${p#\"}"
+    p="${p%\"}"
+  elif [[ "$p" == \'*\' ]]; then
+    p="${p#\'}"
+    p="${p%\'}"
+  fi
+  echo "$p"
+}
 
 # --- Expand ~ and $HOME in a command argument ---
 expand_path() {
@@ -81,6 +124,85 @@ expand_path() {
   echo "$p"
 }
 
+# --- Quote-aware argument tokenizer ---
+# Splits a string into tokens respecting single and double quotes.
+# Tokens are newline-separated on stdout with quotes preserved (expand_path strips them).
+tokenize_args() {
+  local input="$1"
+  local -a tokens=()
+  local current=""
+  local in_sq=0 in_dq=0
+  local i=0 len=${#input}
+
+  while [ $i -lt $len ]; do
+    local ch="${input:$i:1}"
+
+    if [ "$ch" = "'" ] && [ $in_dq -eq 0 ]; then
+      in_sq=$(( 1 - in_sq ))
+      current="${current}${ch}"
+    elif [ "$ch" = '"' ] && [ $in_sq -eq 0 ]; then
+      in_dq=$(( 1 - in_dq ))
+      current="${current}${ch}"
+    elif { [ "$ch" = ' ' ] || [ "$ch" = $'\t' ]; } && [ $in_sq -eq 0 ] && [ $in_dq -eq 0 ]; then
+      if [ -n "$current" ]; then
+        tokens+=("$current")
+        current=""
+      fi
+    else
+      current="${current}${ch}"
+    fi
+    i=$((i + 1))
+  done
+
+  if [ -n "$current" ]; then
+    tokens+=("$current")
+  fi
+
+  for t in "${tokens[@]}"; do
+    echo "$t"
+  done
+}
+
+# --- Extract all option values from CMD_TOKENS ---
+# Usage: extract_option_values <short> <long>
+#   short: e.g. "-o", or "" to skip
+#   long:  e.g. "--output", or "" to skip
+# Supports: "-o value", "--output value", "--output=value".
+# Option flags are matched after stripping surrounding quotes so that
+# `curl "-o" /etc/passwd` also matches.
+# Returns EVERY occurrence (one per line) so callers can validate each one.
+# This is fail-closed and handles both "last-wins" tools (tar, cp/mv)
+# and positional tools (curl -o applies to each URL) — if any single
+# occurrence is outside the project boundary, we block.
+# Returns 0 if at least one found, 1 otherwise.
+extract_option_values() {
+  local short="$1"
+  local long="$2"
+  local i=0 n=${#CMD_TOKENS[@]}
+  local found=1
+  while [ $i -lt $n ]; do
+    local raw_tok="${CMD_TOKENS[$i]}"
+    local tok
+    tok=$(strip_quotes "$raw_tok")
+    if [ -n "$short" ] && [ "$tok" = "$short" ] && [ $((i + 1)) -lt $n ]; then
+      printf '%s\n' "${CMD_TOKENS[$((i + 1))]}"
+      found=0
+    fi
+    if [ -n "$long" ]; then
+      if [ "$tok" = "$long" ] && [ $((i + 1)) -lt $n ]; then
+        printf '%s\n' "${CMD_TOKENS[$((i + 1))]}"
+        found=0
+      fi
+      if [[ "$tok" == "${long}="* ]]; then
+        printf '%s\n' "${tok#${long}=}"
+        found=0
+      fi
+    fi
+    i=$((i + 1))
+  done
+  return $found
+}
+
 # --- Check if a resolved path is inside the project directory ---
 is_inside_project() {
   local resolved="$1"
@@ -90,6 +212,42 @@ is_inside_project() {
   fi
   return 1
 }
+
+# --- Edit/Write tool: check file_path boundary ---
+if [ -n "$FILE_PATH" ]; then
+  FILE_PATH=$(expand_path "$FILE_PATH")
+  if [[ "$FILE_PATH" != /* ]]; then
+    FILE_PATH="$PROJECT_DIR/$FILE_PATH"
+  fi
+  RESOLVED=$(resolve_path "$FILE_PATH")
+  # Fully dereference symlinks so a symlink inside the project pointing
+  # outside is caught (e.g. project/link -> /tmp/secret).
+  # Loop handles chained symlinks (a -> b -> /outside).
+  max_depth=20
+  while [[ -L "$RESOLVED" && $max_depth -gt 0 ]]; do
+    link_target=$(readlink "$RESOLVED")
+    if [[ "$link_target" == /* ]]; then
+      RESOLVED=$(resolve_path "$link_target")
+    else
+      RESOLVED=$(resolve_path "$(dirname "$RESOLVED")/$link_target")
+    fi
+    max_depth=$((max_depth - 1))
+  done
+  # Fail-closed: if symlink chain is too deep or circular, block
+  if [[ -L "$RESOLVED" ]]; then
+    echo "BLOCKED: Symlink chain too deep or circular at '$RESOLVED'. Ask user for explicit permission." >&2
+    exit 2
+  fi
+  # Canonicalize the final path (resolve /var -> /private/var on macOS)
+  if [[ -e "$RESOLVED" ]]; then
+    RESOLVED="$(cd "$(dirname "$RESOLVED")" && pwd -P)/$(basename "$RESOLVED")"
+  fi
+  if ! is_inside_project "$RESOLVED"; then
+    echo "BLOCKED: File '$RESOLVED' is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
+    exit 2
+  fi
+  exit 0
+fi
 
 # --- Check a single (non-chained) command against all guards ---
 check_single_command() {
@@ -109,34 +267,167 @@ check_single_command() {
     CMD="$(echo "$CMD" | sed 's/^[[:space:]]*//')"
   fi
 
+  # --- Tokenize the command once (quote-aware) for option/redirect parsing ---
+  local -a CMD_TOKENS=()
+  while IFS= read -r tok; do
+    [[ -z "$tok" ]] && continue
+    CMD_TOKENS+=("$tok")
+  done < <(tokenize_args "$CMD")
+
+  # --- Block command substitution outside single quotes ---
+  # `$(...)` and backticks are expanded by bash (even inside double quotes),
+  # so the guard cannot know the final target. Single quotes keep them literal,
+  # so only block when they appear outside single quotes. Arithmetic expansion
+  # `$((...))` is allowed — it's a numeric computation, not a command.
+  # Similar rationale to blocking `bash -c` / `eval` — the inner command is
+  # uninspectable.
+  local ci=0 clen=${#CMD}
+  local cin_sq=0 cin_dq=0 cin_esc=0
+  while [ $ci -lt $clen ]; do
+    local cc="${CMD:$ci:1}"
+    if [ $cin_esc -eq 1 ]; then
+      cin_esc=0
+      ci=$((ci + 1))
+      continue
+    fi
+    if [ "$cc" = "\\" ] && [ $cin_sq -eq 0 ]; then
+      cin_esc=1
+      ci=$((ci + 1))
+      continue
+    fi
+    # Single quotes are only delimiters when NOT inside double quotes
+    if [ "$cc" = "'" ] && [ $cin_dq -eq 0 ]; then
+      cin_sq=$(( 1 - cin_sq ))
+      ci=$((ci + 1))
+      continue
+    fi
+    # Double quotes are only delimiters when NOT inside single quotes
+    if [ "$cc" = '"' ] && [ $cin_sq -eq 0 ]; then
+      cin_dq=$(( 1 - cin_dq ))
+      ci=$((ci + 1))
+      continue
+    fi
+    if [ $cin_sq -eq 0 ]; then
+      if [ "$cc" = "\`" ]; then
+        echo "BLOCKED: Command substitution with backticks cannot be safely inspected. Ask user for explicit permission." >&2
+        exit 2
+      fi
+      if [ "$cc" = "\$" ] && [ $((ci + 1)) -lt $clen ] && [ "${CMD:$((ci + 1)):1}" = "(" ]; then
+        # Skip arithmetic expansion $((...)): next-next char is also (
+        if [ $((ci + 2)) -ge $clen ] || [ "${CMD:$((ci + 2)):1}" != "(" ]; then
+          echo "BLOCKED: Command substitution '\$(...)' cannot be safely inspected. Ask user for explicit permission." >&2
+          exit 2
+        fi
+      fi
+    fi
+    ci=$((ci + 1))
+  done
+
   # --- Block cd outside project followed by destructive commands ---
-  if [[ "$CMD" =~ ^cd[[:space:]]+ ]]; then
+  if [[ "$CMD" =~ ^cd($|[[:space:]]) ]]; then
     local cd_target
-    cd_target=$(echo "$CMD" | awk '{print $2}')
-    cd_target=$(expand_path "$cd_target")
+    # cd takes a single argument, so grab everything after 'cd ' as the target
+    # (including spaces if quoted). Not using tokenize_args because cd doesn't
+    # take multiple path arguments.
+    cd_target=$(echo "$CMD" | sed 's/^cd[[:space:]]*//')
+    # cd with no args or cd ~ goes to $HOME
+    if [[ -z "$cd_target" || "$cd_target" == "~" ]]; then
+      cd_target="$HOME"
+    else
+      cd_target=$(expand_path "$cd_target")
+    fi
     if [[ "$cd_target" != /* ]]; then
-      cd_target="$PROJECT_DIR/$cd_target"
+      cd_target="$EFFECTIVE_CWD/$cd_target"
     fi
     local resolved_cd
     resolved_cd=$(resolve_path "$cd_target")
+    EFFECTIVE_CWD="$resolved_cd"
     if ! is_inside_project "$resolved_cd"; then
-      # cd outside project — flag it so subsequent commands in chain are blocked
       export _GUARD_CD_OUTSIDE=1
+      CWD_OUTSIDE_PROJECT=1
+    else
+      export _GUARD_CD_OUTSIDE=0
+      CWD_OUTSIDE_PROJECT=0
     fi
     return 0
   fi
 
-  # If a previous cd went outside project, block any destructive command
-  if [[ "${_GUARD_CD_OUTSIDE:-0}" == "1" ]]; then
+  # Block destructive commands when running outside the project
+  # (either via cd in a chained command, or via cwd from the hook event)
+  local outside_context=0
+  if [[ "${_GUARD_CD_OUTSIDE:-0}" == "1" || "$CWD_OUTSIDE_PROJECT" == "1" ]]; then
+    outside_context=1
+  fi
+
+  if [[ "$outside_context" == "1" ]]; then
     local destructive_cmds="rm|mv|cp|ln|chmod|chown|tee|find|curl|wget"
     if echo "$CMD" | grep -qE "(^|[[:space:]])($destructive_cmds)($|[[:space:]])"; then
-      echo "BLOCKED: Destructive command after 'cd' outside project directory. Ask user for explicit permission." >&2
+      echo "BLOCKED: Destructive command outside project directory. Ask user for explicit permission." >&2
+      exit 2
+    fi
+    # Destructive git subcommands
+    # git clean only destructive with -f/--force AND without -n/--dry-run
+    if echo "$CMD" | grep -qE '(^|[[:space:]])git[[:space:]]+clean([[:space:]]|$)'; then
+      local has_force=0
+      local is_dry_run=0
+      if echo "$CMD" | grep -qE '(^|[[:space:]])--force([[:space:]]|$)' || \
+         echo "$CMD" | grep -qE '(^|[[:space:]])-[a-zA-Z]*f[a-zA-Z]*([[:space:]]|$)'; then
+        has_force=1
+      fi
+      if echo "$CMD" | grep -qE '(^|[[:space:]])--dry-run([[:space:]]|$)' || \
+         echo "$CMD" | grep -qE '(^|[[:space:]])-[a-zA-Z]*n[a-zA-Z]*([[:space:]]|$)'; then
+        is_dry_run=1
+      fi
+      if [[ "$has_force" == "1" && "$is_dry_run" == "0" ]]; then
+        echo "BLOCKED: Destructive 'git clean' outside project directory. Ask user for explicit permission." >&2
+        exit 2
+      fi
+    fi
+    # git checkout . and git checkout -- .
+    if echo "$CMD" | grep -qE '(^|[[:space:]])git[[:space:]]+checkout([[:space:]]+--)?[[:space:]]+\.([[:space:]]|$)'; then
+      echo "BLOCKED: Destructive 'git checkout .' outside project directory. Ask user for explicit permission." >&2
+      exit 2
+    fi
+    # git reset --hard
+    if echo "$CMD" | grep -qE '(^|[[:space:]])git[[:space:]]+reset[[:space:]]+--hard'; then
+      echo "BLOCKED: Destructive 'git reset --hard' outside project directory. Ask user for explicit permission." >&2
+      exit 2
+    fi
+    # git push --force / -f
+    if echo "$CMD" | grep -qE '(^|[[:space:]])git[[:space:]]+push[[:space:]]+.*(--force|-f)([[:space:]]|$)'; then
+      echo "BLOCKED: Destructive 'git push --force' outside project directory. Ask user for explicit permission." >&2
+      exit 2
+    fi
+    # git restore . / git restore -- . / git restore --worktree .
+    if echo "$CMD" | grep -qE '(^|[[:space:]])git[[:space:]]+restore([[:space:]]+(--worktree|--staged|--))*[[:space:]]+\.([[:space:]]|$)'; then
+      echo "BLOCKED: Destructive 'git restore .' outside project directory. Ask user for explicit permission." >&2
+      exit 2
+    fi
+    # git stash drop / clear
+    if echo "$CMD" | grep -qE '(^|[[:space:]])git[[:space:]]+stash[[:space:]]+(drop|clear)'; then
+      echo "BLOCKED: Destructive 'git stash drop/clear' outside project directory. Ask user for explicit permission." >&2
+      exit 2
+    fi
+    # git branch -D / --delete --force
+    if echo "$CMD" | grep -qE '(^|[[:space:]])git[[:space:]]+branch[[:space:]]+(-D|--delete[[:space:]]+--force)'; then
+      echo "BLOCKED: Destructive 'git branch -D' outside project directory. Ask user for explicit permission." >&2
+      exit 2
+    fi
+    # git reflog expire --all or --expire=now
+    if echo "$CMD" | grep -qE '(^|[[:space:]])git[[:space:]]+reflog[[:space:]]+expire'; then
+      echo "BLOCKED: Destructive 'git reflog expire' outside project directory. Ask user for explicit permission." >&2
+      exit 2
+    fi
+    # Destructive rails/rake subcommands
+    if echo "$CMD" | grep -qE '(^|[[:space:]])(rails|rake)[[:space:]]+db:(drop|reset)'; then
+      echo "BLOCKED: Destructive rails/rake command outside project directory. Ask user for explicit permission." >&2
       exit 2
     fi
   fi
 
   # --- Block nested shell execution (bash -c, sh -c, eval) ---
-  if echo "$CMD" | grep -qE '(^|[[:space:]])(bash|sh)[[:space:]]+-c[[:space:]]'; then
+  # Match: bash -c, sh -c, bash -lc, bash -ec, /bin/bash -c, /bin/sh -c, /usr/bin/env bash -c
+  if echo "$CMD" | grep -qE '(^|[[:space:]])(/usr/bin/env[[:space:]]+)?(/bin/)?(bash|sh)[[:space:]]+-[a-zA-Z]*c[[:space:]]'; then
     echo "BLOCKED: Nested shell execution ('bash -c' / 'sh -c') cannot be safely inspected. Ask user for explicit permission." >&2
     exit 2
   fi
@@ -146,36 +437,31 @@ check_single_command() {
   fi
 
   # --- Block piping to sh/bash (e.g. echo "rm -rf /" | sh) ---
-  if echo "$CMD" | grep -qE '^(sh|bash)$'; then
+  # Match bare shell invocations: sh, bash, /bin/sh, /bin/bash,
+  # and with flags: sh -s, bash --login, etc.
+  # But NOT: bash script.sh, bash -x script.sh (running a script file)
+  if echo "$CMD" | grep -qE '^(/bin/)?(sh|bash)$'; then
     echo "BLOCKED: Piping to 'sh'/'bash' cannot be safely inspected. Ask user for explicit permission." >&2
     exit 2
   fi
-
-  # --- Always blocked (dangerous regardless of location) ---
-  local ALWAYS_BLOCKED=(
-    "git push.*--force"
-    "git push.*-f($|[[:space:]])"
-    "git reset --hard"
-    "git checkout \."
-    "git clean.*-f"
-    "drop_table"
-    "drop table"
-    "truncate table"
-    "rails db:drop"
-    "rails db:reset"
-    "rake db:drop"
-    "rake db:reset"
-    "mkfs\."
-    "dd if="
-    "(^|[[:space:]])format($|[[:space:]]).*disk"
-  )
-
-  for pattern in "${ALWAYS_BLOCKED[@]}"; do
-    if echo "$CMD" | grep -qiE "$pattern"; then
-      echo "BLOCKED: '$CMD' matches dangerous pattern '$pattern'. This command is always blocked. Ask user for explicit permission." >&2
+  # Match shell with only flags (no script file): sh -s, bash --login, sh -s -- args
+  if echo "$CMD" | grep -qE '^(/bin/)?(sh|bash)[[:space:]]+-'; then
+    # Check if all args are flags (start with -), not a script path
+    local shell_args
+    shell_args=$(echo "$CMD" | sed -E 's|^(/bin/)?(sh\|bash)[[:space:]]+||')
+    local has_script=0
+    for shell_token in $shell_args; do
+      case "$shell_token" in
+        --) break ;;  # everything after -- is args to the script/stdin
+        -*) continue ;;
+        *) has_script=1; break ;;
+      esac
+    done
+    if [[ $has_script -eq 0 ]]; then
+      echo "BLOCKED: Piping to 'sh'/'bash' cannot be safely inspected. Ask user for explicit permission." >&2
       exit 2
     fi
-  done
+  fi
 
   # --- xargs with dangerous commands ---
   if echo "$CMD" | grep -qE '(^|[[:space:]])xargs($|[[:space:]])'; then
@@ -193,23 +479,29 @@ check_single_command() {
   # --- find with -delete or -exec rm/mv outside project ---
   if echo "$CMD" | grep -qE '(^|[[:space:]])find($|[[:space:]])'; then
     if echo "$CMD" | grep -qE '(-delete|-exec[[:space:]]+(rm|mv))'; then
-      # Extract the find path (first non-option argument after 'find')
-      # Skip options like -L, -H, -P that come before the path
-      local find_path=""
+      # Extract ALL find paths (non-option arguments after 'find')
+      # Skip options like -L, -H, -P that come before the paths
+      local -a find_paths=()
       local find_args
       find_args=$(echo "$CMD" | sed -E 's/.*find[[:space:]]+//')
-      for find_token in $find_args; do
+      local past_options=0
+      while IFS= read -r find_token; do
+        [[ -z "$find_token" ]] && continue
         case "$find_token" in
-          -L|-H|-P|-O*) continue ;;  # find options before path
-          -*) break ;;               # expression starts, no path given
-          *) find_path="$find_token"; break ;;
+          -L|-H|-P|-O*)
+            [[ $past_options -eq 0 ]] && continue
+            break ;;  # expression starts
+          -*)  break ;;  # expression starts
+          *)
+            past_options=1
+            find_paths+=("$find_token") ;;
         esac
-      done
-      find_path="${find_path:-.}"
-      if [ -n "$find_path" ]; then
+      done < <(tokenize_args "$find_args")
+      [[ ${#find_paths[@]} -eq 0 ]] && find_paths=(".")
+      for find_path in "${find_paths[@]}"; do
         find_path=$(expand_path "$find_path")
         if [[ "$find_path" != /* ]]; then
-          find_path="$PROJECT_DIR/$find_path"
+          find_path="$EFFECTIVE_CWD/$find_path"
         fi
         local resolved_find
         resolved_find=$(resolve_path "$find_path")
@@ -217,20 +509,22 @@ check_single_command() {
           echo "BLOCKED: 'find' with destructive action targets '$resolved_find' which is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
           exit 2
         fi
-      fi
+      done
     fi
   fi
 
   # --- File deletion: allowed inside project, blocked outside ---
   if echo "$CMD" | grep -qE '(^|[[:space:]])rm($|[[:space:]])'; then
     # Extract paths from rm command (skip flags)
-    PATHS=$(echo "$CMD" | grep -oE '(^|[[:space:]])rm[[:space:]]+.*' | sed 's/^[[:space:]]*rm[[:space:]]*//' | tr ' ' '\n' | grep -v '^-')
+    local rm_raw
+    rm_raw=$(echo "$CMD" | grep -oE '(^|[[:space:]])rm[[:space:]]+.*' | sed 's/^[[:space:]]*rm[[:space:]]*//')
 
-    for TARGET in $PATHS; do
+    while IFS= read -r TARGET; do
+      [[ -z "$TARGET" || "$TARGET" == -* ]] && continue
       TARGET=$(expand_path "$TARGET")
       # Resolve to absolute path
       if [[ "$TARGET" != /* ]]; then
-        TARGET="$PROJECT_DIR/$TARGET"
+        TARGET="$EFFECTIVE_CWD/$TARGET"
       fi
       RESOLVED=$(resolve_path "$TARGET")
 
@@ -244,17 +538,31 @@ check_single_command() {
         echo "BLOCKED: Cannot delete the project root directory itself." >&2
         exit 2
       fi
-    done
+    done < <(tokenize_args "$rm_raw")
   fi
 
   # --- Moving files outside project ---
   if echo "$CMD" | grep -qE '(^|[[:space:]])mv($|[[:space:]])'; then
-    MV_ARGS=$(echo "$CMD" | grep -oE '(^|[[:space:]])mv[[:space:]]+.*' | sed 's/^[[:space:]]*mv[[:space:]]*//' | tr ' ' '\n' | grep -v '^-')
+    # Check -t / --target-directory
+    while IFS= read -r mv_target_dir; do
+      [ -z "$mv_target_dir" ] && continue
+      mv_target_dir=$(expand_path "$mv_target_dir")
+      [[ "$mv_target_dir" != /* ]] && mv_target_dir="$EFFECTIVE_CWD/$mv_target_dir"
+      local resolved_mv_td
+      resolved_mv_td=$(resolve_path "$mv_target_dir")
+      if ! is_inside_project "$resolved_mv_td"; then
+        echo "BLOCKED: 'mv --target-directory' targets '$resolved_mv_td' which is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
+        exit 2
+      fi
+    done < <(extract_option_values "-t" "--target-directory" || true)
+    local mv_raw
+    mv_raw=$(echo "$CMD" | grep -oE '(^|[[:space:]])mv[[:space:]]+.*' | sed 's/^[[:space:]]*mv[[:space:]]*//')
 
-    for TARGET in $MV_ARGS; do
+    while IFS= read -r TARGET; do
+      [[ -z "$TARGET" || "$TARGET" == -* ]] && continue
       TARGET=$(expand_path "$TARGET")
       if [[ "$TARGET" != /* ]]; then
-        TARGET="$PROJECT_DIR/$TARGET"
+        TARGET="$EFFECTIVE_CWD/$TARGET"
       fi
       RESOLVED=$(resolve_path "$TARGET")
 
@@ -262,17 +570,31 @@ check_single_command() {
         echo "BLOCKED: 'mv' argument '$RESOLVED' is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
         exit 2
       fi
-    done
+    done < <(tokenize_args "$mv_raw")
   fi
 
   # --- cp command: check all non-flag arguments ---
   if echo "$CMD" | grep -qE '(^|[[:space:]])cp($|[[:space:]])'; then
-    CP_ARGS=$(echo "$CMD" | grep -oE '(^|[[:space:]])cp[[:space:]]+.*' | sed 's/^[[:space:]]*cp[[:space:]]*//' | tr ' ' '\n' | grep -v '^-')
+    # Check -t / --target-directory
+    while IFS= read -r cp_target_dir; do
+      [ -z "$cp_target_dir" ] && continue
+      cp_target_dir=$(expand_path "$cp_target_dir")
+      [[ "$cp_target_dir" != /* ]] && cp_target_dir="$EFFECTIVE_CWD/$cp_target_dir"
+      local resolved_cp_td
+      resolved_cp_td=$(resolve_path "$cp_target_dir")
+      if ! is_inside_project "$resolved_cp_td"; then
+        echo "BLOCKED: 'cp --target-directory' targets '$resolved_cp_td' which is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
+        exit 2
+      fi
+    done < <(extract_option_values "-t" "--target-directory" || true)
+    local cp_raw
+    cp_raw=$(echo "$CMD" | grep -oE '(^|[[:space:]])cp[[:space:]]+.*' | sed 's/^[[:space:]]*cp[[:space:]]*//')
 
-    for TARGET in $CP_ARGS; do
+    while IFS= read -r TARGET; do
+      [[ -z "$TARGET" || "$TARGET" == -* ]] && continue
       TARGET=$(expand_path "$TARGET")
       if [[ "$TARGET" != /* ]]; then
-        TARGET="$PROJECT_DIR/$TARGET"
+        TARGET="$EFFECTIVE_CWD/$TARGET"
       fi
       RESOLVED=$(resolve_path "$TARGET")
 
@@ -280,17 +602,19 @@ check_single_command() {
         echo "BLOCKED: 'cp' argument '$RESOLVED' is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
         exit 2
       fi
-    done
+    done < <(tokenize_args "$cp_raw")
   fi
 
   # --- ln command: check all non-flag arguments ---
   if echo "$CMD" | grep -qE '(^|[[:space:]])ln($|[[:space:]])'; then
-    LN_ARGS=$(echo "$CMD" | grep -oE '(^|[[:space:]])ln[[:space:]]+.*' | sed 's/^[[:space:]]*ln[[:space:]]*//' | tr ' ' '\n' | grep -v '^-')
+    local ln_raw
+    ln_raw=$(echo "$CMD" | grep -oE '(^|[[:space:]])ln[[:space:]]+.*' | sed 's/^[[:space:]]*ln[[:space:]]*//')
 
-    for TARGET in $LN_ARGS; do
+    while IFS= read -r TARGET; do
+      [[ -z "$TARGET" || "$TARGET" == -* ]] && continue
       TARGET=$(expand_path "$TARGET")
       if [[ "$TARGET" != /* ]]; then
-        TARGET="$PROJECT_DIR/$TARGET"
+        TARGET="$EFFECTIVE_CWD/$TARGET"
       fi
       RESOLVED=$(resolve_path "$TARGET")
 
@@ -298,17 +622,136 @@ check_single_command() {
         echo "BLOCKED: 'ln' argument '$RESOLVED' is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
         exit 2
       fi
+    done < <(tokenize_args "$ln_raw")
+  fi
+
+  # --- install command: like cp, check all non-flag path arguments ---
+  if echo "$CMD" | grep -qE '(^|[[:space:]])install($|[[:space:]])'; then
+    local install_raw
+    install_raw=$(echo "$CMD" | grep -oE '(^|[[:space:]])install[[:space:]]+.*' | sed 's/^[[:space:]]*install[[:space:]]*//')
+    # Skip mode arg (numeric, after -m/--mode), owner arg (after -o), group (after -g)
+    while IFS= read -r TARGET; do
+      [[ -z "$TARGET" || "$TARGET" == -* ]] && continue
+      # Skip pure numeric (mode) or user:group patterns
+      if [[ "$TARGET" =~ ^[0-9]+$ ]] || [[ "$TARGET" =~ ^[a-zA-Z_][a-zA-Z0-9_]*(:[a-zA-Z_][a-zA-Z0-9_]*)?$ ]]; then
+        continue
+      fi
+      TARGET=$(expand_path "$TARGET")
+      if [[ "$TARGET" != /* ]]; then
+        TARGET="$EFFECTIVE_CWD/$TARGET"
+      fi
+      RESOLVED=$(resolve_path "$TARGET")
+      if ! is_inside_project "$RESOLVED"; then
+        echo "BLOCKED: 'install' argument '$RESOLVED' is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
+        exit 2
+      fi
+    done < <(tokenize_args "$install_raw")
+  fi
+
+  # --- rsync command: check all non-flag path arguments ---
+  if echo "$CMD" | grep -qE '(^|[[:space:]])rsync($|[[:space:]])'; then
+    local rsync_raw
+    rsync_raw=$(echo "$CMD" | grep -oE '(^|[[:space:]])rsync[[:space:]]+.*' | sed 's/^[[:space:]]*rsync[[:space:]]*//')
+    while IFS= read -r TARGET; do
+      [[ -z "$TARGET" || "$TARGET" == -* ]] && continue
+      # Skip remote paths (user@host:/path or host:/path)
+      if [[ "$TARGET" =~ : ]]; then
+        continue
+      fi
+      TARGET=$(expand_path "$TARGET")
+      if [[ "$TARGET" != /* ]]; then
+        TARGET="$EFFECTIVE_CWD/$TARGET"
+      fi
+      RESOLVED=$(resolve_path "$TARGET")
+      if ! is_inside_project "$RESOLVED"; then
+        echo "BLOCKED: 'rsync' argument '$RESOLVED' is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
+        exit 2
+      fi
+    done < <(tokenize_args "$rsync_raw")
+  fi
+
+  # --- tar: check every -C / --directory=PATH for extraction ---
+  # tar allows multiple -C switches and the *last* one wins, so we must
+  # validate every occurrence — not just the first.
+  if echo "$CMD" | grep -qE '(^|[[:space:]])tar($|[[:space:]])'; then
+    local ti=0 tn=${#CMD_TOKENS[@]}
+    while [ $ti -lt $tn ]; do
+      local ttok
+      ttok=$(strip_quotes "${CMD_TOKENS[$ti]}")
+      local tar_dir=""
+      if [ "$ttok" = "-C" ] || [ "$ttok" = "--directory" ]; then
+        if [ $((ti + 1)) -lt $tn ]; then
+          tar_dir="${CMD_TOKENS[$((ti + 1))]}"
+          ti=$((ti + 2))
+        else
+          ti=$((ti + 1))
+        fi
+      elif [[ "$ttok" == "--directory="* ]]; then
+        tar_dir="${ttok#--directory=}"
+        ti=$((ti + 1))
+      else
+        ti=$((ti + 1))
+        continue
+      fi
+      if [ -n "$tar_dir" ]; then
+        tar_dir=$(expand_path "$tar_dir")
+        if [[ "$tar_dir" != /* ]]; then
+          tar_dir="$EFFECTIVE_CWD/$tar_dir"
+        fi
+        local resolved_tar
+        resolved_tar=$(resolve_path "$tar_dir")
+        if ! is_inside_project "$resolved_tar"; then
+          echo "BLOCKED: 'tar -C' targets '$resolved_tar' which is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
+          exit 2
+        fi
+      fi
     done
+  fi
+
+  # --- unzip -d PATH ---
+  if echo "$CMD" | grep -qE '(^|[[:space:]])unzip($|[[:space:]])'; then
+    while IFS= read -r unzip_dir; do
+      [ -z "$unzip_dir" ] && continue
+      unzip_dir=$(expand_path "$unzip_dir")
+      if [[ "$unzip_dir" != /* ]]; then
+        unzip_dir="$EFFECTIVE_CWD/$unzip_dir"
+      fi
+      local resolved_unzip
+      resolved_unzip=$(resolve_path "$unzip_dir")
+      if ! is_inside_project "$resolved_unzip"; then
+        echo "BLOCKED: 'unzip -d' targets '$resolved_unzip' which is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
+        exit 2
+      fi
+    done < <(extract_option_values "-d" "" || true)
+  fi
+
+  # --- cpio -D PATH ---
+  if echo "$CMD" | grep -qE '(^|[[:space:]])cpio($|[[:space:]])'; then
+    while IFS= read -r cpio_dir; do
+      [ -z "$cpio_dir" ] && continue
+      cpio_dir=$(expand_path "$cpio_dir")
+      if [[ "$cpio_dir" != /* ]]; then
+        cpio_dir="$EFFECTIVE_CWD/$cpio_dir"
+      fi
+      local resolved_cpio
+      resolved_cpio=$(resolve_path "$cpio_dir")
+      if ! is_inside_project "$resolved_cpio"; then
+        echo "BLOCKED: 'cpio -D' targets '$resolved_cpio' which is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
+        exit 2
+      fi
+    done < <(extract_option_values "-D" "" || true)
   fi
 
   # --- tee command: extract file arguments, block if outside project ---
   if echo "$CMD" | grep -qE '(^|[[:space:]])tee($|[[:space:]])'; then
-    TEE_ARGS=$(echo "$CMD" | grep -oE '(^|[[:space:]])tee[[:space:]]+.*' | sed 's/^[[:space:]]*tee[[:space:]]*//' | tr ' ' '\n' | grep -v '^-')
+    local tee_raw
+    tee_raw=$(echo "$CMD" | grep -oE '(^|[[:space:]])tee[[:space:]]+.*' | sed 's/^[[:space:]]*tee[[:space:]]*//')
 
-    for TARGET in $TEE_ARGS; do
+    while IFS= read -r TARGET; do
+      [[ -z "$TARGET" || "$TARGET" == -* ]] && continue
       TARGET=$(expand_path "$TARGET")
       if [[ "$TARGET" != /* ]]; then
-        TARGET="$PROJECT_DIR/$TARGET"
+        TARGET="$EFFECTIVE_CWD/$TARGET"
       fi
       RESOLVED=$(resolve_path "$TARGET")
 
@@ -316,24 +759,18 @@ check_single_command() {
         echo "BLOCKED: 'tee' targets '$RESOLVED' which is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
         exit 2
       fi
-    done
+    done < <(tokenize_args "$tee_raw")
   fi
 
   # --- curl -o / curl --output outside project ---
+  # curl -o is positional: `curl -o out1 URL1 -o out2 URL2` writes each URL
+  # to its corresponding output. Validate EVERY occurrence.
   if echo "$CMD" | grep -qE '(^|[[:space:]])curl($|[[:space:]])'; then
-    local curl_output=""
-    # Match -o <file> or --output <file> or --output=<file>
-    if echo "$CMD" | grep -qE '(^|[[:space:]])-o[[:space:]]'; then
-      curl_output=$(echo "$CMD" | sed -E 's/.*[[:space:]]-o[[:space:]]+([^ ]+).*/\1/')
-    elif echo "$CMD" | grep -qE '(^|[[:space:]])--output[[:space:]]'; then
-      curl_output=$(echo "$CMD" | sed -E 's/.*--output[[:space:]]+([^ ]+).*/\1/')
-    elif echo "$CMD" | grep -qE '(^|[[:space:]])--output='; then
-      curl_output=$(echo "$CMD" | sed -E 's/.*--output=([^ ]+).*/\1/')
-    fi
-    if [ -n "$curl_output" ]; then
+    while IFS= read -r curl_output; do
+      [ -z "$curl_output" ] && continue
       curl_output=$(expand_path "$curl_output")
       if [[ "$curl_output" != /* ]]; then
-        curl_output="$PROJECT_DIR/$curl_output"
+        curl_output="$EFFECTIVE_CWD/$curl_output"
       fi
       local resolved_curl
       resolved_curl=$(resolve_path "$curl_output")
@@ -341,23 +778,16 @@ check_single_command() {
         echo "BLOCKED: 'curl' output file '$resolved_curl' is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
         exit 2
       fi
-    fi
+    done < <(extract_option_values "-o" "--output" || true)
   fi
 
   # --- wget -O / wget --output-document outside project ---
   if echo "$CMD" | grep -qE '(^|[[:space:]])wget($|[[:space:]])'; then
-    local wget_output=""
-    if echo "$CMD" | grep -qE '(^|[[:space:]])-O[[:space:]]'; then
-      wget_output=$(echo "$CMD" | sed -E 's/.*[[:space:]]-O[[:space:]]+([^ ]+).*/\1/')
-    elif echo "$CMD" | grep -qE '(^|[[:space:]])--output-document[[:space:]]'; then
-      wget_output=$(echo "$CMD" | sed -E 's/.*--output-document[[:space:]]+([^ ]+).*/\1/')
-    elif echo "$CMD" | grep -qE '(^|[[:space:]])--output-document='; then
-      wget_output=$(echo "$CMD" | sed -E 's/.*--output-document=([^ ]+).*/\1/')
-    fi
-    if [ -n "$wget_output" ]; then
+    while IFS= read -r wget_output; do
+      [ -z "$wget_output" ] && continue
       wget_output=$(expand_path "$wget_output")
       if [[ "$wget_output" != /* ]]; then
-        wget_output="$PROJECT_DIR/$wget_output"
+        wget_output="$EFFECTIVE_CWD/$wget_output"
       fi
       local resolved_wget
       resolved_wget=$(resolve_path "$wget_output")
@@ -365,47 +795,144 @@ check_single_command() {
         echo "BLOCKED: 'wget' output file '$resolved_wget' is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
         exit 2
       fi
-    fi
+    done < <(extract_option_values "-O" "--output-document" || true)
   fi
 
-  # --- Writing to files outside project via redirection (> and >>) ---
-  if echo "$CMD" | grep -qE '>{1,2}[[:space:]]*/|>{1,2}[[:space:]]*~|>{1,2}[[:space:]]*\$HOME|>{1,2}[[:space:]]*"[/~]|>{1,2}[[:space:]]*'"'"'[/~]'; then
-    # Extract redirect targets for both > and >>
-    REDIR_TARGET=$(echo "$CMD" | grep -oE '>{1,2}[[:space:]]*[^ ]+' | sed 's/^>*[[:space:]]*//')
+  # --- dd of= outside project ---
+  # dd accepts repeated key=value operands and the last one wins, so we must
+  # validate every of= occurrence — not just the first.
+  if echo "$CMD" | grep -qE '(^|[[:space:]])dd($|[[:space:]])'; then
+    for raw_tok in "${CMD_TOKENS[@]}"; do
+      local tok
+      tok=$(strip_quotes "$raw_tok")
+      if [[ "$tok" == of=* ]]; then
+        local dd_output="${tok#of=}"
+        if [ -n "$dd_output" ]; then
+          dd_output=$(expand_path "$dd_output")
+          if [[ "$dd_output" != /* ]]; then
+            dd_output="$EFFECTIVE_CWD/$dd_output"
+          fi
+          local resolved_dd
+          resolved_dd=$(resolve_path "$dd_output")
+          if ! is_inside_project "$resolved_dd"; then
+            echo "BLOCKED: 'dd' output '$resolved_dd' is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
+            exit 2
+          fi
+        fi
+      fi
+    done
+  fi
+
+  # --- Writing to files outside project via redirection ---
+  # Walk tokens and scan each one for an unquoted > operator anywhere
+  # (not just at the start). This catches both separated forms (`> file`,
+  # `2>> file`) and attached forms (`>file`, `x>file`, `"a">file`).
+  # Skips fd-to-fd redirects like 2>&1 (target starts with &).
+  local ri=0 rn=${#CMD_TOKENS[@]}
+  while [ $ri -lt $rn ]; do
+    local rtok="${CMD_TOKENS[$ri]}"
+    local REDIR_TARGET=""
+
+    # Scan the token for an unquoted > (respecting ' and " quotes and
+    # backslash escapes). `\>` outside single quotes is a literal >, not
+    # a redirect operator.
+    local j=0 tlen=${#rtok}
+    local tin_sq=0 tin_dq=0
+    local tin_esc=0
+    local redir_pos=-1
+    while [ $j -lt $tlen ]; do
+      local tc="${rtok:$j:1}"
+      if [ $tin_esc -eq 1 ]; then
+        tin_esc=0
+        j=$((j + 1))
+        continue
+      fi
+      if [ "$tc" = "\\" ] && [ $tin_sq -eq 0 ]; then
+        tin_esc=1
+        j=$((j + 1))
+        continue
+      fi
+      if [ "$tc" = "'" ] && [ $tin_dq -eq 0 ]; then
+        tin_sq=$(( 1 - tin_sq ))
+      elif [ "$tc" = '"' ] && [ $tin_sq -eq 0 ]; then
+        tin_dq=$(( 1 - tin_dq ))
+      elif [ "$tc" = ">" ] && [ $tin_sq -eq 0 ] && [ $tin_dq -eq 0 ]; then
+        redir_pos=$j
+        break
+      fi
+      j=$((j + 1))
+    done
+
+    if [ $redir_pos -lt 0 ]; then
+      ri=$((ri + 1))
+      continue
+    fi
+
+    # Found > at redir_pos. Extend past a second > if present (>>).
+    local op_end=$((redir_pos + 1))
+    if [ $op_end -lt $tlen ] && [ "${rtok:$op_end:1}" = ">" ]; then
+      op_end=$((op_end + 1))
+    fi
+    # Also consume a trailing | (Bash clobber operator: >| or >>|).
+    if [ $op_end -lt $tlen ] && [ "${rtok:$op_end:1}" = "|" ]; then
+      op_end=$((op_end + 1))
+    fi
+
+    # Extract target: rest of token if any, otherwise next token
+    local rest="${rtok:$op_end}"
+    if [ -z "$rest" ]; then
+      if [ $((ri + 1)) -lt $rn ]; then
+        REDIR_TARGET="${CMD_TOKENS[$((ri + 1))]}"
+        ri=$((ri + 2))
+      else
+        ri=$((ri + 1))
+      fi
+    elif [[ "$rest" == \&* ]]; then
+      # fd-to-fd redirect like 2>&1, no file target
+      ri=$((ri + 1))
+    else
+      REDIR_TARGET="$rest"
+      ri=$((ri + 1))
+    fi
+
     if [ -n "$REDIR_TARGET" ]; then
+      # Block process substitution — `> >(cmd)` runs `cmd` which the guard
+      # cannot safely inspect, similar to nested shells.
+      if [[ "$REDIR_TARGET" == \(* ]] || [[ "$REDIR_TARGET" == \>\(* ]] || [[ "$REDIR_TARGET" == \<\(* ]]; then
+        echo "BLOCKED: Process substitution redirect '$REDIR_TARGET' cannot be safely inspected. Ask user for explicit permission." >&2
+        exit 2
+      fi
       REDIR_TARGET=$(expand_path "$REDIR_TARGET")
       if [[ "$REDIR_TARGET" != /* ]]; then
-        REDIR_TARGET="$PROJECT_DIR/$REDIR_TARGET"
+        REDIR_TARGET="$EFFECTIVE_CWD/$REDIR_TARGET"
       fi
-      RESOLVED=$(resolve_path "$REDIR_TARGET")
-
-      if ! is_inside_project "$RESOLVED"; then
-        echo "BLOCKED: Redirect target '$RESOLVED' is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
+      local resolved_redir
+      resolved_redir=$(resolve_path "$REDIR_TARGET")
+      if ! is_inside_project "$resolved_redir"; then
+        echo "BLOCKED: Redirect target '$resolved_redir' is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
         exit 2
       fi
     fi
-  fi
+  done
 
   # --- Chmod/chown outside project ---
   for CMD_NAME in chmod chown; do
     if echo "$CMD" | grep -qE "(^|[[:space:]])${CMD_NAME}($|[[:space:]])"; then
       # Extract args after command name, skip flags, then skip the first
       # non-flag token (mode for chmod, owner[:group] for chown)
-      local all_args
-      all_args=$(echo "$CMD" | grep -oE "(^|[[:space:]])${CMD_NAME}[[:space:]]+.*" | sed "s/^[[:space:]]*${CMD_NAME}[[:space:]]*//" | tr ' ' '\n' | grep -v '^-')
+      local perm_raw
+      perm_raw=$(echo "$CMD" | grep -oE "(^|[[:space:]])${CMD_NAME}[[:space:]]+.*" | sed "s/^[[:space:]]*${CMD_NAME}[[:space:]]*//")
       local skipped_first=0
-      PATHS=""
-      for token in $all_args; do
+
+      while IFS= read -r TARGET; do
+        [[ -z "$TARGET" || "$TARGET" == -* ]] && continue
         if [[ $skipped_first -eq 0 ]]; then
           skipped_first=1
           continue
         fi
-        PATHS="$PATHS $token"
-      done
-      for TARGET in $PATHS; do
         TARGET=$(expand_path "$TARGET")
         if [[ "$TARGET" != /* ]]; then
-          TARGET="$PROJECT_DIR/$TARGET"
+          TARGET="$EFFECTIVE_CWD/$TARGET"
         fi
         RESOLVED=$(resolve_path "$TARGET")
 
@@ -413,7 +940,7 @@ check_single_command() {
           echo "BLOCKED: '${CMD_NAME}' targets '$RESOLVED' which is OUTSIDE project directory. Ask user for explicit permission." >&2
           exit 2
         fi
-      done
+      done < <(tokenize_args "$perm_raw")
     fi
   done
 }
@@ -474,8 +1001,26 @@ split_and_check() {
         fi
       fi
 
-      # Check for ; or |
-      if [ "$ch" = ";" ] || [ "$ch" = "|" ]; then
+      # Check for ;
+      if [ "$ch" = ";" ]; then
+        subcmds+=("$current")
+        current=""
+        prev_ch="$ch"
+        i=$((i + 1))
+        continue
+      fi
+
+      # Check for | — but not if it's part of the Bash clobber operator >| or >>|
+      if [ "$ch" = "|" ]; then
+        # Look at the trailing chars of current (trimmed) to detect > or >>
+        local trimmed="${current%"${current##*[![:space:]]}"}"
+        if [[ "$trimmed" == *\> ]]; then
+          # Part of >| or >>| — keep it as a redirect operator, not a pipe
+          current="${current}${ch}"
+          prev_ch="$ch"
+          i=$((i + 1))
+          continue
+        fi
         subcmds+=("$current")
         current=""
         prev_ch="$ch"

--- a/plugins/project-boundary/hooks/hooks.json
+++ b/plugins/project-boundary/hooks/hooks.json
@@ -1,9 +1,39 @@
 {
-  "description": "Blocks always-dangerous commands everywhere and file operations outside the project directory",
+  "description": "Blocks file operations outside the project directory",
   "hooks": {
     "PreToolUse": [
       {
         "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/guard.sh\"",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/guard.sh\"",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/guard.sh\"",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "MultiEdit",
         "hooks": [
           {
             "type": "command",


### PR DESCRIPTION
## Summary

- Add Edit, Write, MultiEdit tool boundary guards (previously only Bash was covered)
- Block command substitution `$(...)` and backticks outside single quotes
- Fix quoted paths with spaces in argument parsing
- Remove always-blocked commands, focus on boundary checking only
- Bump version to 1.1.0

Triggered by user report: https://github.com/justi/claude-code-project-boundary/issues/11 — the marketplace was serving v1.0.0 which only had the Bash matcher, leaving Edit/Write/MultiEdit unguarded.

## Test plan

- [x] 150+ tests passing in source repo
- [x] True-negative test suite confirms no false positives on real workflows