### PR TITLE
fix(claude-ops): align daemon agent name with filename for CI

### DIFF
--- a/plugins/claude-ops/agents/daemon-agent.md
+++ b/plugins/claude-ops/agents/daemon-agent.md
@@ -1,5 +1,5 @@
 ---
-name: ops-daemon-manager
+name: daemon-agent
 description: Manages the ops background daemon — start, stop, restart services, check health
 model: claude-sonnet-4-6
 effort: low


### PR DESCRIPTION
CI validate step requires `name:` in agent frontmatter to match the `*.md` basename. Updates `daemon-agent.md` so the workflow passes.

Made with [Cursor](https://cursor.com)