### PR TITLE
docs(CONTRIBUTING): add Hanko as a pre-flight schema check before submission

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,8 @@ Thank you for your interest in contributing to Build with Claude! This guide wil
 
 3. **One purpose per contribution**: Each component should have a single, clear responsibility
 
+4. **Pre-flight your plugin manifest**: Run [`hanko check .`](https://github.com/RoninForge/hanko) on your plugin directory to catch reserved marketplace names (`claude-*`, `anthropic-*`), duplicate hooks declarations, and schema errors before opening a PR. This complements `npm run validate`: Hanko checks the upstream Claude Code plugin schema, the buildwithclaude validators check submission structure.
+
 ## Project Structure
 
 ```


### PR DESCRIPTION
Adds one bullet under "Before You Start" pointing submitters at `hanko check .` to validate the plugin manifest before opening a PR.
                                                                                                                                                                                                                                                                                                                                                                        
**Hank** covers issues `npm run validate` does not:                                                                                                                                                                                                                                                                                                                      
                                                  
- Reserved marketplace names (`claude-*`, `anthropic-*`)                                                                                                                                                                                                                                                                                                               - Duplicate hooks declarations                          
- Schema errors in `plugin.json` and `marketplace.json`
                                                                                                                                                                                                                                                                                                                                                                        It checks against the upstream Claude Code plugin schema. The buildwithclaude validators check submission structure. The two layers don't overlap.
                                                                                                                                                                                                                                                                                                                                                                        
**Disclosure:** I author Hanko (https://github.com/RoninForge/hanko, MIT, Go binary, also on the GitHub Actions Marketplace). Happy to drop or rewrite if it doesn't fit.
                                                                                                                                                                                                                                                                                                                                                                        
**What I changed:** 
- Cut "the intent is to reduce review burden on issues you already see in incoming PRs" — was presumptuous about what the maintainer sees                                                                                                                                                                                                                             
- Cut "v2.1+ footgun" — colloquial jargon                                                                                                                                                                                                                                                                                                                             - Cut "Author here" — odd register       
- Disclosure moved into a clear labeled line so it's unambiguous, not buried as an aside                                                                                                                                                                                                                                                                              
- Last sentence is a real off-ramp, not theatre