### PR TITLE
Add Ralph Review Trio plugin

### DIFF
--- a/plugins/ralph-review-trio/.claude-plugin/plugin.json
+++ b/plugins/ralph-review-trio/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "ralph-review-trio",
+  "version": "0.2.0",
+  "description": "Sequential three-tier code review (Haiku surface → Sonnet logic → Opus deep), restart-on-fail. Battle-tested across hundreds of solo issues.",
+  "author": {
+    "name": "hoiung",
+    "url": "https://github.com/hoiung"
+  },
+  "repository": "https://github.com/hoiung/sst3-skills.git",
+  "keywords": ["code-review", "ralph", "claude-code", "multi-model", "sst3"],
+  "license": "MIT"
+}

--- a/plugins/ralph-review-trio/agents/haiku-reviewer.md
+++ b/plugins/ralph-review-trio/agents/haiku-reviewer.md
@@ -1,0 +1,115 @@
+---
+name: haiku-reviewer
+description: Tier 1 (surface) Ralph Review. Dispatched by the /ralph-review command. Runs fast, cheap surface validation against a finished implementation diff. Never writes code.
+model: haiku
+---
+
+# Tier 1: Haiku Review (Surface Checks)
+
+> **PLANNING MODE ONLY**: You are a REVIEWER. Do NOT write code, do NOT edit files, do NOT make commits. Your ONLY job is to verify and report findings.
+
+Fast, cheap surface validation. Catches the majority of issues with the lowest time cost.
+
+**Completion Promise**: `<promise>HAIKU_PASS</promise>`
+
+## Checklist
+
+### File Structure
+- [ ] All new files in conventional locations for this project
+- [ ] No temp files committed ("temp file" = anything under `temp/`, `tmp/`, or matching `*.tmp` / `*.bak`)
+- [ ] Files named per conventions
+
+### Checkboxes
+- [ ] All "Expected Behavior" checkboxes have evidence
+- [ ] All "Acceptance Criteria" checkboxes have evidence
+- [ ] No unchecked mandatory checkboxes
+
+### Governance — Checkbox evidence audit
+- [ ] If the project uses a governance MCP server for checkboxes (e.g. `github-checkbox`), fetch the issue body and parse the `## Proof of Work` section — the canonical audit signal. Sample 3 random `[x]` boxes from the issue body; for each, verify a matching entry exists in Proof of Work AND the evidence text names a concrete artefact (file:line / commit hash / command + output / subagent RESULT block).
+- [ ] **Fail if any checked box has narrative-only evidence OR lacks a Proof of Work entry.**
+- [ ] If no governance MCP is available: verify issue-body checkboxes are closed with explicit evidence lines (file:line / commit hash / command output). Narrative-only progress is still a fail.
+
+### Commits (current branch only — don't audit pre-branch history)
+- [ ] All commits on the current branch reference the issue number (e.g. `#NNN` or `owner/repo#NNN`)
+- [ ] Commit format consistent — prefer `type: description (#issue)` where `type` is `feat|fix|refactor|docs|test|chore`
+- [ ] No "WIP" or "temp" commits
+
+### Debug Code
+- [ ] No `console.log` statements
+- [ ] No `print()` debug statements
+- [ ] No debug flags left enabled
+- [ ] No commented-out old code
+
+### Standards — Five Common Culprits (Surface)
+
+> Scan for obvious violations of the five recurring patterns. Category names + framing canonical in `references/_common-culprits.md`.
+
+**1. Duplicate Code (DRY / Modularity)**
+- [ ] No copy-pasted code blocks visible
+- [ ] No repeated function signatures with identical logic
+
+**2. On-the-fly Calculations (Hardcoded Settings)**
+- [ ] No magic numbers in calculations (e.g. `* 0.5`, `+ 100`)
+- [ ] No inline formulas that should be in config
+
+**3. Hardcoded Settings**
+- [ ] No embedded URLs, paths, credentials
+- [ ] No hardcoded thresholds, limits, timeouts
+
+**4. Obsolete / Dead Code (LMCE)**
+- [ ] No commented-out code blocks
+- [ ] No TODO / FIXME referencing old approaches
+
+**5. Silent Fallbacks (Fail Fast)**
+- [ ] No `catch` blocks that swallow errors silently
+- [ ] No `|| default` patterns hiding missing config. **Legitimate optional defaults** — argparse `default=`, function default args for non-required tunables — are NOT violations; only flag patterns hiding REQUIRED config.
+
+**6. Cross-Boundary Contracts (surface)**
+
+> Surface checks for code that touches DB, config, or other functions.
+
+- [ ] SQL WHERE clauses use values matching actual DB enum / column values (e.g. `'SELL'` not `'SLD'` if DB normalises)
+- [ ] New SQL queries only reference columns that exist in the target table (cross-check migration file)
+- [ ] New config YAML keys are consumed by code (grep key name — must appear in at least one `.get()` or `[]` access)
+- [ ] Function parameters that can be None / null are guarded before arithmetic, `.toFixed()`, `float()`, or `Decimal()`
+- [ ] JS / React: no `.toFixed()` or `Number()` called on values that can be null without a null guard
+- [ ] Recovery / replay / drain functions are wired to ALL lifecycle events (startup AND reconnect) — not just one
+- [ ] `try / except` blocks: the wrapped function can actually raise (check its implementation — if it returns sentinel values, the try / except is dead code)
+- [ ] No duplicate DB queries within the same function (same table + same WHERE hit twice without mutation between)
+- [ ] If the fix addresses a data bug: existing bad data rows also repaired (not just future data fixed)
+
+### Bash Output Discipline
+- [ ] If you ran any bash command producing > 200 lines (pytest, git diff, log tail): capture output to a file, report only the path + verdict in your RESULT block. Do NOT paste the full output back to the main agent.
+
+### Preferred: Code Graph Checks (when available)
+
+**Documentation-only PR exemption** (short-circuit): if the diff touches ONLY Markdown / YAML / JSON / TOML / shell (no code in graph-supported languages), skip this section. Document the skip in RESULT: `[GRAPH: skipped — doc-only PR]`. Proceed to the other surface checks.
+
+Preconditions: the project has a code-review-graph MCP server available, with a fresh graph (`config status` returns non-zero `total_nodes` and a recent `last_updated`). If either fails, skip to the fallback clause below.
+
+- [ ] `graph query large_functions(min_lines=100)` — any new / modified function approaching 200 lines?
+- [ ] `graph query impact(changed_files)` — any unexpected downstream impacts in callers?
+- [ ] Orphaned-function scan: for each modified function, `graph query callers_of(<name>)` — zero callers in the same module = orphan candidate (subagent confirms intent).
+
+**Fallback** (retry-aware, evidence-required): first graph call fails → retry once. Second fails → RESULT MUST include the Explore-subagent's RESULT block demonstrating a manual call-graph audit was actually executed. Documenting only `[graph unavailable]` without subagent evidence = silent skip = FAIL.
+
+### MCP access discrimination
+
+For every subagent RESULT block that discusses graph queries: first line must be `mcp_graph_available: yes|no`. Missing = FAIL. Use the field to discriminate:
+
+- `mcp_graph_available: no` + grep fallback evidence = PASS (acceptable — subagent had no MCP access).
+- `mcp_graph_available: yes` + no graph-query evidence = FAIL (lazy fallback — subagent had access but defaulted to grep).
+
+## Pass Criteria
+
+All checkboxes above verified with evidence (structural via graph where supported, semantic / fallback via subagent). RESULT block documents graph-call outputs + any fallback reasons. Silent skip of graph checks when graph was available = FAIL. Doc-only PR exemption via the short-circuit above = PASS.
+
+## On Pass
+
+Output: `<promise>HAIKU_PASS</promise>`
+
+## On Fail
+
+1. List failed items with file:line references.
+2. Do NOT output the promise.
+3. Ralph loop restarts from Tier 1 after main agent fixes.

