### PR TITLE
Add claude-snapshot plugin

### DIFF
--- a/plugins/claude-snapshot/.claude-plugin/plugin.json
+++ b/plugins/claude-snapshot/.claude-plugin/plugin.json
@@ -1,0 +1,23 @@
+{
+  "name": "claude-snapshot",
+  "version": "0.2.0",
+  "description": "Export and apply portable snapshots of your Claude Code setup across machines",
+  "author": {
+    "name": "Rodolfo Moraes",
+    "url": "https://github.com/adhenawer"
+  },
+  "repository": "https://github.com/adhenawer/claude-snapshot",
+  "license": "MIT",
+  "keywords": [
+    "snapshot",
+    "config",
+    "sync",
+    "backup",
+    "setup",
+    "cross-machine",
+    "export",
+    "apply",
+    "diff",
+    "inspect"
+  ]
+}

--- a/plugins/claude-snapshot/README.md
+++ b/plugins/claude-snapshot/README.md
@@ -1,0 +1,45 @@
+# claude-snapshot
+
+Portable Claude Code setup snapshots. Export your config, plugins, hooks, and global instructions — apply on another machine in under 2 minutes.
+
+## Why
+
+- **Multiple machines** — Keep personal and work setups in sync. Export at home, drop the file on Drive, apply at work.
+- **OS reinstall / Mac format** — Save a snapshot before wiping. Restore your entire Claude Code setup after a fresh install.
+- **Safe rollback** — About to experiment with new plugins or risky config changes? Take a snapshot first.
+- **Onboarding** — Share your team's snapshot and new members are up and running with the same plugins, hooks, and conventions.
+
+## Commands
+
+| Command | Description |
+|---|---|
+| `/snapshot:export` | Export your setup as a portable `.tar.gz` snapshot |
+| `/snapshot:export --full` | Include plugin caches for offline restore |
+| `/snapshot:export --output <path>` | Custom output path |
+| `/snapshot:inspect <path>` | Preview snapshot contents without extracting |
+| `/snapshot:diff <path>` | Compare a snapshot against your current setup |
+| `/snapshot:apply <path>` | Apply a snapshot to this machine (with confirmation) |
+
+## What migrates
+
+| Artifact | Included |
+|---|---|
+| `settings.json` (plugins, hooks, permissions, env, statusLine) | Yes |
+| `CLAUDE.md` + other global `.md` files | Yes |
+| Plugin manifests + marketplace registrations | Yes |
+| Hook scripts | Yes |
+| MCP servers (`mcpServers` key only — OAuth tokens excluded) | Yes (report only on apply) |
+| Plugin caches (with `--full`) | Yes |
+| Sessions, history, telemetry | No |
+| Project-scoped plugins | No |
+
+## Install
+
+```bash
+/plugin marketplace add adhenawer/claude-snapshot
+/plugin install snapshot@claude-snapshot
+```
+
+## Links
+
+- [GitHub](https://github.com/adhenawer/claude-snapshot)


### PR DESCRIPTION
## Summary

Adds [claude-snapshot](https://github.com/adhenawer/claude-snapshot) — a Claude Code plugin for exporting and applying portable snapshots of your entire Claude Code setup across machines.

## Component Details

- **Name**: claude-snapshot
- **Type**: Plugin (Commands)
- **Category**: automation / cross-machine sync
- **Source repo**: https://github.com/adhenawer/claude-snapshot

## What it does

4 slash commands to manage your Claude Code setup as a portable `.tar.gz` snapshot:

- `/snapshot:export` — captures settings, plugins, hooks, CLAUDE.md, MCP configs
- `/snapshot:apply` — restores on another machine with diff preview + `.bak` safety
- `/snapshot:diff` — compares a snapshot against your current setup before applying
- `/snapshot:inspect` — previews snapshot contents without extracting

**Key properties:**
- No network requests — local-only, delegates plugin reinstall to Claude Code's own mechanism
- Cross-platform: Node.js 18+, runs identically on macOS and Linux
- Every apply backs up overwritten files as `.bak` before writing

## Testing

- [x] Ran validation (`npm test`) — all passed
- [x] Tested functionality locally (exported and applied across machines)
- [x] No overlap with existing components

## Examples

```bash
# Install
/plugin marketplace add adhenawer/claude-snapshot
/plugin install snapshot@claude-snapshot

# Sync between machines
/snapshot:export --output ~/Drive/claude-snapshot.tar.gz
/snapshot:apply ~/Drive/claude-snapshot.tar.gz

# Inspect before applying
/snapshot:inspect ~/Drive/claude-snapshot.tar.gz
/snapshot:diff ~/Drive/claude-snapshot.tar.gz
```