### PR TITLE
Add Archcore Plugin v0.3.5

### DIFF
--- a/plugins/archcore/.claude-plugin/plugin.json
+++ b/plugins/archcore/.claude-plugin/plugin.json
@@ -1,0 +1,30 @@
+{
+  "name": "archcore",
+  "version": "0.3.5",
+  "description": "Make your AI agent code with your project's architecture, rules, and decisions. Git-native context (folder conventions, ADRs, team standards) so new code lands in the right place and decisions persist across sessions and agents.",
+  "author": {
+    "name": "Archcore",
+    "url": "https://github.com/archcore-ai"
+  },
+  "repository": "https://github.com/archcore-ai/archcore-plugin",
+  "license": "Apache-2.0",
+  "keywords": [
+    "claude-code",
+    "claude-code-plugin",
+    "mcp",
+    "ai-agents",
+    "ai-coding",
+    "context-engineering",
+    "architecture",
+    "adr",
+    "knowledge-management",
+    "rules",
+    "decisions",
+    "conventions",
+    "git-native",
+    "skills",
+    "subagents",
+    "spec-driven",
+    "documentation"
+  ]
+}

--- a/plugins/archcore/README.md
+++ b/plugins/archcore/README.md
@@ -1,0 +1,44 @@
+# Archcore
+
+Make your AI agent code with your project's architecture, rules, and decisions. Git-native context (folder conventions, ADRs, team standards) lives in `.archcore/` next to your code, so every agent and every contributor reads from the same source of truth.
+
+## Why
+
+- **Right placement** — New code lands where your conventions say it should, not wherever the agent guesses.
+- **Standards apply themselves** — Rules load into the agent's context automatically.
+- **Decisions persist** — ADRs captured once stay enforced across sessions and agents.
+- **Team-wide** — Context is in Git, shared by humans and agents alike.
+
+## What's included
+
+| Component   | Details                                                                                                                                                                                         |
+| ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| MCP server  | `archcore` (init project, create/get/list/search/update/remove documents, manage relations)                                                                                                     |
+| Agents      | `archcore-assistant`, `archcore-auditor`                                                                                                                                                        |
+| Skills (18) | architecture-track, bootstrap, capture, context, decide, plan, review, verify, status, graph, help, actualize, feature-track, iso-track, product-track, sources-track, standard, standard-track |
+| Hooks       | session-start, cursor sync                                                                                                                                                                      |
+| Rules       | Cursor `.mdc` files (architecture-context, file ownership)                                                                                                                                      |
+
+## Document types
+
+`.archcore/` stores Markdown with YAML frontmatter. Categories are derived from the type in the filename (`slug.type.md`):
+
+- **knowledge** — `adr` (decisions), `rfc` (proposals), `rule` (standards), `guide` (how-tos), `doc` (reference), `spec` (contracts)
+- **vision** — `prd`, `idea`, `plan`, `mrd`, `brd`, `urd`, `srs`
+- **experience** — `task-type`, `cpat` (code patterns)
+
+Documents can be linked with directed relations stored in the sync manifest.
+
+## Install
+
+```bash
+/plugin marketplace add archcore-ai/archcore-plugin
+/plugin install archcore@archcore-plugin
+```
+
+The plugin ships a launcher in `bin/` that backs the MCP server, so install from the upstream marketplace above — this buildwithclaude listing is for discovery only.
+
+## Links
+
+- [GitHub](https://github.com/archcore-ai/archcore-plugin)
+- License: Apache-2.0


### PR DESCRIPTION
Hello @davepoon!                                       
                                                                                                                                                                                                                  
  Adds [archcore](https://github.com/archcore-ai/archcore-plugin) — a Claude Code plugin that gives coding agents the architecture, rules, and past decisions of your repo, stored as Markdown in `.archcore/`    
  next to your code. New code lands in the right place, follows team conventions automatically, and ADRs persist across sessions and agents.                                                                      
                                                                                                                                                                                                                  
  ## Component Details                                                                                                                                                                                            
                                                                                                                                                                                                                  
  - **Name**: archcore                                                                                                                                                                                            
  - **Type**: Plugin (1 MCP server + 2 agents + 18 skills + hooks)
  - **Version**: 0.3.5                                                                                                                                                                                            
  - **Repository**: https://github.com/archcore-ai/archcore-plugin
  - **Author**: Archcore (https://github.com/archcore-ai)                                                                                                                                                         
  - **License**: Apache-2.0
  - **Category**: productivity                                                                                                                                                                                    
                                                                                                                                                                                                                  
  ## Description
                                                                                                                                                                                                                  
  Git-native context for AI coding agents. `.archcore/` holds Markdown documents (rules, ADRs, RFCs, PRDs, code patterns) with YAML frontmatter; the `archcore` MCP server lets agents create, search, and link   
  them; 18 skills cover the full lifecycle (bootstrap → capture → decide → plan → review → verify); session-start hooks load the right context automatically; Cursor `.mdc` rules keep behavior consistent across
  host tools.                                                                                                                                                                                                     
                  
  **Document categories** are derived from the type in the filename (`slug.type.md`):                                                                                                                             
   
  - **knowledge** — `adr`, `rfc`, `rule`, `guide`, `doc`, `spec`                                                                                                                                                  
  - **vision** — `prd`, `idea`, `plan`, `mrd`, `brd`, `urd`, `srs`
  - **experience** — `task-type`, `cpat` (code patterns)                                                                                                                                                          
                                                                                                                                                                                                                  
  ## Install                                                                                                                                                                                                      
                                                                                                                                                                                                                  
  ```bash         
  /plugin marketplace add archcore-ai/archcore-plugin
  /plugin install archcore@archcore-plugins 
```                                                                                                                                                                
   
  This buildwithclaude listing is for discovery — the plugin ships a launcher in bin/ that backs the MCP server, so install from the upstream marketplace above.                                                  
                  
  Testing                                                                                                                                                                                                         
                  
  - Plugin manifest follows .claude-plugin/plugin.json schema                                                                                                                                                     
  - npm run validate passes (no new errors)
  - No overlap with existing plugins                                                                                                                                                                              
  - Repository is public and Apache-2.0 licensed
                                                                                                                                                                                                                  
  Examples        
                                                                                                                                                                                                                  
  "Check the rules for src/payments/ before adding the new webhook handler"
     → archcore-assistant loads matching rules and ADRs into context                                                                                                                                              
                                                                                                                                                                                                                  
  "Place the new auth middleware according to our conventions"                                                                                                                                                    
     → folder placement decided by .archcore/ rules, not a guess                                                                                                                                                  
                                                                                                                                                                                                                  
  "Record this decision: webhooks must be idempotent (Stripe retries)"                                                                                                                                            
     → captured as an ADR, enforced on future code touching webhook paths                                                                                                                                         
                                                                                                                                                                                                                  
  Links           
                                                                                                                                                                                                                  
  - Repository: https://github.com/archcore-ai/archcore-plugin
  - License: Apache-2.0