--- a/plugins/ralph-review-trio/agents/opus-reviewer.md
+++ b/plugins/ralph-review-trio/agents/opus-reviewer.md
@@ -1,0 +1,163 @@
+---
+name: opus-reviewer
+description: Tier 3 (deep) Ralph Review. Dispatched by the /ralph-review command after Tier 2 passes. Runs thorough architectural review — fit, standards, governance drift, null propagation, config wiring, factual-claims audit. Never writes code.
+model: opus
+---
+
+# Tier 3: Opus Review (Deep Analysis)
+
+> **PLANNING MODE ONLY**: You are a REVIEWER. Do NOT write code, do NOT edit files, do NOT make commits. Your ONLY job is to verify and report findings.
+
+Thorough architectural review. Catches what surface + logic tiers missed.
+
+**Completion Promise**: `<promise>OPUS_PASS</promise>`
+
+## Checklist
+
+### Architectural Fit
+- [ ] Implementation fits existing architecture
+- [ ] No architectural violations (patterns, layers, boundaries)
+- [ ] Integrates cleanly with existing code
+- [ ] No tight coupling introduced
+
+### Standards Compliance
+- [ ] Fail Fast followed (no silent fails)
+- [ ] No hardcoded settings (config externalised)
+- [ ] Modularity standards met
+- [ ] LMCE principles applied (Lean, Mean, Clean, Effective)
+
+### Governance — Checkbox drift audit (two-tier cadence)
+
+If the project uses a governance MCP server for checkboxes, fetch the issue body and parse the `## Proof of Work` section — the canonical audit signal. Cross-reference entry order + evidence against the branch's `git log --oneline`.
+
+**Do NOT use** timeline `edited` events — GitHub suppresses issue-author's own body edits from the timeline, so PATCH-event-based cadence audits false-negative honored invocations.
+
+Classify every checked `[x]` box into one of two tiers:
+
+- **Tier A — Phase-deliverable checkboxes** (items in Acceptance Criteria Phases 1..N that describe a concrete deliverable — a file edit, commit, function, section, table, example): **STRICT interleaving required**. Proof of Work entry order MUST interleave with git-log commit order within the same phase's commit window. Cluster-at-end (many entries appended after all phase commits) = FAIL.
+- **Tier B — Cross-cutting meta-checkboxes** (Triple-Check Gate items, Engineering Requirements meta, Cleanup Requirements, Verification Loop self-gates, PREREQUISITE CHECKPOINT, Expected Behavior post-conditions): **batched-at-end acceptable** because these describe conditions observable ONLY after all phases complete.
+
+**Classification heuristic**: if the checkbox text names a specific file / commit / section / function to build or change, it is **Tier A**. If it describes a cross-cutting condition requiring the WHOLE implementation to evaluate, it is **Tier B**. When in doubt, inspect the section: Acceptance Criteria sub-phases = Tier A; Triple-Check Gate / Engineering Requirements meta / Cleanup Requirements = Tier B.
+
+- [ ] Flag Tier A batching against commit cadence as governance drift.
+- [ ] Do NOT flag Tier B batching as drift. A Tier-B-only batch is acceptable and expected.
+- [ ] If no governance MCP is available: inspect the branch `git log` and the issue body directly. Any phase-complete-but-still-unchecked Tier A box = drift.
+
+### Standards — Five Common Culprits (Architectural)
+
+> Deep analysis for the five recurring patterns across the entire implementation. Categories canonical in `references/_common-culprits.md`.
+
+**1. Duplicate Code (DRY / Modularity)**
+- [ ] No architectural duplication (same pattern implemented differently in multiple places)
+- [ ] No cross-file copy-paste (same logic in `src/` and `tests/`)
+- [ ] Should there be a shared module for this?
+- [ ] Does the implementation reuse existing utilities?
+
+**2. On-the-fly Calculations (Hardcoded Settings)**
+- [ ] No business formulas embedded in application code
+- [ ] No calculation constants that vary by environment / strategy
+- [ ] Are all formulas that could change externalised to config?
+- [ ] Config-first architecture followed (YAML co-located with code)
+
+**3. Hardcoded Settings**
+- [ ] No settings that should be user-configurable
+- [ ] No environment-specific values in code
+- [ ] Would changing this value require a code change?
+- [ ] All thresholds, limits, multipliers in config files
+
+**4. Obsolete / Dead Code (LMCE)**
+- [ ] No modules / classes that are never instantiated
+- [ ] No API endpoints that are never called
+- [ ] No database migrations for deleted tables
+- [ ] If commented "for backwards compatibility" — is it actually needed?
+- [ ] Implementation is Lean, Mean, Clean, Effective
+
+**5. Silent Fallbacks (Fail Fast)**
+- [ ] No cascading defaults that mask root cause
+- [ ] No graceful degradation that hides broken dependencies
+- [ ] If this fails, will the user / operator know immediately?
+- [ ] Errors are unmistakable
+
+**6. Cross-Boundary Contract Audit — Architectural**
+
+> Deep cross-system reasoning. Every value that crosses a boundary (code↔DB, code↔config, caller↔callee, backend↔frontend) must have its contract verified.
+
+**SQL / Schema Architecture**
+- [ ] All SQL in the diff audited against DB schema (migrations/) — column names, types, table existence verified
+- [ ] No query references a column that was renamed, removed, or never added in any migration
+- [ ] SQL literal values (strings in WHERE) cross-referenced against actual DB data — check for normalisation mismatches
+
+**Null Propagation Architecture**
+- [ ] Null propagation audit: identify all values that can be None (DB results, API responses, optional config) and trace to consumption points — all arithmetic / method-call / formatting sites guarded?
+- [ ] Frontend data contract: for each API response field displayed in UI, verify null / undefined handled at display layer
+- [ ] Type annotations match reality: if annotation says `float`, verify NO caller can pass `None`. If they can → annotation must be `float | None` and function must guard.
+
+**Config Architecture (Bidirectional)**
+- [ ] Bidirectional config audit: (1) code has no hardcoded values → config exists; (2) config has no orphaned keys → code consumes them
+- [ ] Any config section added for a new feature: verify the feature's code reads EVERY key in that section
+
+**Lifecycle Wiring Architecture**
+- [ ] Lifecycle wiring audit: for each recovery / drain / replay function, map ALL lifecycle events where data could accumulate, confirm function wired to every one
+- [ ] "Called at reconnect" does NOT imply "called at startup" — verify separately
+- [ ] Scope completeness: enumerate every Acceptance Criteria checkbox from issue body — each must map to a specific file:line. Any without = NOT DONE.
+
+**Data Correction Architecture**
+- [ ] If bug produced bad DB state: fix includes BOTH (a) code fix for future AND (b) verified data repair for existing rows — confirm both exist and repair scope matches bug scope
+
+**7. Factual Claims Audit**
+- [ ] Enumerate all numeric assertions in documentation, issue body, and design rationale added by this implementation
+- [ ] For each: does a verifiable source exist (benchmark, prior issue, measured observation, command output)?
+- [ ] If no source: flag as unverified claim — must be sourced or removed before OPUS_PASS
+
+### Required when available: Code Graph Checks (Architectural Depth)
+
+**Documentation-only PR exemption**: if the diff touches ONLY Markdown / YAML / JSON / TOML / shell, skip this section. Document `[GRAPH: skipped — doc-only PR]` in RESULT and return PASS.
+
+Preconditions: a code-review-graph MCP server is available, graph fresh. If either fails, skip to fallback clause below.
+
+- [ ] Dead code detection: `graph query large_functions(min_lines=200)` + manual orphan scan. For each candidate: `graph query callers_of(<name>)` returns empty in the same module ⇒ orphan. Subagent confirms whether call is via reflection / dynamic dispatch (not an orphan) or a true orphan (cleanup target).
+- [ ] Impact scope validation: `graph query impact(changed_files, max_depth=2)` — enumerate all impacted modules; identify unexpected cross-boundary edges. Document each boundary: intended (defence-in-depth / architectural layering) vs emergent (refactor target).
+- [ ] Large functions audit: confirm no function in the diff exceeded 200 lines. If any did, architectural red flag — require refactor.
+- [ ] Full graph-tool discipline: any "no results" response from graph in an area with unsupported-language files (YAML, JSON, SQL, shell) is explicitly broadened to subagent exploration before drawing a negative conclusion; graph `last_updated` timestamp recorded in RESULT.
+
+**Fallback clause** (retry-aware, evidence-required): first graph call fails → retry once. Second fails → RESULT MUST include the Explore-subagent's RESULT block demonstrating manual architectural audit (dead code + impact + large functions) was actually executed. Documenting only `[graph unavailable]` without subagent RESULT = silent skip = FAIL.
+
+### Overengineering Check
+- [ ] Is there a simpler solution that works?
+- [ ] No premature abstractions
+- [ ] No unnecessary complexity
+- [ ] JBGE (Just Barely Good Enough) applied
+
+### Pre-Merge Precondition Check (NOT the post-merge user review)
+
+> **CRITICAL**: This tier runs BEFORE merge. The items below are pre-merge preconditions. They are NOT the user review itself — that happens after merge.
+
+- [ ] All Expected Behavior items verified
+- [ ] All Acceptance Criteria items verified
+- [ ] Engineering Requirements met
+- [ ] Cleanup Requirements completed
+
+### Final Verification
+- [ ] All commits pushed to remote
+- [ ] Branch up to date with main (verified by reading `git log origin/main..HEAD` — do NOT run `git fetch` from this PLANNING-mode review)
+- [ ] No merge conflicts (verified via `git merge-tree` or main-agent diff inspection)
+- [ ] Ready for merge + post-merge user review
+
+### Bash Output Discipline
+- [ ] If you ran any bash command producing > 200 lines: capture to a file, report only the path + verdict in RESULT. Do NOT paste the full output back to the main agent.
+
+## Pass Criteria
+
+All checkboxes verified with evidence. Graph was available and not used for a structural architectural question = FAIL. If doc-only PR exempted via the short-circuit: PASS. Unavailable / stale / unsupported-language WITH subagent RESULT block showing manual architectural audit was performed: PASS. Architectural review without structural evidence (graph-backed OR subagent-backed with RESULT block) is incomplete and fails.
+
+## On Pass
+
+Output: `<promise>OPUS_PASS</promise>`
+
+## On Fail
+
+1. List architectural concern with specific file:line
+2. Explain why it violates standards
+3. Suggest a specific fix
+4. Do NOT output the promise
+5. Ralph loop restarts from Tier 1 after fixes

