### PR TITLE
Add slopmop plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -100,6 +100,32 @@
       "source": "./plugins/claude-hud"
     },
     {
+      "name": "slopmop",
+      "description": "Quality gates for AI-assisted codebases. Provides refit onboarding, the swab/scour/buff/sail remediation loop, and barnacle friction reporting as a Claude skill and slash commands.",
+      "version": "1.1.0",
+      "author": {
+        "name": "ScienceIsNeato",
+        "url": "https://github.com/ScienceIsNeato"
+      },
+      "repository": "https://github.com/ScienceIsNeato/slop-mop",
+      "license": "Slop-Mop Attribution License v1.0",
+      "keywords": [
+        "quality-gate",
+        "linting",
+        "testing",
+        "code-quality",
+        "ci-cd",
+        "ai",
+        "llm",
+        "vibe-coding",
+        "remediation",
+        "pre-pr",
+        "claude-code-plugin"
+      ],
+      "category": "code-quality",
+      "source": "./plugins/slopmop"
+    },
+    {
       "name": "agents-blockchain-web3",
       "description": "Specialized agents for blockchain development, smart contracts, and Web3 applications",
       "version": "1.0.0",

--- a/plugins/slopmop/.claude-plugin/plugin.json
+++ b/plugins/slopmop/.claude-plugin/plugin.json
@@ -1,0 +1,26 @@
+{
+  "name": "slopmop",
+  "version": "1.1.0",
+  "description": "Quality gates for AI-assisted codebases — catch the slop LLMs leave behind. Provides refit onboarding, the swab/scour/buff/sail remediation loop, and barnacle friction reporting as a Claude skill and slash commands.",
+  "author": {
+    "name": "ScienceIsNeato",
+    "url": "https://github.com/ScienceIsNeato"
+  },
+  "homepage": "https://github.com/ScienceIsNeato/slop-mop",
+  "repository": "https://github.com/ScienceIsNeato/slop-mop",
+  "license": "Slop-Mop Attribution License v1.0",
+  "keywords": [
+    "quality-gate",
+    "linting",
+    "testing",
+    "code-quality",
+    "ci-cd",
+    "ai",
+    "llm",
+    "vibe-coding",
+    "remediation",
+    "pre-pr"
+  ],
+  "skills": "./skills/",
+  "commands": "./commands/"
+}

--- a/plugins/slopmop/README.md
+++ b/plugins/slopmop/README.md
@@ -1,0 +1,27 @@
+# slopmop
+
+Slop-mop adds quality-gate rails for AI-assisted codebases. It gives Claude Code a skill and slash commands for the refit onboarding flow, the swab/scour/buff/sail maintenance loop, and barnacle friction reporting.
+
+## Install
+
+```text
+/plugin marketplace add davepoon/buildwithclaude
+/plugin install slopmop@buildwithclaude
+```
+
+The slop-mop CLI is required on the user's machine:
+
+```bash
+pipx install slopmop[all]
+```
+
+## What It Provides
+
+- `/sm-refit` for onboarding an existing repository into quality-gated maintenance.
+- `/sm-sail` for running the next obvious slop-mop workflow step.
+- `/sm-swab` for fast local validation during development.
+- `/sm-scour` for comprehensive pre-PR checks.
+- `/sm-buff` for CI and PR feedback triage.
+- `/sm-barnacle` for reporting slop-mop tooling friction.
+
+Repository: https://github.com/ScienceIsNeato/slop-mop

--- a/plugins/slopmop/README.md
+++ b/plugins/slopmop/README.md
@@ -17,11 +17,11 @@ pipx install slopmop[all]
 
 ## What It Provides
 
-- `/sm-refit` for onboarding an existing repository into quality-gated maintenance.
-- `/sm-sail` for running the next obvious slop-mop workflow step.
-- `/sm-swab` for fast local validation during development.
-- `/sm-scour` for comprehensive pre-PR checks.
-- `/sm-buff` for CI and PR feedback triage.
-- `/sm-barnacle` for reporting slop-mop tooling friction.
+- `/slopmop:sm-refit` for onboarding an existing repository into quality-gated maintenance.
+- `/slopmop:sm-sail` for running the next obvious slop-mop workflow step.
+- `/slopmop:sm-swab` for fast local validation during development.
+- `/slopmop:sm-scour` for comprehensive pre-PR checks.
+- `/slopmop:sm-buff` for CI and PR feedback triage.
+- `/slopmop:sm-barnacle` for reporting slop-mop tooling friction.
 
 Repository: https://github.com/ScienceIsNeato/slop-mop

--- a/plugins/slopmop/commands/sm-barnacle.md
+++ b/plugins/slopmop/commands/sm-barnacle.md
@@ -1,0 +1,30 @@
+# /sm-barnacle — report slop-mop tool friction
+
+Use when `sm` itself gives invalid guidance, blocks valid work, produces
+confusing output, or breaks install/upgrade/refit flow.  Do not use this for
+real target-repo failures; fix those through the normal rail.
+
+```bash
+sm barnacle file \
+  --title "short summary of the slop-mop friction" \
+  --command "sm <verb> [flags]" \
+  --expected "what should have happened" \
+  --actual "what happened instead" \
+  --repro-step "how to reproduce it" \
+  --tried "what you already tried" \
+  --workflow swab \
+  --blocker-type blocking \
+  --json
+```
+
+Use `--dry-run` when GitHub auth is unavailable.  The generated issue body is
+written to `.slopmop/last_barnacle_issue.md`; pass `--body-file <path>` when a
+specific retry artifact path matters.
+
+The point is to improve the rail, not hide the defect.  File the barnacle, then
+continue only if the friction is non-blocking.
+
+**Prerequisite:** `sm` must be installed. If `command not found`, suggest:
+```bash
+pipx install slopmop[all]
+```

--- a/plugins/slopmop/commands/sm-barnacle.md
+++ b/plugins/slopmop/commands/sm-barnacle.md
@@ -1,4 +1,9 @@
-# /sm-barnacle — report slop-mop tool friction
+---
+description: Report slop-mop tooling friction with a structured barnacle
+allowed-tools: Bash(sm:*)
+---
+
+# /slopmop:sm-barnacle - report slop-mop tool friction
 
 Use when `sm` itself gives invalid guidance, blocks valid work, produces
 confusing output, or breaks install/upgrade/refit flow.  Do not use this for

--- a/plugins/slopmop/commands/sm-buff.md
+++ b/plugins/slopmop/commands/sm-buff.md
@@ -1,4 +1,10 @@
-# /sm-buff
+---
+description: Triage pull request CI results and review feedback with slop-mop
+argument-hint: <pr-number>
+allowed-tools: Bash(sm:*)
+---
+
+# /slopmop:sm-buff
 
 Triage CI results and review feedback for a pull request.
 

--- a/plugins/slopmop/commands/sm-buff.md
+++ b/plugins/slopmop/commands/sm-buff.md
@@ -1,0 +1,16 @@
+# /sm-buff
+
+Triage CI results and review feedback for a pull request.
+
+Usage: Run `sm buff <PR_NUMBER>` after CI completes or review feedback lands.
+
+1. Run `sm buff <PR_NUMBER>`.
+2. Summarize what passed, what failed, and what needs attention.
+3. Propose a concrete remediation plan for each actionable item.
+
+This converts raw feedback into your next set of tasks. Never mark a failing check as resolved without actually fixing it.
+
+**Prerequisite:** `sm` must be installed. If `command not found`, suggest:
+```bash
+pipx install slopmop[all]
+```

--- a/plugins/slopmop/commands/sm-refit.md
+++ b/plugins/slopmop/commands/sm-refit.md
@@ -1,0 +1,17 @@
+# /sm-refit
+
+Run slop-mop's one-time onboarding remediation rail for this repository.
+
+1. For an existing repo that has not been remediated, start with `sm refit --start`.
+2. Fix the current gate or blocker it reports.
+3. Run `sm refit --iterate` to resume the stored plan.
+4. Repeat until the plan is complete, then run `sm refit --finish`.
+
+This is step 0 for inherited or already-messy repositories. Let refit own the
+structured remediation plan and commits; use the swab/scour/buff loop after the
+repo has entered maintenance.
+
+**Prerequisite:** `sm` must be installed. If `command not found`, suggest:
+```bash
+pipx install slopmop[all]
+```

--- a/plugins/slopmop/commands/sm-refit.md
+++ b/plugins/slopmop/commands/sm-refit.md
@@ -1,4 +1,9 @@
-# /sm-refit
+---
+description: Run slop-mop's one-time repository onboarding remediation rail
+allowed-tools: Bash(sm:*)
+---
+
+# /slopmop:sm-refit
 
 Run slop-mop's one-time onboarding remediation rail for this repository.
 

--- a/plugins/slopmop/commands/sm-sail.md
+++ b/plugins/slopmop/commands/sm-sail.md
@@ -1,0 +1,17 @@
+# /sm-sail
+
+Auto-advance the slop-mop workflow loop for this repository.
+
+1. Run `sm sail`.
+2. It reads the workflow state and runs the next obvious verb — swab, scour, or buff.
+3. Fix whatever it reports, then run `sm sail` again.
+4. Repeat until the PR lands.
+
+This is the "do the next thing" command. Use it when you're not sure whether to swab, scour, or buff. For surgical work on a specific gate or PR thread, use the individual verbs directly.
+
+**First time in a repo?** If `sm sail` reports no workflow state, the repo hasn't been onboarded yet. Run `sm refit --start` to begin.
+
+**Prerequisite:** `sm` must be installed. If `command not found`, suggest:
+```bash
+pipx install slopmop[all]
+```

--- a/plugins/slopmop/commands/sm-sail.md
+++ b/plugins/slopmop/commands/sm-sail.md
@@ -1,4 +1,9 @@
-# /sm-sail
+---
+description: Auto-advance the slop-mop workflow loop for this repository
+allowed-tools: Bash(sm:*)
+---
+
+# /slopmop:sm-sail
 
 Auto-advance the slop-mop workflow loop for this repository.
 

--- a/plugins/slopmop/commands/sm-scour.md
+++ b/plugins/slopmop/commands/sm-scour.md
@@ -1,0 +1,14 @@
+# /sm-scour
+
+Run slop-mop's comprehensive pre-PR sweep for this repository.
+
+1. Run `sm scour`.
+2. Summarize every issue found — these are the things that would compound if left unchecked.
+3. Propose concrete fixes for each.
+
+Only open or update a PR when `sm scour` reports a clean run.
+
+**Prerequisite:** `sm` must be installed. If `command not found`, suggest:
+```bash
+pipx install slopmop[all]
+```

--- a/plugins/slopmop/commands/sm-scour.md
+++ b/plugins/slopmop/commands/sm-scour.md
@@ -1,4 +1,9 @@
-# /sm-scour
+---
+description: Run slop-mop's comprehensive pre-PR sweep for this repository
+allowed-tools: Bash(sm:*)
+---
+
+# /slopmop:sm-scour
 
 Run slop-mop's comprehensive pre-PR sweep for this repository.
 

--- a/plugins/slopmop/commands/sm-swab.md
+++ b/plugins/slopmop/commands/sm-swab.md
@@ -1,4 +1,9 @@
-# /sm-swab
+---
+description: Run slop-mop's fast iterative development validation loop
+allowed-tools: Bash(sm:*)
+---
+
+# /slopmop:sm-swab
 
 Run slop-mop's iterative development loop for this repository.
 

--- a/plugins/slopmop/commands/sm-swab.md
+++ b/plugins/slopmop/commands/sm-swab.md
@@ -1,0 +1,15 @@
+# /sm-swab
+
+Run slop-mop's iterative development loop for this repository.
+
+1. Run `sm swab`.
+2. Read the output — each failing check is a gradient to descend.
+3. Apply fixes for each reported issue.
+4. Re-run `sm swab` until clean.
+
+This is your inner development loop. Run it early and often — each pass reduces repo entropy. Never bypass or silence a failing check.
+
+**Prerequisite:** `sm` must be installed. If `command not found`, suggest:
+```bash
+pipx install slopmop[all]
+```

--- a/plugins/slopmop/skills/slopmop/SKILL.md
+++ b/plugins/slopmop/skills/slopmop/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: slopmop
+description: >-
+  Trigger when you would normally reach for pytest, gh, mypy, black, or other
+  raw repo tooling. Redirect to `sm swab`, `sm scour`, `sm buff`, `sm sail`,
+  `sm refit`, or `sm doctor` so remediation follows the established rails.
+  Also trigger when filing issues about slop-mop friction — use
+  `sm barnacle file` / `/sm-barnacle`, never `gh issue create`.
+---
+
+# Slop-mop skill
+
+> **Filing slop-mop friction?** Use `/sm-barnacle` or `sm barnacle file` — **never `gh issue create` directly**. The barnacle CLI auto-applies the correct labels and targets the right repo regardless of where you are.
+
+Slop-mop (`sm`) has two primary modes: **refit** (one-time onboarding) and **maintenance** (steady-state development). Refit remediates all existing slop and installs permanent guards; the swab/scour/buff loop then keeps the repo clean as you work.
+
+## When to use
+
+- **Default action**: Run `sm sail` when you're not sure what's next — it reads workflow state and does the right thing.
+- **Refit (step 0)**: Run `sm refit --start` to generate a remediation plan, then `sm refit --iterate` until complete, then `sm refit --finish` to enter maintenance.
+- **During implementation**: Run `sm swab` after every meaningful code change. Keep running until clean.
+- **Before PR**: Run `sm scour` for a comprehensive sweep.
+- **After CI/review**: Run `sm buff <PR_NUMBER>` to convert feedback into next steps.
+
+## The maintenance loop
+
+```
+Fastest path:  sm sail → fix what it finds → sm sail → repeat until PR lands
+Manual path:   write code → sm swab → fix → repeat → sm scour → sm buff <PR#>
+```
+
+`sm sail` automates verb selection. Use individual verbs (`sm swab -g <gate>`, `sm buff resolve`, etc.) for surgical work.
+
+## Refit (before entering the loop)
+
+Refit is not part of the maintenance loop. It is step 0 — how you earn the right to enter the loop.
+
+```
+sm refit --start → fix one gate → sm refit --iterate → ... → sm refit --finish
+```
+
+## Prerequisite
+
+The `sm` CLI must be installed in the user's environment. If invocation fails with "command not found", suggest:
+
+```bash
+pipx install slopmop[all]
+```
+
+Then re-run the command.
+
+## Safety
+
+- Never bypass or silence a failing check — that's how repo rot compounds.
+- If a gate seems wrong, tune it or file a bug. Don't disable it as a workaround.
+- Report friction (invalid guidance, broken state, blocked rails) via `/sm-barnacle` rather than working around it.
+
+## Reference
+
+Full project docs: https://github.com/ScienceIsNeato/slop-mop
+Workflow state machine: https://github.com/ScienceIsNeato/slop-mop/blob/main/DOCS/WORKFLOW.md
+Gate reasoning: https://github.com/ScienceIsNeato/slop-mop/blob/main/DOCS/GATE_REASONING.md

--- a/plugins/slopmop/skills/slopmop/SKILL.md
+++ b/plugins/slopmop/skills/slopmop/SKILL.md
@@ -5,12 +5,12 @@ description: >-
   raw repo tooling. Redirect to `sm swab`, `sm scour`, `sm buff`, `sm sail`,
   `sm refit`, or `sm doctor` so remediation follows the established rails.
   Also trigger when filing issues about slop-mop friction — use
-  `sm barnacle file` / `/sm-barnacle`, never `gh issue create`.
+  `sm barnacle file` / `/slopmop:sm-barnacle`, never `gh issue create`.
 ---
 
 # Slop-mop skill
 
-> **Filing slop-mop friction?** Use `/sm-barnacle` or `sm barnacle file` — **never `gh issue create` directly**. The barnacle CLI auto-applies the correct labels and targets the right repo regardless of where you are.
+> **Filing slop-mop friction?** Use `/slopmop:sm-barnacle` or `sm barnacle file` — **never `gh issue create` directly**. The barnacle CLI auto-applies the correct labels and targets the right repo regardless of where you are.
 
 Slop-mop (`sm`) has two primary modes: **refit** (one-time onboarding) and **maintenance** (steady-state development). Refit remediates all existing slop and installs permanent guards; the swab/scour/buff loop then keeps the repo clean as you work.
 
@@ -53,7 +53,7 @@ Then re-run the command.
 
 - Never bypass or silence a failing check — that's how repo rot compounds.
 - If a gate seems wrong, tune it or file a bug. Don't disable it as a workaround.
-- Report friction (invalid guidance, broken state, blocked rails) via `/sm-barnacle` rather than working around it.
+- Report friction (invalid guidance, broken state, blocked rails) via `/slopmop:sm-barnacle` rather than working around it.
 
 ## Reference
 


### PR DESCRIPTION
## Summary
Add the slopmop Claude Code plugin to the Build with Claude marketplace catalog.

## Component Details
- **Name**: slopmop
- **Type**: Plugin / Skill / Commands
- **Category**: code-quality

## Testing
- [x] Ran validation (`npm test`)
- [x] No validation errors or warnings
- [x] Added plugin manifest, skill, slash commands, and README

## Examples
- `/sm-sail` to run the next obvious slop-mop workflow step
- `/sm-swab` for fast local validation during development
- `/sm-buff` for PR/CI feedback triage
