### PR TITLE
Add vibe-prospecting plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1506,7 +1506,7 @@
         "mcp",
         "explorium"
       ],
-      "category": "productivity",
+      "category": "sales-marketing",
       "source": "./plugins/vibe-prospecting"
     }
   ]

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1484,6 +1484,30 @@
       ],
       "category": "orchestration",
       "source": "./plugins/magic-cc-codex-worker"
+    },
+    {
+      "name": "vibe-prospecting",
+      "description": "Power your chat with live B2B data to create lead lists, research companies, enrich contacts, personalize outreach, and inspect business signals, tech stacks, events, and website changes. 150M+ businesses and 800M+ professionals via the Explorium MCP.",
+      "version": "0.1.56",
+      "author": {
+        "name": "vibeprospecting.ai",
+        "url": "https://vibeprospecting.ai"
+      },
+      "repository": "https://github.com/explorium-ai/vibeprospecting-plugin",
+      "license": "MIT",
+      "keywords": [
+        "b2b",
+        "prospecting",
+        "leads",
+        "sales",
+        "enrichment",
+        "companies",
+        "contacts",
+        "mcp",
+        "explorium"
+      ],
+      "category": "productivity",
+      "source": "./plugins/vibe-prospecting"
     }
   ]
 }

--- a/plugins/vibe-prospecting/.claude-plugin/plugin.json
+++ b/plugins/vibe-prospecting/.claude-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "vibe-prospecting",
+  "version": "0.1.56",
+  "description": "Power your chat with live B2B data to create lead lists, research companies, enrich contacts, personalize outreach, and inspect business signals, tech stacks, events, and website changes. 150M+ businesses and 800M+ professionals via the Explorium MCP.",
+  "author": {
+    "name": "vibeprospecting.ai",
+    "email": "support@vibeprospecting.ai",
+    "url": "https://vibeprospecting.ai"
+  },
+  "homepage": "https://vibeprospecting.ai",
+  "repository": "https://github.com/explorium-ai/vibeprospecting-plugin",
+  "license": "MIT",
+  "keywords": [
+    "b2b",
+    "prospecting",
+    "leads",
+    "sales",
+    "enrichment",
+    "companies",
+    "contacts",
+    "mcp",
+    "explorium"
+  ]
+}

--- a/plugins/vibe-prospecting/README.md
+++ b/plugins/vibe-prospecting/README.md
@@ -1,0 +1,22 @@
+# Vibe Prospecting
+
+Power your chat with live B2B data — build lead lists, research companies, enrich contacts, personalize outreach, and inspect business signals, tech stacks, events, and website changes — all from inside Claude Code.
+
+Backed by the Explorium MCP: **150M+ businesses**, **800M+ professional profiles**, **4,000+ signals**, **50+ data sources**.
+
+## What you can ask
+
+- *"Find prospects at SaaS companies in New York."*
+- *"Research the engineering leaders at Palo Alto Networks."*
+- *"Build a lead list of companies using Salesforce."*
+- *"Enrich this CSV of companies with revenue, headcount, and tech stack."*
+
+## Source & install
+
+- Plugin source: https://github.com/explorium-ai/vibeprospecting-plugin
+- MCP endpoint: `https://vibeprospecting.explorium.ai/mcp`
+- Homepage: https://vibeprospecting.ai
+
+## License
+
+MIT — see the source repository for details.


### PR DESCRIPTION
## Summary

Adds the **Vibe Prospecting** plugin to the marketplace under the `productivity` category. Source: https://github.com/explorium-ai/vibeprospecting-plugin

The plugin powers Claude Code with live B2B data via the Explorium MCP — 150M+ businesses, 800M+ professional profiles, 4,000+ signals — for lead-list building, prospect enrichment, executive discovery, firmographics, technographics, funding signals, and multi-step GTM workflows.

## Component Details
- **Name**: vibe-prospecting
- **Type**: Plugin
- **Category**: productivity
- **Version**: 0.1.56
- **License**: MIT
- **Repository**: https://github.com/explorium-ai/vibeprospecting-plugin

## Files added
- `plugins/vibe-prospecting/.claude-plugin/plugin.json` — plugin manifest
- `plugins/vibe-prospecting/README.md` — short description, example prompts, source/install pointers
- `.claude-plugin/marketplace.json` — entry appended to the `plugins` array

## Example usages

1. *"Find prospects at SaaS companies in New York."*
2. *"Research the engineering leaders at Palo Alto Networks."*
3. *"Build a lead list of companies using Salesforce, then enrich each with revenue and tech stack."*

## Testing
- [x] JSON validates (`marketplace.json` and `plugin.json`)
- [x] No overlap with existing plugins (closest neighbor in `productivity`: `claude-ops` — different scope)
- [x] Branch name follows convention: `add-vibe-prospecting-plugin`

## Disclosure
I'm the CEO of Explorium, which maintains this plugin.