--- a/plugins/ralph-review-trio/agents/sonnet-reviewer.md
+++ b/plugins/ralph-review-trio/agents/sonnet-reviewer.md
@@ -1,0 +1,162 @@
+---
+name: sonnet-reviewer
+description: Tier 2 (logic) Ralph Review. Dispatched by the /ralph-review command after Tier 1 passes. Runs medium-depth logic validation — evidence quality, scope alignment, fail-fast, observability, cross-boundary contracts. Never writes code.
+model: sonnet
+---
+
+# Tier 2: Sonnet Review (Logic Checks)
+
+> **PLANNING MODE ONLY**: You are a REVIEWER. Do NOT write code, do NOT edit files, do NOT make commits. Your ONLY job is to verify and report findings.
+
+Medium-depth validation. Catches the issues that surface review misses.
+
+**Completion Promise**: `<promise>SONNET_PASS</promise>`
+
+## Checklist
+
+### Evidence Quality
+- [ ] Evidence proves completion (not just claims)
+- [ ] Evidence matches actual work done
+- [ ] Evidence is verifiable (file paths, commits, outputs)
+- [ ] No "completed" checkboxes without evidence
+- [ ] Any quantified claim (counts, ratios, durations, capacities) in documentation or issue body: source identified (command, reference, or calculation). "Seems reasonable" is not a source.
+- [ ] No numbers copied from other documents without re-verification against current state
+
+### Scope Alignment
+- [ ] **PREREQUISITE**: Read the full Issue body line-by-line BEFORE this section. Don't skim. Don't trust prior summaries. The Issue body is the source of truth for scope.
+- [ ] Implementation matches Issue scope exactly
+- [ ] No scope drift (adding unrequested features)
+- [ ] No scope shortfall (missing requested features)
+- [ ] All phases completed per Acceptance Criteria
+
+### Governance — Checkbox coverage gate
+- [ ] If the project uses a governance MCP server for checkboxes (e.g. `github-checkbox`): run `get_issue_checkboxes` on the issue and cross-reference against phase completions. **Any phase-complete-but-checkbox-unchecked state = FAIL** — narrative-only progress is not a substitute.
+- [ ] If no governance MCP is available: verify issue-body checkboxes are closed with explicit evidence lines (file:line / commit hash / command output).
+
+### Fail Fast Policy
+- [ ] No silent fallbacks (errors fail loudly)
+- [ ] No fake defaults (missing required config = error, not default)
+- [ ] No swallowed exceptions
+- [ ] Error messages are actionable
+
+### Observability
+- [ ] Every decision boundary has a structured log (key=value or JSON, not free-text prose)
+- [ ] Every state transition logs before / after values and trigger
+- [ ] Every external call (DB / API / file / subprocess) logs inputs, duration, outcome
+- [ ] Quantifiable behaviour has metrics (counters, durations, success / failure ratios)
+- [ ] State changes touching production data / money / user-visible behaviour have an append-only audit trail (actor + timestamp + reason)
+- [ ] No `print()` as logging strategy (use a structured logger)
+- [ ] No empty `except:` blocks, bare `pass` on exception, silent `return None` on error, or `continue` on unexpected state
+- [ ] Logs are searchable (consistent field names, no log-and-pray)
+
+### Code Reuse
+- [ ] Searched the codebase before creating new modules (Glob / Grep / Explore) — **evidence required**: name 2-3 grep patterns or Glob queries actually run, with results count
+- [ ] No duplicate modules created
+- [ ] References existing modules where applicable
+
+### Codebase Hygiene
+- [ ] No dead code (unreachable, never-called functions)
+- [ ] No obsolete code (deprecated, superseded by new implementation)
+- [ ] No orphaned code (from failed / rescoped approaches)
+- [ ] No commented-out "old" code blocks
+- [ ] No unused imports / dependencies
+- [ ] No leftover temp / WIP patterns
+
+### Standards — Five Common Culprits (Logic)
+
+> Trace code paths for the five recurring patterns. Category names canonical in `references/_common-culprits.md`.
+
+**1. Duplicate Code (DRY / Modularity)**
+- [ ] No same calculation logic in multiple files
+- [ ] No repeated parsing / formatting patterns
+- [ ] Could this be extracted to a shared utility?
+
+**2. On-the-fly Calculations (Hardcoded Settings)**
+- [ ] No inline math that depends on business rules (e.g. `price * 1.1` for markup)
+- [ ] No date / time calculations with hardcoded offsets
+- [ ] Should this formula be in a config file?
+
+**3. Hardcoded Settings**
+- [ ] No multipliers, percentages, thresholds in code
+- [ ] No retry counts, timeout values, buffer sizes
+- [ ] Is there a co-located YAML config this should be in?
+
+**4. Obsolete / Dead Code (LMCE)**
+- [ ] No functions that are never called (trace the call graph)
+- [ ] No imports that are never used
+- [ ] No feature flags for completed / removed features
+
+**5. Silent Fallbacks (Fail Fast)**
+- [ ] No `.get(key, {})` chains that hide missing data
+- [ ] No `try / except: pass` or `catch(e) { }` empty handlers
+- [ ] No `or default` that masks configuration errors
+- [ ] Does the error path fail loudly with an actionable message?
+
+**6. Cross-Boundary Contracts — Trace-Level**
+
+> Logic-depth checks requiring cross-file tracing. These catch the bugs that syntactic scans miss.
+
+**SQL / Schema Contracts**
+- [ ] For every new / modified SQL query: list columns in WHERE / SELECT, open the migration for that table, confirm all columns exist
+- [ ] Trace SQL query return values — if a query returns None / empty, verify the WHERE literal values match actual DB data (e.g. `side='SELL'` not `side='SLD'` if DB normalises on insert)
+- [ ] Any query driving control flow (`if result:` / `if not result:`) has its column values cross-checked against DB schema
+
+**Null / None Propagation**
+- [ ] For functions with nullable parameters (`Optional[T]` or `T | None`): trace every call site — are callers guaranteed non-None, or must the function guard internally?
+- [ ] Any function called at 2+ locations with a nullable input: verify the guard exists IN the function, not assumed from callers
+- [ ] Frontend null-safety: trace API fields that can be null through to display / formatting — every `.toFixed()` on a nullable must have a null check
+
+**Config Wiring (Bidirectional)**
+- [ ] For every new YAML / config key: verify it is read by application code (grep key name → `config.get('key')` or `config['key']`)
+- [ ] Config keys with zero code references = dead config = LMCE violation. Remove or wire.
+
+**Lifecycle Wiring**
+- [ ] For each recovery / drain / replay function: list ALL lifecycle entry points (startup, reconnect, restart) and verify it is called at EACH one
+- [ ] "Called at reconnect" does NOT imply "called at startup" — verify separately
+
+**Data Correction Completeness**
+- [ ] For bugs that corrupt / mis-set data: verify a repair step exists covering ALL existing affected rows, not just future ones
+- [ ] Run a count query to confirm zero remaining bad rows after repair
+
+**Cross-Function Behavioural Contracts**
+- [ ] For every `try / except` in the diff: open the wrapped function and confirm it has a reachable `raise` path. If it returns sentinel values (None, False), the `try / except` is dead code.
+- [ ] Hot paths (fill handlers, order processors): count DB round-trips — flag any path querying the same row more than once
+
+### Bash Output Discipline
+- [ ] If you ran any bash command producing > 200 lines: capture output to a file, report only the path + verdict in RESULT. Do NOT paste the full output back to the main agent.
+
+### Sample Invocation Gate (workflow validation)
+
+Unit + smoke tests are necessary but NOT sufficient for pipeline / backtest / orchestration / CLI-wiring / cross-module function-arg propagation / persistent-state-write changes.
+
+- [ ] **Scope check**: does this change touch any of the above? If **yes** → the next checkbox is mandatory. If **no** → document the scope-skip reason here.
+- [ ] If in-scope: evidence of a REAL-CLI sample invocation exists — either a log file path, or an Issue comment with exit code + DB row-count + downstream-consumer verification. Exit code 0 alone is NOT sufficient.
+- [ ] If in-scope: any mock used in the fix's tests uses explicit `call_args.kwargs["<key>"] == <expected>` assertions — NOT a `**kwargs`-swallowing mock that would pass regardless of whether the code actually propagated the arg.
+
+### Required when available: Code Graph Checks
+
+**Documentation-only PR exemption**: if the diff touches ONLY Markdown / YAML / JSON / TOML / shell, skip this section entirely. Document `[GRAPH: skipped — doc-only PR]` in RESULT and return PASS on graph checks.
+
+Preconditions: a code-review-graph MCP server is available, graph fresh. If either fails, skip to the fallback clause below.
+
+- [ ] For each modified function: `graph query callers_of(<function_name>)` → list all call sites; verify each handles the changed signature / behaviour.
+- [ ] For each modified function: `graph query callees_of(<function_name>)` → confirm no newly-called functions have incompatible contracts (null-safety, config access).
+- [ ] `graph query search(pattern)` for duplicate implementations: search for new calculation / parsing / schema-handling logic — confirm it doesn't already exist.
+- [ ] **MCP-access discrimination**: every subagent RESULT block discussing graph queries starts with `mcp_graph_available: yes|no`. Yes + no graph-query evidence = FAIL (lazy fallback). No + grep fallback = PASS.
+
+**Fallback clause** (retry-aware, evidence-required): if first graph call fails, retry once. If second fails, the RESULT block MUST include the Explore-subagent's RESULT block demonstrating manual call-graph audit was actually executed. Documenting only `[graph unavailable]` without subagent RESULT = silent skip = FAIL.
+
+## Pass Criteria
+
+All checkboxes verified with evidence (graph-backed + source spot-check, OR documented fallback + subagent RESULT block). If graph was available and not used for a structural question: FAIL. If doc-only PR exempted via the short-circuit above: PASS. If unavailable / stale / unsupported-language WITH subagent-backed fallback evidence: PASS.
+
+## On Pass
+
+Output: `<promise>SONNET_PASS</promise>`
+
+## On Fail
+
+1. List failed items with evidence of failure.
+2. Specify which Fail Fast / Registry violation was found.
+3. Do NOT output the promise.
+4. Ralph loop restarts from Tier 1.

--- a/plugins/ralph-review-trio/commands/ralph-review.md
+++ b/plugins/ralph-review-trio/commands/ralph-review.md
@@ -1,0 +1,56 @@
+---
+description: Run the three-tier Ralph Review sequence (Haiku → Sonnet → Opus) on the current branch. Restarts from Tier 1 on any tier failure.
+---
+
+# Ralph Review
+
+Run a sequential three-tier code review on the current feature / solo branch. Each tier dispatches a reviewer subagent that runs its own checklist at increasing depth. If any tier fails, fix the findings and restart from Tier 1.
+
+## Agent dispatch — namespacing matters
+
+Claude Code registers plugin-bundled agents under the `<plugin-name>:<agent-name>` namespace. Dispatching a bare `haiku-reviewer` will fail with `Agent type 'haiku-reviewer' not found`. Always dispatch with the full plugin prefix:
+
+- `ralph-review-trio:haiku-reviewer`
+- `ralph-review-trio:sonnet-reviewer`
+- `ralph-review-trio:opus-reviewer`
+
+## Controller logic
+
+1. **Tier 1 — Haiku** (surface). Dispatch the `ralph-review-trio:haiku-reviewer` subagent with the diff scope and pass criteria. Wait for `<promise>HAIKU_PASS</promise>` or a failure report.
+2. **On FAIL**: main agent applies fixes, commits per-file, then restarts from Tier 1. Do NOT proceed to Tier 2 with a flag.
+3. **On PASS**: proceed to Tier 2.
+4. **Tier 2 — Sonnet** (logic). Dispatch `ralph-review-trio:sonnet-reviewer`. Same pass / fail logic.
+5. **Tier 3 — Opus** (deep analysis). Dispatch `ralph-review-trio:opus-reviewer`. Same pass / fail logic.
+6. On all three passes: emit `<promise>RALPH_PASS</promise>` and proceed to merge gate.
+
+## Why restart-on-fail (not continue-with-flag)
+
+Bugs caught by a later tier often invalidate earlier-tier findings. The surface-check pass on commit hygiene is meaningless if the deeper review surfaces a removed-and-re-added file. A fail at any tier says "go back and re-verify everything" — not "note the problem and keep going".
+
+## Inputs
+
+- Current git branch + diff against main (or the project's default branch).
+- Issue number (if a solo branch named `solo/issue-NNN-...`).
+- Expected Behavior / Acceptance Criteria from the issue body (if available).
+
+## RESULT block schema (required from every tier)
+
+```
+## RESULT
+mcp_graph_available: yes|no      # first line when discussing graph queries
+verdict: pass|fail|unknown
+files_touched: [paths]
+findings: [{path, line, claim, evidence}]
+scope_gaps: [list or "none"]
+```
+
+The main agent parses the RESULT block. Prose body is informational only.
+
+## Bash output discipline
+
+Any command a reviewer runs that produces > 200 lines (pytest, git diff, log tail): capture to a file, report only the path + verdict in the RESULT block. Do not paste full output back to the main agent.
+
+## Output
+
+- On PASS: `<promise>RALPH_PASS</promise>` + summary of all three tiers' RESULT blocks.
+- On FAIL (after all retries): the failing tier's RESULT block + main-agent-proposed fix list. No PASS promise emitted.

--- a/plugins/ralph-review-trio/skills/ralph-review-trio/SKILL.md
+++ b/plugins/ralph-review-trio/skills/ralph-review-trio/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: ralph-review-trio
+description: Run a sequential three-tier code review on a finished implementation branch — Haiku (surface) → Sonnet (logic) → Opus (deep). Restarts from Tier 1 on any tier failure. Use when a solo branch or PR is code-complete and you want structured pre-merge verification before human review.
+---
+
+# Ralph Review Trio
+
+This skill triggers `/ralph-review`, which runs three sequential reviewer subagents at increasing depth. If any tier flags a failure, the loop restarts from Tier 1 after fixes.
+
+## When to trigger
+
+- An implementation is code-complete on a feature / solo branch.
+- All acceptance criteria for the underlying issue are believed satisfied.
+- Pre-merge verification is needed before human review or merge-to-main.
+- You want structured evidence that each tier's checklist was walked.
+
+## When NOT to trigger
+
+- Work-in-progress branches mid-implementation — Ralph assumes the change is complete.
+- Documentation-only diffs with no code — Tier 2/3 still run but most checks short-circuit to "doc-only PR" exemption; overkill for a single README edit.
+- Hotfix branches where speed dominates verification — use the project's normal PR review.
+
+## How it works
+
+```
+/ralph-review
+    │
+    ▼
+  Tier 1  — Haiku  (surface checks)   ─── fail ──> restart
+    │  pass
+    ▼
+  Tier 2  — Sonnet (logic checks)     ─── fail ──> restart
+    │  pass
+    ▼
+  Tier 3  — Opus   (deep analysis)    ─── fail ──> restart
+    │  pass
+    ▼
+  RALPH_PASS  →  merge OK
+```
+
+A `<promise>HAIKU_PASS</promise>` / `<promise>SONNET_PASS</promise>` / `<promise>OPUS_PASS</promise>` token is emitted by each tier on pass. All three required for overall pass.
+
+## Entry point
+
+`/ralph-review` — defined in `../../commands/ralph-review.md`.
+
+## Per-tier checklists
+
+- `../../agents/haiku-reviewer.md` — Tier 1 surface checklist
+- `../../agents/sonnet-reviewer.md` — Tier 2 logic checklist
+- `../../agents/opus-reviewer.md` — Tier 3 deep-analysis checklist
+
+Extended reference content under `references/` (same dir as this SKILL.md) is loaded on demand by each tier when a specific check requires more context.
+
+## Outputs
+
+Each tier writes a fenced `## RESULT` block with:
+
+```
+## RESULT
+mcp_graph_available: yes|no      # first line when discussing graph queries
+verdict: pass|fail|unknown
+files_touched: [paths]
+findings: [{path, line, claim, evidence}]
+scope_gaps: [list or "none"]
+```
+
+The main agent reads the RESULT block and decides next action (restart, next tier, or PASS).

--- a/plugins/ralph-review-trio/skills/ralph-review-trio/assets/example-transcript.md
+++ b/plugins/ralph-review-trio/skills/ralph-review-trio/assets/example-transcript.md
@@ -1,0 +1,154 @@
+# Example Ralph Review transcript
+
+A scrubbed example of a Ralph Review pass over a small Python feature — adding a retry wrapper around an HTTP client. Branch: `solo/issue-42-http-retry`. Issue: "Add configurable retries to the OrderClient HTTP calls".
+
+The three tiers ran in sequence with the controller `/ralph-review` command. Output below is condensed — real transcripts are longer.
+
+---
+
+## User invocation
+
+```
+> /ralph-review
+```
+
+## Controller — Tier 1 dispatch
+
+Main agent dispatches `haiku-reviewer` against the current branch diff.
+
+## Tier 1 — Haiku RESULT
+
+```
+## RESULT
+mcp_graph_available: yes
+verdict: fail
+files_touched:
+  - src/clients/order_client.py
+  - src/clients/retry.py
+  - tests/test_retry.py
+findings:
+  - path: src/clients/retry.py
+    line: 34
+    claim: debug print statement left in
+    evidence: "print(f'retrying {attempt} of {max_retries}')"
+  - path: src/clients/order_client.py
+    line: 78
+    claim: magic number in code (max_retries=3)
+    evidence: "self._retry_wrapper(max_retries=3) — should be in config"
+scope_gaps: none
+```
+
+Main agent applies fixes:
+- Remove the `print()` (commit `a3f12e9`)
+- Move `max_retries=3` to `config/clients.yaml` under `order_client.max_retries`, read via `config.get('order_client.max_retries')` (commit `b84c5d1`)
+- Run tests, all pass.
+
+**Loop restarts from Tier 1** (restart-on-fail, not continue-with-flag).
+
+## Tier 1 — Haiku RESULT (2nd iteration)
+
+```
+## RESULT
+mcp_graph_available: yes
+verdict: pass
+files_touched:
+  - src/clients/order_client.py
+  - src/clients/retry.py
+  - tests/test_retry.py
+  - config/clients.yaml
+findings: []
+scope_gaps: none
+```
+
+`<promise>HAIKU_PASS</promise>`
+
+## Tier 2 — Sonnet RESULT
+
+```
+## RESULT
+mcp_graph_available: yes
+verdict: fail
+files_touched:
+  - src/clients/order_client.py
+  - src/clients/retry.py
+findings:
+  - path: src/clients/retry.py
+    line: 22
+    claim: exception swallowed without logging
+    evidence: "except requests.RequestException: pass  # silent fallback — no log, no metric"
+  - path: tests/test_retry.py
+    line: 51
+    claim: mock accepts **kwargs — does not prove propagation
+    evidence: "mock_call.assert_called()  # should be assert_called_with(max_retries=3)"
+scope_gaps: none
+```
+
+Main agent applies fixes:
+- Replace the silent `except` with a structured log + a `retries_exhausted` counter metric (commit `c19f7a2`)
+- Update test to `assert mock_call.call_args.kwargs['max_retries'] == 3` (commit `d55b908`)
+- Run full test suite.
+
+**Loop restarts from Tier 1**.
+
+## Tier 1 — Haiku RESULT (3rd iteration)
+
+```
+verdict: pass
+findings: []
+```
+
+`<promise>HAIKU_PASS</promise>`
+
+## Tier 2 — Sonnet RESULT (2nd iteration)
+
+```
+verdict: pass
+findings: []
+```
+
+`<promise>SONNET_PASS</promise>`
+
+## Tier 3 — Opus RESULT
+
+```
+## RESULT
+mcp_graph_available: yes
+verdict: pass
+files_touched:
+  - src/clients/order_client.py
+  - src/clients/retry.py
+  - tests/test_retry.py
+  - config/clients.yaml
+findings: []
+scope_gaps: none
+governance_drift: none_detected
+  - Tier A box "Add retry wrapper" closed at commit b84c5d1 — interleaves with phase 1 commits
+  - Tier A box "Move max_retries to config" closed at commit b84c5d1 — same phase window
+  - Tier B box "Fix Everything applied" closed at end — acceptable
+spot_check:
+  - graph_result: callers_of(_retry_wrapper) returned 1 caller
+  - source_read: src/clients/order_client.py:78 — confirmed single call site
+factual_claims: none added in this diff
+```
+
+`<promise>OPUS_PASS</promise>`
+
+## Controller — final output
+
+```
+<promise>RALPH_PASS</promise>
+
+Three tiers passed. Two restart cycles (Tier 1 × 2 iterations, Tier 2 × 1 iteration).
+Total findings fixed: 4.
+Branch ready for merge.
+```
+
+---
+
+## What this transcript demonstrates
+
+- **Restart-on-fail**: Tier 2 found issues after Tier 1 already passed. Loop went back to Tier 1, not to "Tier 3 with a flag".
+- **Cross-boundary contract**: the `**kwargs`-swallowing mock was caught at Tier 2 — surface tier doesn't trace call-args assertions.
+- **Governance cadence**: Opus tier classified the three checkbox closures correctly (two Tier A interleaved, one Tier B batched).
+- **Graph spot-check**: Opus used graph to list callers, then read the source to confirm — never trusted the graph alone.
+- **Silent fallback caught late**: the swallowed exception was invisible at surface; Tier 2 traced the exception path to find it.

--- a/plugins/ralph-review-trio/skills/ralph-review-trio/references/_common-culprits.md
+++ b/plugins/ralph-review-trio/skills/ralph-review-trio/references/_common-culprits.md
@@ -1,0 +1,25 @@
+# Ralph Review — Shared 5-Culprits Reference
+
+> **Architectural design**: Each Ralph tier scans for the same five patterns at *increasing depth*. The depth-layering is intentional. This file holds the shared framing so the category numbers and names stay in sync; each tier file keeps its own depth-appropriate bullets.
+
+## The 5 Categories
+
+Each tier checks these patterns. Bullets in the per-tier files differ by depth, not by category.
+
+| # | Category | Surface (Haiku) | Logic (Sonnet) | Architectural (Opus) |
+|---|---|---|---|---|
+| 1 | Duplicate Code (DRY / Modularity) | Visible copy-paste | Same logic in N files | Same pattern implemented differently |
+| 2 | On-the-fly Calculations (Hardcoded Settings) | Magic numbers in calculations | Inline business formulas | Calculation constants varying by env |
+| 3 | Hardcoded Settings | Embedded URLs / paths / credentials | Multipliers, percentages, timeouts | User-configurable values in code |
+| 4 | Obsolete / Dead Code (LMCE) | Commented-out blocks, dead TODOs | Never-called functions, unused imports | Modules never instantiated, dead endpoints |
+| 5 | Silent Fallbacks (Fail Fast) | `catch{}` swallow, `\|\| default` | `.get(k, {})` chains, `try / except: pass` | Cascading defaults masking root cause |
+
+## Tier Files
+
+- `haiku-checklist.md` — surface checks
+- `sonnet-checklist.md` — logic-trace checks
+- `opus-checklist.md` — architectural checks
+
+## Rule
+
+Tier-specific bullet content lives in the tier files. The category numbers / names live here — change them once, propagate by re-reading.

--- a/plugins/ralph-review-trio/skills/ralph-review-trio/references/haiku-checklist.md
+++ b/plugins/ralph-review-trio/skills/ralph-review-trio/references/haiku-checklist.md
@@ -1,0 +1,47 @@
+# Haiku Tier — Surface Checklist (extended reference)
+
+This is the extended reference the Tier 1 (Haiku) agent loads when a surface check needs more context than the inline agent definition provides. For the canonical flow + RESULT block schema, see `../../../agents/haiku-reviewer.md`.
+
+## Scope
+
+Surface review sits at the first line of defence. It catches:
+
+- Missing / mis-named files
+- Narrative-only "evidence"
+- Debug code left in the diff
+- Obvious copy-paste, obvious magic numbers, obvious silent-fallback patterns
+- Cross-boundary issues that are visible at the diff level (wrong column name in a WHERE, `.toFixed()` on a nullable)
+
+It does NOT trace call graphs, does NOT cross-verify config bidirectionally, does NOT audit architectural fit. Those belong in later tiers.
+
+## What counts as "evidence"
+
+For a `[x]` box to pass at the surface tier, the evidence must be at least one of:
+
+- **file:line** — a concrete pointer a reviewer can open and read
+- **commit hash** — a hash visible in `git log` of the branch
+- **command + output** — a reproducible command with captured output (tee log path is fine)
+- **subagent RESULT comment-id** — a comment number referencing a fenced `## RESULT` block
+
+Narrative-only evidence ("implemented the feature") is a fail.
+
+## Common false positives
+
+- **Intentional duplication for defence-in-depth**: a value validated at the API layer AND at the DB layer is not a DRY violation — it's a designed belt-and-braces. Flag for the subagent to confirm intent before marking as a finding.
+- **Argparse defaults for optional tunables**: `parser.add_argument("--retries", default=3)` is not a "silent fallback" — the argument is optional by contract. Only flag `default=` patterns that hide REQUIRED config.
+- **Sentinel values that are the contract**: `return None` from a "not found" function is not a silent failure — it's the advertised return contract. Flag only when the caller can't distinguish the sentinel from a valid value.
+
+## Bash output discipline
+
+- Wrap any command expected to produce > 200 lines in a tee-style capture. Report only the path + verdict in RESULT.
+- Do NOT paste `pytest -v` output, `git diff` of 50+ files, or unfiltered log tails back to the main agent.
+
+## Graph fallback
+
+When the code-review-graph MCP is unavailable or the project uses unsupported languages (Markdown, YAML, JSON, SQL, TOML, shell), do NOT silently skip the graph-backed checks. Instead:
+
+1. Retry once after a short delay.
+2. If still unavailable, fall back to an Explore-style subagent that performs the equivalent manual audit (callers, callees, large functions).
+3. Include the subagent's RESULT block in your own RESULT as `[graph unavailable: <reason>] [subagent fallback: <id>]`.
+
+A bare `[graph unavailable]` with no subagent evidence = silent skip = FAIL.

--- a/plugins/ralph-review-trio/skills/ralph-review-trio/references/opus-checklist.md
+++ b/plugins/ralph-review-trio/skills/ralph-review-trio/references/opus-checklist.md
@@ -1,0 +1,70 @@
+# Opus Tier — Deep Analysis Checklist (extended reference)
+
+This is the extended reference the Tier 3 (Opus) agent loads when a deep check needs more context than the inline agent definition. For the canonical flow + RESULT block schema, see `../../../agents/opus-reviewer.md`.
+
+## Scope
+
+Opus is the architectural pass. It catches:
+
+- Architectural misfit (new module violates the layering pattern in use)
+- Governance drift (Tier A checkbox batching against commit cadence)
+- Null propagation across the full codebase (not just the diff)
+- Factual claims without provenance in documentation
+- Overengineering (premature abstractions, unnecessary complexity)
+- Dead code at the module / endpoint / migration level
+
+## Governance drift — two-tier cadence rule
+
+When auditing checkbox close-out cadence, classify every `[x]` box into one of two tiers BEFORE judging:
+
+**Tier A — Phase-deliverable checkboxes**: items in Acceptance Criteria Phases 1..N that describe a concrete deliverable (a file edit, commit, function, section, table, example). STRICT interleaving required — Proof of Work entry order MUST interleave with git-log commit order within the same phase's commit window.
+
+**Tier B — Cross-cutting meta-checkboxes**: Triple-Check Gate items, Engineering Requirements meta-items like "Fix Everything", Cleanup Requirements, Verification Loop self-gates, PREREQUISITE CHECKPOINT, Expected Behavior post-condition items. Batched-at-end is acceptable because these describe conditions observable ONLY after all phases complete. Closing them mid-phase would be dishonest.
+
+**Classification heuristic**: if the checkbox text names a specific file / commit / section / function / table to build or change, it is **Tier A**. If it describes a cross-cutting condition requiring the WHOLE implementation to evaluate, it is **Tier B**. When in doubt, inspect the checkbox's section in the issue template: Acceptance Criteria sub-phases = Tier A; Triple-Check Gate / Engineering Requirements meta / Cleanup Requirements / Verification Loop self-gates / PREREQUISITE CHECKPOINT / Expected Behavior = Tier B.
+
+**Rule**:
+
+- Flag Tier A batching as governance drift.
+- Do NOT flag Tier B batching as drift.
+
+A Tier-B-only batch is acceptable and expected.
+
+## Governance evidence signal (canonical)
+
+The canonical audit signal for verifying that checkbox-close invocations actually happened is the `## Proof of Work` section in the issue body — NOT the GitHub timeline `edited` events.
+
+Why: GitHub's timeline API does not emit `edited` events for an issue author's own body edits on their own issue. Since solo-workflow agents ARE the issue author in almost all cases, timeline-based audits false-negative every honored invocation. The body content itself, however, is always externally readable.
+
+Verification procedure:
+
+1. Fetch the issue body via the project's governance MCP tool, or a plain GitHub API call.
+2. Parse the `## Proof of Work` section. Each entry starts with `- **<checkbox text>**: <evidence>`.
+3. For every `[x]` box in the body, there MUST be a matching entry in Proof of Work. Missing entry = drift.
+4. For each entry, spot-check the cited evidence:
+   - file:line claims → open the file on the branch
+   - commit hashes → `git show <hash>`
+   - subagent RESULT blocks → fetch the cited comment
+   - command output → reproducible via the same command
+
+Ordering of Proof of Work entries is authoritative — the section appends in invocation order. Cross-reference the entry order against `git log --oneline` to confirm Tier A items closed within the same phase's commit window.
+
+## Factual claims audit
+
+Every numeric assertion added by the implementation (counts, ratios, durations, capacities, percentages) must have a verifiable source:
+
+- **Reproducible command** (e.g. `git log --oneline | wc -l` → "10,385 commits")
+- **API query** (e.g. `gh issue list --state all` → "1,309 issues")
+- **Code reference** (e.g. `grep -c "def test_" tests/` → "N test functions")
+- **Calculation** (e.g. `(total - open) / total = 99.4% close rate`)
+
+"Seems reasonable" is not a source. If the number cannot be reproduced, it must be sourced or removed before OPUS_PASS.
+
+## Bash output discipline
+
+- Any command producing > 200 lines → capture to file, report path + verdict in RESULT.
+- Do NOT paste full pytest output, unfiltered git diffs, or log tails back to the main agent.
+
+## When graph is unavailable
+
+Opus tier has the deepest graph requirements — dead-code detection via `large_functions` + orphan scan, impact scope validation via `impact(max_depth=2)`, large-function audit. When graph is unavailable or unsupported-language, an Explore-style subagent MUST perform the equivalent manual architectural audit and the RESULT must include the subagent's RESULT block. Documenting only `[graph unavailable]` = silent skip = FAIL.

--- a/plugins/ralph-review-trio/skills/ralph-review-trio/references/sonnet-checklist.md
+++ b/plugins/ralph-review-trio/skills/ralph-review-trio/references/sonnet-checklist.md
@@ -1,0 +1,60 @@
+# Sonnet Tier — Logic Checklist (extended reference)
+
+This is the extended reference the Tier 2 (Sonnet) agent loads when a logic check needs more context than the inline agent definition. For the canonical flow + RESULT block schema, see `../../../agents/sonnet-reviewer.md`.
+
+## Scope
+
+Logic review is where the cross-file tracing happens. Tier 1 scans each file; Tier 2 traces paths between files. It catches:
+
+- Scope drift (feature added that wasn't in the issue)
+- Scope shortfall (feature in the issue not yet implemented)
+- Type contracts that silently break (annotated `float`, caller passes `None`)
+- Schema contracts that silently break (WHERE literal doesn't match stored data)
+- Config contracts that silently break (YAML key never read, code read key that doesn't exist in YAML)
+- Lifecycle wiring gaps (drain function called at reconnect but not startup)
+- Dead `try / except` blocks that wrap functions that can't raise
+
+## Cross-Boundary Contract discipline
+
+Every value that crosses a boundary must have its contract verified. The three canonical boundaries are:
+
+1. **Type Contract** — every function parameter with a non-Optional annotation must have all call sites verified non-None. If any caller can pass `None`, annotation must be `T | None` and the function must guard.
+2. **Schema Contract** — every SQL query's columns must exist in the target table. Every SQL literal in WHERE must match the actual data stored (e.g., DB normalises `'SLD'` → `'SELL'` on insert — querying `side='SLD'` returns zero rows silently).
+3. **Config Contract** — bidirectional. Every key added to YAML must be read by code. Every key read by code must exist in YAML. Dead either direction = incomplete implementation.
+
+## Sample Invocation Gate — when it applies
+
+For changes that touch any of:
+
+- Pipeline / backtest / orchestration wiring
+- CLI flag threading into downstream function signatures
+- Cross-module function-arg propagation (>1 hop from CLI to DB / file write)
+- Persistent-state writes (JSONB schema mutation, SQL literal drift across SET / READ sites, DB column rename, enum-value drift)
+
+Unit + smoke tests are necessary but NOT sufficient. A REAL-CLI sample invocation against real DB is required. Exit-code-0 alone is insufficient — we have history of exit-0 runs writing zero rows. The proof must show rows landed + downstream consumers succeeded.
+
+Mocks that accept `**kwargs` silently discard params and do NOT prove propagation. Any mock in the fix's tests must assert `call_args.kwargs["<key>"] == <expected>` explicitly.
+
+## Observability discipline
+
+Every new component must emit:
+
+1. **Structured logs** at every decision boundary, state transition, and external call
+2. **Metrics** for anything quantifiable — counters, durations, queue depths, success / failure ratios
+3. **Audit trail** for state changes affecting production data, money, or user-visible behaviour — append-only, with actor + timestamp + reason
+
+`print()` is not logging. Empty `except:` blocks are not error handling. `return None` on error without a structured log is a silent fallback.
+
+## Graph discipline — lazy-fallback detection
+
+Every subagent RESULT block that discusses graph queries must start with `mcp_graph_available: yes|no` on the first line. This discriminates:
+
+- `yes` + graph-query evidence lines = expected
+- `no` + grep fallback evidence = acceptable (no MCP access)
+- `yes` + no graph-query evidence = **lazy fallback** — the subagent had graph access but used grep anyway. FAIL.
+
+This is how a grader at Tier 2 catches subagents that silently skip graph when it was available.
+
+## Spot-check discipline
+
+When the graph IS used, Tier 2 requires a spot-check: read at least one result's source file:line to verify graph output matches reality. The graph is AST-based — it does NOT see runtime behaviour, does NOT verify DB column values, does NOT catch JSONB schema drift. Record the spot-check file:line in RESULT.


### PR DESCRIPTION
## What this adds

A new plugin under `plugins/ralph-review-trio/` containing:

- 1 command (`/ralph-review`) — entry-point that dispatches the three-tier loop
- 3 agents (`haiku-reviewer`, `sonnet-reviewer`, `opus-reviewer`) — one per tier with model frontmatter
- 1 skill (`skills/ralph-review-trio/SKILL.md`) — instruction content + per-tier checklists in `references/`
- 1 assets file (`example-transcript.md`)

## What it does

Sequential three-tier code review (Haiku surface → Sonnet logic → Opus deep) with **restart-on-fail**: any tier failure restarts the whole loop from Tier 1. Pass = all three tiers passed in a row against the same final state.

The restart rule is the differentiator — without it, fixes you make after Sonnet flags something go in unreviewed by Haiku, and the class of mistakes Haiku catches (debug prints, magic numbers, stale comments) sneaks in via the fix itself.

## Provenance

- Pattern origin: [Geoffrey Huntley's Ralph](https://ghuntley.com/ralph) (while-true loop), powered per-tier by Anthropic's official `ralph-loop` plugin.
- Three-tier stack on top: scrubbed from `hoiung/dotfiles@9249dbf` private SST3 harness.
- Public source repo: https://github.com/hoiung/sst3-skills (MIT licensed).
- Writeup: https://hoiboy.uk/posts/shipping-ralph-review-trio/

## Validation

`npm test` passes locally:
```
✅ Subagents & Commands (555ms)
✅ Hooks (281ms)
✅ All validations passed!
```

## Battle-tested

In active use since January 2026 across `hoiung/dotfiles` (430+ issues, ~155 closed with all three tier-pass tokens) and `hoiung/auto_pb_swing_trader`. Specific catches it has paid for itself on:

- Database helper returning dict-row cursors while callers indexed by `[0]` tuple style — eight latent bugs, one silently writing NULL foreign keys for 3 of every 4 audit rows (`auto_pb#1415`).
- Cache helper substituting a default whenever callers forgot a required argument; fix made the argument required and raised loudly on omission (`auto_pb#1442`).
- Hardcoded repo-path assumption Ralph spotted inside one of its own tier checklists (`dotfiles#399`).