### PR TITLE
chore(plugins): bump project-boundary to 1.10.0

### DIFF
--- a/plugins/project-boundary/.claude-plugin/plugin.json
+++ b/plugins/project-boundary/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "project-boundary",
-  "version": "1.8.0",
+  "version": "1.10.0",
   "description": "Blocks destructive commands outside the project directory. Allows file operations within the project (refactoring, cleanup) but prevents accidental damage outside it.",
   "author": {
     "name": "Justyna Wojtczak",

--- a/plugins/project-boundary/README.md
+++ b/plugins/project-boundary/README.md
@@ -25,10 +25,11 @@ Allows destructive operations **within your project** but blocks them **outside*
 | `wget -O` / `wget --output-document` | Allowed | **Blocked** |
 | `find -delete` / `find -exec rm` | Allowed | **Blocked** |
 | `dd of=` | Allowed | **Blocked** |
-| `install` (source and destination) | Allowed | **Blocked** |
-| `rsync` (source and destination) | Allowed | **Blocked** |
+| `install` (source, destination, `--target-directory=`) | Allowed | **Blocked** |
+| `rsync` (source, destination, `--log-file=`, `--partial-dir=`, `--backup-dir=`, `--temp-dir=`, `--write-batch=`, `--only-write-batch=`) | Allowed | **Blocked** |
 | `tar -C` / `--directory=` | Allowed | **Blocked** |
 | `unzip -d` / `cpio -D` | Allowed | **Blocked** |
+| `7z -o<dir>` / `7z -w<dir>` (extract verbs only) | Allowed | **Blocked** |
 | **Edit** tool (file edits) | Allowed | **Blocked** |
 | **MultiEdit** tool (multi-file edits) | Allowed | **Blocked** |
 | **Write** tool (file creation) | Allowed | **Blocked** |
@@ -41,13 +42,17 @@ Allows destructive operations **within your project** but blocks them **outside*
 | `eval '...'` | Cannot safely parse evaluated code |
 | Piping to `sh` / `bash` | Inner commands invisible to guard |
 | `xargs rm/mv/cp/...` | Arguments cannot be validated |
+| `python -c` / `ruby -e` / `perl -e` / `node --eval` / `php -r/-R/--run` / `Rscript -e` / `osascript -e` | Inline interpreter code is opaque to the Bash parser |
+| `awk '... system("...") ...'` (and similar `\| "sh"`) | Awk programs can shell out without the guard seeing the inner command |
+| `env -S` / `env --split-string` / `env -C` / `env --chdir` | These either smuggle a real command inside a string or change the working directory before the inner tool runs |
 | `$(...)` / backticks (outside single quotes) | Command substitution target is uninspectable. Single-quoted forms like `'$(cmd)'` and arithmetic expansion `$((2+2))` are allowed. |
+| `$VAR` / `${VAR}` and positional / special parameters (`$1` … `$9`, `$@`, `$*`, `$#`, `$?`, `$$`, `$!`, `$-`) outside single quotes | Variable expansion target is uninspectable for the same reason as `$(...)`. Only `$HOME` / `${HOME}` is allowed (canonical home path). Use literal values inline, or reach for the `Read` / `Grep` tools instead of piping shell vars. ANSI-C `$'…'`, i18n `$"…"`, backslash-escaped `\$VAR`, single-quoted `'$VAR'`, and quoted-heredoc bodies are unaffected. |
 
 ### Additional protections
 
-- **Chained commands** — splits on `;`, `&&`, `||`, `|` and checks each sub-command independently
+- **Chained commands** — splits on `;`, `&&`, `||`, `|`, and unquoted newlines, then checks each sub-command independently
 - **`cwd` awareness** — uses `cwd` from the hook event, so commands run outside the project (without an explicit `cd`) are also guarded
-- **`cd` tracking** — `cd /tmp && rm -rf something` is blocked because `cd` left the project; `cd $PROJECT && rm file` is allowed even if the event `cwd` was outside
+- **`cd` tracking** — `cd /tmp && rm -rf something` is blocked because `cd` left the project; `cd ~/your-repo && rm file` is allowed even if the event `cwd` was outside (`$PROJECT` and other non-`$HOME` variables are uninspectable, so use `~`/`$HOME` or a literal path)
 - **Destructive subcommands outside project** — when running outside the project (via event `cwd` or `cd`), these are blocked: `git clean -f`, `git checkout .`, `git restore .`, `git reset --hard`, `git push --force`, `git stash drop/clear`, `git branch -D`, `git reflog expire`, `rails db:drop/reset`, `rake db:drop/reset`. Safe commands like `git status`, `git log`, `rails routes` remain allowed.
 - **`sudo` prefix** — stripped before checking, so `sudo rm /etc/passwd` is still blocked
 - **`find` options** — handles `-L`, `-H`, `-P` before the search path
@@ -55,10 +60,16 @@ Allows destructive operations **within your project** but blocks them **outside*
 - **`~` and `$HOME` expansion** — `rm ~/file` and `rm $HOME/file` are correctly detected as outside-project
 - **Symlink resolution** — handles macOS `/var` → `/private/var`, dereferences symlink chains in Edit/Write/MultiEdit (fail-closed after 20 hops)
 - **`/dev/null` bit-bucket** — `curl -o /dev/null`, `2>/dev/null`, `tee /dev/null`, `dd of=/dev/null`, and all redirect target forms are allowed so routine probe and silencing workflows don't hit the boundary. Narrow exemption: the discard-only walkers short-circuit *before* `is_write_permitted`; `sed -i /dev/null`, `truncate /dev/null`, and `cp|mv|ln ... /dev/null` remain blocked because each performs a real filesystem write under `/dev/`.
+- **POSIX `--` end-of-options** — `install`, `rsync`, `sed -i`, and `truncate` continue parsing operands after a literal `--`, so `rsync … -- -outside/file` and similar dash-prefixed targets are validated rather than silently skipped as flags.
+- **Windows-native path tokens in COMMAND** — `tee C:\Windows\System32\…`, `rm C:/Users/x/.ssh/id_rsa`, redirects to drive-letter paths and UNC `\\server\share\…` are rewritten per-token via `cygpath -u` (MSYS2) before walkers run, then the boundary check rejects them. On non-MSYS2 shells Windows-shape tokens fail closed because they don't match the POSIX absolute-path pattern.
+- **`jq` behaviour canary** — the hook entry challenges `jq` with a randomised key/value JSON object on every invocation. A hostile shim that returns canned output (`jq() { echo ""; }`) cannot reproduce a per-call random value and the hook blocks, so the parser used to extract `tool_input` is provably real `jq`.
+- **NTFS reparse-point traversal** — junctions (`mklink /J`) and symbolic links (`mklink /D`) inside the project are followed to their physical target by `cd -P` (MSYS2 implements it via Win32 `SetCurrentDirectory`), so `project/escape -> C:\Windows` resolves to `/c/Windows` and writes through it are blocked. Regression-anchored on the Windows-smoke job.
 
 ### Path allowlist (`hooks/allowlist.conf`)
 
 Some paths legitimately live outside every project — e.g. Claude Code's auto-memory under `~/.claude/projects/<slug>/memory/`, which needs to persist across projects by design. The allowlist file lets you permit writes to those paths without loosening the project boundary for everything else.
+
+**Scope:** the allowlist is a **WRITE exception only**. It applies to the gentle write paths — `Edit` / `Write` / `MultiEdit`, redirects (`>` / `>>`), `tee`, `curl -o`, `wget -O`, `dd of=`, and similar — and to `cd` into an allowlisted directory. It deliberately does **not** apply to destructive or move/copy operations (`rm`, `mv`, `cp`, `ln`, `chmod`, `chown`, `find -delete`, `find -exec rm`, `install`, `rsync`, `tar -C`, `unzip -d`, `cpio -D`) or to script execution and shell redirection from outside paths. An allowlist entry that grants WRITE to `~/.claude/projects/*/memory/**` will **not** let `rm` or `rsync` run against that path.
 
 **Format:** one glob pattern per line; `#` starts a comment; `~` expands to `$HOME`; `**` matches across path segments (bash globstar), `*` within a single segment.
 
@@ -71,7 +82,6 @@ Some paths legitimately live outside every project — e.g. Claude Code's auto-m
 ### Known limitations
 
 - Paths with spaces work when properly quoted (single or double quotes). Unquoted paths with spaces are not supported.
-- Heredoc body contents are not inspected (only the first line of the command, where redirects are handled normally)
 - Brace expansion (`{a,b,c}`) is not enumerated — literal match only
 - `~user/` (home of another user) is not expanded; only `~/` (current user) is handled
 
@@ -79,25 +89,38 @@ Some paths legitimately live outside every project — e.g. Claude Code's auto-m
 
 The common idiom `git commit -m "$(cat <<'EOF' … EOF)"` is **blocked on purpose** — command substitution `$(…)` is fail-closed because the inner command is not inspectable in the general case (`$(cat && rm /etc/passwd)` looks identical to the parser). Making an exception for one shape of `cat` would just open a new bypass category.
 
-Equivalent patterns that pass the guard:
+The supported pattern is heredoc on stdin:
 
 ```bash
-# A) Heredoc piped on stdin — no $(), just a redirect
 git commit -F - <<'EOF'
 Subject line
 
 Body paragraph.
 EOF
+```
 
-# B) Write the message to a file, commit from file
-# (this is what Claude Code falls back to automatically)
-git commit -F .git/COMMIT_EDITMSG_DRAFT
+Repeated `-m` works for shorter messages where every paragraph fits on one line:
 
-# C) Repeated -m: each flag becomes one paragraph
+```bash
 git commit -m "Subject line" -m "Body paragraph."
 ```
 
-When Claude Code hits the block it will transparently switch to pattern **B** — cost is one extra tool call (Write + Bash instead of single Bash). No user action needed: the plugin registers a `SessionStart` hook that injects a one-line hint into every session, so Claude picks the right workaround on the first try.
+Avoid: writing the message to `.git/COMMIT_*` files (triggers a Write-tool prompt) or to `/tmp/*_msg.txt` (outside-project, blocked). The `SessionStart` hook ships a one-line hint that points Claude at the heredoc form on the first try, so no manual nudging is needed.
+
+## Requirements
+
+`bash` and `jq` must be on the PATH of the hook shell. macOS and most Linux distros ship bash; `jq` is usually present but install it explicitly if missing — without `jq` the hook fails closed with a clear `BLOCKED: 'jq' is required ...` message.
+
+| Platform | Install |
+|---|---|
+| macOS | `brew install jq` |
+| Debian/Ubuntu | `apt install jq` |
+| Fedora/RHEL | `dnf install jq` |
+| Arch | `pacman -S jq` |
+| Windows (MSYS2) | `pacman -S jq` |
+| Windows (Scoop/Winget) | `scoop install jq` or `winget install jqlang.jq` |
+
+On Windows the plugin runs under MSYS2 bash; `cygpath` (shipped with MSYS2) is required for Windows-native paths (`C:\…`, `\\server\…`) to be normalized — without it those paths fail closed.
 
 ## Install
 
@@ -122,7 +145,7 @@ Pure-bash PreToolUse hooks for Bash, Edit, MultiEdit, and Write tools. The Bash 
 bash tests/test_guard.sh
 ```
 
-Full test suite covering all guard scenarios. CI runs on Ubuntu and macOS.
+Full test suite covering all guard scenarios. CI runs on Ubuntu, macOS, and Windows (MSYS2 smoke job — minimal end-to-end coverage of Windows-native path handling and the NTFS reparse-point regression anchor).
 
 ## License
 

--- a/plugins/project-boundary/hooks/guard.sh
+++ b/plugins/project-boundary/hooks/guard.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 # so the sourced `lib/` siblings would be looked up in the wrong
 # directory. Chase the symlink chain to the real file before taking
 # its directory. Portable across Linux and macOS (no `readlink -f`
-# dependency). Reported by Copilot review on PR #15.
+# dependency).
 _guard_source="${BASH_SOURCE[0]}"
 while [ -L "$_guard_source" ]; do
   _guard_target="$(readlink "$_guard_source")"
@@ -23,8 +23,18 @@ _GUARD_DIR="$(cd "$(dirname "$_guard_source")" && pwd)"
 unset _guard_source _guard_target
 # shellcheck source=lib/tokenize.sh
 source "$_GUARD_DIR/lib/tokenize.sh"
+# shellcheck source=lib/wrapper_opts.sh
+source "$_GUARD_DIR/lib/wrapper_opts.sh"
 # shellcheck source=lib/command_name.sh
 source "$_GUARD_DIR/lib/command_name.sh"
+# shellcheck source=lib/git_walkers.sh
+source "$_GUARD_DIR/lib/git_walkers.sh"
+# shellcheck source=lib/shell_exec_walkers.sh
+source "$_GUARD_DIR/lib/shell_exec_walkers.sh"
+# shellcheck source=lib/cd_destructive_walker.sh
+source "$_GUARD_DIR/lib/cd_destructive_walker.sh"
+# shellcheck source=lib/expansion_blocks.sh
+source "$_GUARD_DIR/lib/expansion_blocks.sh"
 # shellcheck source=lib/paths.sh
 source "$_GUARD_DIR/lib/paths.sh"
 # shellcheck source=lib/heredoc.sh
@@ -33,18 +43,182 @@ source "$_GUARD_DIR/lib/heredoc.sh"
 source "$_GUARD_DIR/lib/detectors/inplace.sh"
 # shellcheck source=lib/detectors/destructive.sh
 source "$_GUARD_DIR/lib/detectors/destructive.sh"
+# shellcheck source=lib/detectors/permissions.sh
+source "$_GUARD_DIR/lib/detectors/permissions.sh"
 # shellcheck source=lib/detectors/write_targets.sh
 source "$_GUARD_DIR/lib/detectors/write_targets.sh"
+# write_targets_b.sh was split by domain (Codex r5 finding #4).
+# shellcheck source=lib/detectors/download.sh
+source "$_GUARD_DIR/lib/detectors/download.sh"
+# shellcheck source=lib/detectors/redirects.sh
+source "$_GUARD_DIR/lib/detectors/redirects.sh"
+# shellcheck source=lib/detectors/db_dump.sh
+source "$_GUARD_DIR/lib/detectors/db_dump.sh"
+# shellcheck source=lib/detectors/filesystem_create.sh
+source "$_GUARD_DIR/lib/detectors/filesystem_create.sh"
 # shellcheck source=lib/options.sh
 source "$_GUARD_DIR/lib/options.sh"
+# shellcheck source=lib/remote_dispatch.sh
+source "$_GUARD_DIR/lib/remote_dispatch.sh"
+# shellcheck source=lib/subcmd_flags.sh
+source "$_GUARD_DIR/lib/subcmd_flags.sh"
 
 INPUT=$(cat)
+
+# jq is a hard dependency for parsing the hook input JSON. Without it
+# the parsing below silently produces empty values, which then makes
+# the guard exit 0 — indistinguishable from "boundary working but
+# command happened to be allowed". Fail loud (issue #32).
+if ! command -v jq >/dev/null 2>&1; then
+  echo "BLOCKED: 'jq' is required by the project-boundary hook shell but was not found on PATH. Install jq (brew install jq / apt install jq / scoop install jq / winget install jqlang.jq) and retry." >&2
+  exit 2
+fi
+# Defense in depth (Codex sweep 4 #2): the `command -v jq` check
+# above only confirms a binary named `jq` exists on PATH. A hostile
+# shim that returns empty output for every query would slip past it
+# and silently produce COMMAND="" / FILE_PATH="" below, making the
+# guard `exit 0` for every Bash/Edit/Write call.
+#
+# Randomised canary: build a JSON object whose key and value are
+# both bash $RANDOM at hook entry; require jq to echo the value
+# back through `.<key>`. A trivial pattern-match shim that just
+# prints "1" for an _pb_canary key cannot reproduce a per-invocation
+# random value. This is NOT bullet-proof — a shim that bundles real
+# jq still passes — but it raises the bar from "10-line shell shim"
+# to "ship a working jq parser", which is on par with the
+# user-controls-PATH attacker model the plugin operates under.
+_pb_canary_k="pbk${RANDOM}_${RANDOM}"
+_pb_canary_v="${RANDOM}-${RANDOM}-${RANDOM}"
+if [ "$(printf '{"%s":"%s"}' "$_pb_canary_k" "$_pb_canary_v" | jq -r ".$_pb_canary_k" 2>/dev/null)" != "$_pb_canary_v" ]; then
+  echo "BLOCKED: 'jq' on PATH does not behave like real jq (randomised canary check failed). Cannot safely parse hook input — check PATH for a shim or reinstall jq." >&2
+  exit 2
+fi
+unset _pb_canary_k _pb_canary_v
+
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
 EVENT_CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
 
 if [ -z "$COMMAND" ] && [ -z "$FILE_PATH" ]; then
   exit 0
+fi
+
+# --- Normalize Windows-native paths from hook input (issue #28) ---
+# On Windows + MSYS2 bash, the Bash hook benefits from MSYS path
+# rewriting on command-line arguments (`C:\Users\x` → `/c/Users/x`),
+# but Edit/Write/MultiEdit deliver `tool_input.file_path` and `cwd`
+# as raw JSON strings — `C:\Users\x` arrives unchanged. The downstream
+# code's `[[ "$path" != /* ]]` relative-path branch then prepends
+# `$PROJECT_DIR/`, masking outside-project writes as in-project.
+#
+# Detect Windows-native shapes:
+#   ^[A-Za-z]:[\\/]   drive-letter (C:\, D:/, ...)
+#   ^\\\\             UNC (\\server\share)
+# When `cygpath -u` is available (MSYS2/Cygwin shell), convert to
+# POSIX form and let the normal boundary check run. Without cygpath,
+# fail-closed: refuse to interpret an absolute Windows path as if
+# it were project-relative. On Linux/macOS shells these shapes are
+# never legitimate POSIX paths, so the fail-closed branch is the
+# correct default.
+_pb_normalize_windows_path() {
+  local label="$1"
+  local val="$2"
+  # file:// URIs are never a legitimate file_path or cwd value —
+  # refuse them outright (Codex re-#28 Cat 1b). cygpath does not
+  # parse URIs, so fail-closed regardless of its presence.
+  if [[ "$val" =~ ^file:// ]]; then
+    echo "BLOCKED: $label is a file:// URI '$val'; pass a POSIX path instead." >&2
+    return 2
+  fi
+  # Windows-native path shapes:
+  #   ^[A-Za-z]:[\\/]   drive-letter + slash (C:\, D:/)
+  #   ^\\\\             UNC path (\\server\share, \\?\C:\)
+  #   ^[A-Za-z]:        drive-relative (C:foo) — Codex re-#28 Cat 1a.
+  #                     Accepted FP risk: a POSIX file literally named
+  #                     `c:something` is fail-closed; rare in practice.
+  if [[ "$val" =~ ^([A-Za-z]:|\\\\) ]]; then
+    if command -v cygpath >/dev/null 2>&1; then
+      cygpath -u "$val"
+      return 0
+    fi
+    echo "BLOCKED: $label is a Windows-native path '$val' but cygpath is not available; cannot reliably enforce the project boundary. Pass POSIX paths or install cygpath (MSYS2/Cygwin)." >&2
+    return 2
+  fi
+  printf '%s\n' "$val"
+}
+
+if [ -n "$FILE_PATH" ]; then
+  FILE_PATH=$(_pb_normalize_windows_path "tool_input.file_path" "$FILE_PATH") || exit $?
+fi
+if [ -n "$EVENT_CWD" ]; then
+  EVENT_CWD=$(_pb_normalize_windows_path "hook event cwd" "$EVENT_CWD") || exit $?
+fi
+
+# Bash hook COMMAND can also carry Windows-native path tokens
+# (Codex re-review Cat 6): `echo x > C:/Users/foo`, `tee C:\path`,
+# `curl -o C:/path URL`, etc. resolve_command_path treats those as
+# relative and resolves them under EFFECTIVE_CWD, producing an
+# in-project-looking path that passes is_inside_project.
+#
+# Detection scope is the whole COMMAND string with token-boundary
+# anchors (start, whitespace, redirect/pipe/separator). We accept
+# that this matches inside heredoc bodies too — a fail-closed
+# false-positive on a path-shaped string in a heredoc is preferred
+# over leaving the bypass open.
+#
+# Linux/macOS (cygpath absent): fail-closed via the detection
+# branch — there is no legitimate Windows-shaped path token on
+# these platforms.
+# MSYS2/Cygwin (cygpath present): each detected token is rewritten
+# in place via `cygpath -u` so downstream walkers see normalised
+# POSIX paths and the boundary check rejects outside-project values
+# (sec 108 + per-token rewrite landed in 1ac00ae).
+if [ -n "$COMMAND" ]; then
+  # Skip Windows-path detection for tools whose operands include
+  # `host:path` / `container:path` shapes that visually collide with
+  # Windows drive letters (`c:/tmp`). These tools route the path-side
+  # to a remote filesystem the project boundary doesn't apply to:
+  #   ssh REMOTE_HOST [command]    — remote command on remote host
+  #   scp src host:path            — remote copy
+  #   rsync src host:path          — remote sync
+  #   docker cp src container:/p   — container copy
+  #   kubectl cp pod:src local     — k8s copy
+  #   oc cp / podman cp            — same shape
+  _pb_cmd_trimmed="${COMMAND#"${COMMAND%%[![:space:]]*}"}"
+  _pb_cmd_first="${_pb_cmd_trimmed%% *}"
+  _pb_cmd_basename="${_pb_cmd_first##*/}"
+  _pb_cmd_basename_quoteless="${_pb_cmd_basename%\"}"
+  _pb_cmd_basename_quoteless="${_pb_cmd_basename_quoteless#\"}"
+  case "$_pb_cmd_basename_quoteless" in
+    ssh|scp|rsync|docker|kubectl|oc|podman)
+      : ;;
+    *)
+      if echo "$COMMAND" | grep -qE "(^|[[:space:]>|<&;=(\"'])([A-Za-z]:[\\\\/]|\\\\\\\\)"; then
+        if ! command -v cygpath >/dev/null 2>&1; then
+          echo "BLOCKED: command contains a Windows-native path token but cygpath is not available; cannot reliably enforce the project boundary. Pass POSIX paths or install cygpath (MSYS2/Cygwin)." >&2
+          exit 2
+        fi
+        # cygpath present (MSYS2/Cygwin shell): rewrite each
+        # Windows-shaped token to POSIX form so downstream walkers
+        # see normalized paths. Without this, on MSYS2 the
+        # walkers treated `C:\Users\foo` as project-relative and
+        # produced an in-project-looking path that passed the
+        # boundary check (Codex sweep 4 #3 / issue #34).
+        while IFS= read -r _pb_winpath; do
+          [ -z "$_pb_winpath" ] && continue
+          _pb_posix=$(cygpath -u "$_pb_winpath" 2>/dev/null)
+          [ -z "$_pb_posix" ] && continue
+          # Bash native replacement; quoting guards against glob
+          # interpretation of literal `\` / `/` in winpath.
+          COMMAND="${COMMAND//"$_pb_winpath"/"$_pb_posix"}"
+        done < <(echo "$COMMAND" \
+          | grep -oE "([A-Za-z]:[\\\\/][^[:space:]\"'<>|&;()=]*|\\\\\\\\[^[:space:]\"'<>|&;()=]+)" \
+          | sort -u)
+        unset _pb_winpath _pb_posix
+      fi
+      ;;
+  esac
+  unset _pb_cmd_trimmed _pb_cmd_first _pb_cmd_basename _pb_cmd_basename_quoteless
 fi
 
 # Use cwd from the hook event if provided, so relative paths resolve correctly.
@@ -64,6 +238,11 @@ fi
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
 # Ensure PROJECT_DIR has no trailing slash for consistent comparison
 PROJECT_DIR="${PROJECT_DIR%/}"
+# Normalize PROJECT_DIR if it arrived as a Windows-native path
+# (issue #28). Same fail-closed semantics as FILE_PATH/EVENT_CWD.
+if [ -n "$PROJECT_DIR" ]; then
+  PROJECT_DIR=$(_pb_normalize_windows_path "CLAUDE_PROJECT_DIR" "$PROJECT_DIR") || exit $?
+fi
 
 # EFFECTIVE_CWD: where relative paths in commands resolve to.
 # Uses cwd from hook event if provided, otherwise PROJECT_DIR.
@@ -114,7 +293,6 @@ ALLOWLIST_BASE_REGEXES=()
 # per session. Compiling glob_to_regex inside the hot loop wastes
 # cycles on identical work across every invocation. Compile once
 # here and reuse the cached regexes in is_allowlisted below.
-# Reported by Copilot review on commit aa6409b (guard.sh:298).
 _awl_i=0
 while [ $_awl_i -lt ${#ALLOWLIST_PATTERNS[@]} ]; do
   _awl_p="${ALLOWLIST_PATTERNS[$_awl_i]}"
@@ -216,10 +394,42 @@ check_single_command() {
     return 0
   fi
 
-  # --- Strip sudo prefix ---
-  if [[ "$CMD" =~ ^sudo[[:space:]]+ ]]; then
-    CMD="${CMD#sudo }"
-    CMD="$(echo "$CMD" | sed 's/^[[:space:]]*//')"
+  # Snapshot CMD BEFORE sudo-strip and any other normalization, so
+  # extract_subcmd_flag_payloads can see the wrapper + its option-with-
+  # value flags (e.g. `sudo -u root tar --to-command='<payload>'`).
+  # Sudo-strip below removes only the bare `sudo ` token; leftover
+  # `-u root` would mis-identify the verb in the subcmd-flag scan.
+  local _CMD_PRE_STRIP="$CMD"
+
+  # --- Strip sudo prefix and its option-with-value pairs ---
+  # Bare `${CMD#sudo }` left orphaned `-u root` in front of the verb,
+  # which mis-led every command-name walker (`root` got treated as the
+  # verb and install / /bin/<name> / "<name>" normalisations fell
+  # through). The helper walks sudo's options-with-value (-u USER,
+  # --user=USER, -g GROUP, …) so `sudo -u root install …` collapses to
+  # `install …` before any downstream walker runs. env / nice / ionice
+  # / timeout / chrt are NOT literal-stripped — _cn_find_verb_idx (and
+  # its _sf_/_rd_ siblings) handle their opt-with-value pairs in place.
+  CMD=$(strip_sudo_wrapper_with_opts "$CMD")
+  CMD="$(echo "$CMD" | sed 's/^[[:space:]]*//')"
+
+  # --- Block shell-opening sudo invocations ---
+  # `sudo -i` / `sudo -s` / `sudo --login` / `sudo --shell` open a
+  # privileged interactive shell whose subsequent commands cannot be
+  # inspected — strictly more dangerous than bare `bash`, which the
+  # shell-execute walker already blocks. _cn_is_sudo_shell_opener also
+  # catches clustered (`sudo -ni`, `-in`, `-nis`), quoted (`sudo "-i"`),
+  # and outer-wrapper-prefixed (`env -u FOO sudo -i`) forms. Runs on
+  # _CMD_PRE_STRIP so the original wrapper + sudo + flag layout is still
+  # visible; if CMD is empty after sudo-strip but the original was bare
+  # `sudo` / `sudo -l` / `-V` / `-v`, this returns 1 and we fall through
+  # to the harmless-empty ALLOW.
+  if _cn_is_sudo_shell_opener "$_CMD_PRE_STRIP"; then
+    echo "BLOCKED: 'sudo -i' / 'sudo -s' / 'sudo --login' / 'sudo --shell' (also clustered like -ni / -nis, quoted, or wrapper-prefixed) opens a privileged interactive shell whose subsequent commands cannot be inspected. Ask user for explicit permission." >&2
+    exit 2
+  fi
+  if [ -z "$CMD" ]; then
+    return 0
   fi
 
   # --- Snapshot raw CMD before alias-escape / paren normalization ---
@@ -240,31 +450,17 @@ check_single_command() {
   # Normalize these into the bare command form before any detection runs.
   # This only touches the string used for matching — argument extraction below
   # operates on the normalized CMD too, so paths are not mangled.
-  # Strip subshell grouping parens only when they sit at a token boundary so
-  # that `$(…)` (command substitution) is NOT mangled — that form is caught
-  # by a dedicated check below. `(rm …)` → `rm …`, `( rm … )` → `rm …`,
-  # `$(foo)` stays as is because the `(` is preceded by `$`, not space/start.
-  CMD="$(printf '%s' "$CMD" | sed -E 's/(^|[[:space:]])\(+/\1/g; s/\)+($|[[:space:]])/\1/g')"
-  # Strip a backslash that precedes a shell-word character (alias escape).
-  CMD="$(printf '%s' "$CMD" | sed -E 's/\\([a-zA-Z_])/\1/g')"
-  # Strip the common binary path prefix from the command-name token so
-  # that `/bin/rm` is recognised as `rm` by every command-name regex.
-  # MUST NOT touch operand or redirect-target tokens — see the helper
-  # docstring for the bypass shape this guards against (Codex review
-  # on commit e01df86, bypass A). The previous sed-based fallback for
-  # the start-of-CMD case is preserved so that a CMD whose tokenizer
-  # output is empty (defensively impossible but cheap) still gets the
-  # leading prefix stripped.
-  # Strip surrounding quotes from the command-name token so that
-  # `"rm" /etc/x` / `'rm' /etc/x` / `"/bin/rm" /etc/x` are still
-  # recognised by bare-name detectors. bash strips these quotes at
-  # exec time, invoking the bare binary either way. Must run before
-  # the /bin/-prefix passes so those see the bare path.
-  CMD="$(strip_command_name_quotes "$CMD")"
-  CMD="$(printf '%s' "$CMD" | sed -E 's#^/(usr/local/bin|usr/bin|bin|sbin|usr/sbin)/##')"
-  CMD="$(strip_command_name_prefix "$CMD")"
-  # Trim duplicated whitespace introduced by the substitutions.
-  CMD="$(printf '%s' "$CMD" | sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//')"
+  CMD=$(normalize_command_view "$CMD")
+
+  # --- Cache the post-normalisation verb name ---
+  # command_name_is is called ~64× per check_single_command (once per
+  # detector that gates on a verb). Without a cache each call would
+  # re-tokenise CMD and re-walk wrappers. CMD_VERB is read by
+  # command_name_is via dynamic scope; refreshed after rewrite_remote_
+  # dispatch below because that rewrite can change the visible verb
+  # (e.g. by stripping the ssh wrapper). Codex round-5 finding #3.
+  local CMD_VERB
+  CMD_VERB=$(_cn_compute_verb_name "$CMD")
 
   # --- Build a heredoc-sanitized view for expansion-scans ---
   # $VAR and $(...)/backtick inside a *quoted* heredoc body are literal
@@ -287,578 +483,98 @@ check_single_command() {
   # body bytes into the blanker.
   local CMD_BLANKED
   CMD_BLANKED=$(blank_quoted_heredoc_bodies "$CMD_RAW")
-  CMD_BLANKED="$(printf '%s' "$CMD_BLANKED" | sed 's/^[[:space:]]*//' | sed 's/[[:space:]]*$//')"
-  CMD_BLANKED="$(printf '%s' "$CMD_BLANKED" | sed -E 's/(^|[[:space:]])\(+/\1/g; s/\)+($|[[:space:]])/\1/g')"
-  CMD_BLANKED="$(printf '%s' "$CMD_BLANKED" | sed -E 's/\\([a-zA-Z_])/\1/g')"
-  CMD_BLANKED="$(strip_command_name_quotes "$CMD_BLANKED")"
-  CMD_BLANKED="$(printf '%s' "$CMD_BLANKED" | sed -E 's#^/(usr/local/bin|usr/bin|bin|sbin|usr/sbin)/##')"
-  CMD_BLANKED=$(strip_command_name_prefix "$CMD_BLANKED")
-  CMD_BLANKED="$(printf '%s' "$CMD_BLANKED" | sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//')"
+  CMD_BLANKED=$(normalize_command_view "$CMD_BLANKED")
 
   # --- Fail closed on unexpanded $VAR outside single quotes ---
-  # `expand_path` only handles ~, $HOME, ${HOME}. Any other $VAR is kept
-  # verbatim and then joined under $EFFECTIVE_CWD, so it looks "inside the
-  # project" to the guard while Bash expands it at exec time. Treat it like
-  # `$(…)`: if the value cannot be inspected, refuse.
-  local vi=0 vlen=${#CMD_EXPAND_SCAN}
-  local vin_sq=0 vin_dq=0 vin_esc=0
-  while [ $vi -lt $vlen ]; do
-    local vc="${CMD_EXPAND_SCAN:$vi:1}"
-    if [ $vin_esc -eq 1 ]; then vin_esc=0; vi=$((vi+1)); continue; fi
-    if [ "$vc" = "\\" ] && [ $vin_sq -eq 0 ]; then vin_esc=1; vi=$((vi+1)); continue; fi
-    if [ "$vc" = "'" ] && [ $vin_dq -eq 0 ]; then vin_sq=$((1-vin_sq)); vi=$((vi+1)); continue; fi
-    if [ "$vc" = '"' ] && [ $vin_sq -eq 0 ]; then vin_dq=$((1-vin_dq)); vi=$((vi+1)); continue; fi
-    if [ $vin_sq -eq 0 ] && [ "$vc" = "\$" ] && [ $((vi+1)) -lt $vlen ]; then
-      local vnext="${CMD_EXPAND_SCAN:$((vi+1)):1}"
-      # Explicit passthroughs — NOT parameter expansions:
-      #   $(...)   — command substitution, caught by the substitution detector
-      #   $'...'   — ANSI-C quoted literal (escape decoding, no expansion)
-      #   $"..."   — i18n string literal (no parameter expansion)
-      # Arithmetic `$((...))` is handled by the substitution detector.
-      if [ "$vnext" = "(" ] || [ "$vnext" = "'" ] || [ "$vnext" = '"' ]; then
-        :
-      # Allow $HOME / ${HOME} — expand_path handles them.
-      elif [[ "$vnext" =~ [A-Za-z_] ]]; then
-        local rest="${CMD_EXPAND_SCAN:$((vi+1))}"
-        local vname="${rest%%[^A-Za-z0-9_]*}"
-        if [ "$vname" != "HOME" ]; then
-          echo "BLOCKED: Variable expansion '\$${vname}' cannot be safely inspected. Ask user for explicit permission." >&2
-          exit 2
-        fi
-      elif [ "$vnext" = "{" ]; then
-        local rest="${CMD_EXPAND_SCAN:$((vi+2))}"
-        local vname="${rest%%\}*}"
-        if [ "$vname" != "HOME" ]; then
-          echo "BLOCKED: Variable expansion '\${${vname}}' cannot be safely inspected. Ask user for explicit permission." >&2
-          exit 2
-        fi
-      # Positional ($0..$9) and special ($@ $* $# $? $$ $! $-) parameters.
-      # These expand at exec time to values the guard cannot inspect —
-      # e.g. `set -- /etc/passwd; rm $1` looks like `rm $1` (treated as a
-      # relative filename inside cwd) to the regex checks, but bash
-      # expands $1 to /etc/passwd at execution. Same fail-closed rule as
-      # $FOO applies — every non-HOME expansion is refused.
-      elif [[ "$vnext" =~ [0-9@*#?!\$\-] ]]; then
-        echo "BLOCKED: Shell parameter expansion '\$${vnext}' cannot be safely inspected. Ask user for explicit permission." >&2
-        exit 2
-      fi
-    fi
-    vi=$((vi+1))
-  done
+  block_unexpanded_var
 
   # --- Tokenize the command once (quote-aware) for option/redirect parsing ---
+  # CMD_TOKENS_SCAN is the parallel token stream built from CMD_BLANKED.
+  # Used by detectors that walk tokens looking for a marker word (sed,
+  # truncate, `>`-redirect operator) and would otherwise pick up heredoc
+  # body bytes as if they were live commands. See the comment on
+  # CMD_BLANKED for why the source MUST be CMD_RAW (alias-escape would
+  # silently downgrade `<<\EOF` to its unquoted twin and re-leak body
+  # bytes).
   local -a CMD_TOKENS=()
-  while IFS= read -r tok; do
-    [[ -z "$tok" ]] && continue
-    CMD_TOKENS+=("$tok")
-  done < <(tokenize_args "$CMD")
-
-  # CMD_TOKENS_SCAN is the parallel token stream built from CMD_BLANKED
-  # (computed above near the top of check_single_command, alongside
-  # CMD_EXPAND_SCAN). Used by detectors that walk tokens looking for a
-  # marker word (sed, truncate, `>`-redirect operator) and would
-  # otherwise pick up heredoc body bytes as if they were live commands.
-  # See the comment on CMD_BLANKED for why the source MUST be CMD_RAW
-  # (alias-escape would silently downgrade `<<\EOF` to its unquoted
-  # twin and re-leak body bytes).
   local -a CMD_TOKENS_SCAN=()
-  while IFS= read -r tok; do
-    [[ -z "$tok" ]] && continue
-    CMD_TOKENS_SCAN+=("$tok")
-  done < <(tokenize_args "$CMD_BLANKED")
+  fill_tokens_from CMD_TOKENS "$CMD"
+  fill_tokens_from CMD_TOKENS_SCAN "$CMD_BLANKED"
 
   # --- Block command substitution outside single quotes ---
-  # `$(...)` and backticks are expanded by bash (even inside double quotes),
-  # so the guard cannot know the final target. Single quotes keep them literal,
-  # so only block when they appear outside single quotes. Arithmetic expansion
-  # `$((...))` is allowed — it's a numeric computation, not a command.
-  # Similar rationale to blocking `bash -c` / `eval` — the inner command is
-  # uninspectable.
-  local ci=0 clen=${#CMD_EXPAND_SCAN}
-  local cin_sq=0 cin_dq=0 cin_esc=0
-  while [ $ci -lt $clen ]; do
-    local cc="${CMD_EXPAND_SCAN:$ci:1}"
-    if [ $cin_esc -eq 1 ]; then
-      cin_esc=0
-      ci=$((ci + 1))
-      continue
-    fi
-    if [ "$cc" = "\\" ] && [ $cin_sq -eq 0 ]; then
-      cin_esc=1
-      ci=$((ci + 1))
-      continue
-    fi
-    # Single quotes are only delimiters when NOT inside double quotes
-    if [ "$cc" = "'" ] && [ $cin_dq -eq 0 ]; then
-      cin_sq=$(( 1 - cin_sq ))
-      ci=$((ci + 1))
-      continue
-    fi
-    # Double quotes are only delimiters when NOT inside single quotes
-    if [ "$cc" = '"' ] && [ $cin_sq -eq 0 ]; then
-      cin_dq=$(( 1 - cin_dq ))
-      ci=$((ci + 1))
-      continue
-    fi
-    if [ $cin_sq -eq 0 ]; then
-      if [ "$cc" = "\`" ]; then
-        echo "BLOCKED: Command substitution with backticks cannot be safely inspected. Ask user for explicit permission." >&2
-        exit 2
-      fi
-      if [ "$cc" = "\$" ] && [ $((ci + 1)) -lt $clen ] && [ "${CMD_EXPAND_SCAN:$((ci + 1)):1}" = "(" ]; then
-        # Skip arithmetic expansion $((...)): next-next char is also (
-        if [ $((ci + 2)) -ge $clen ] || [ "${CMD_EXPAND_SCAN:$((ci + 2)):1}" != "(" ]; then
-          echo "BLOCKED: Command substitution '\$(...)' cannot be safely inspected. Ask user for explicit permission." >&2
-          exit 2
-        fi
-      fi
-    fi
-    ci=$((ci + 1))
-  done
+  block_command_substitution
 
-  # --- Block cd outside project followed by destructive commands ---
-  if [[ "$CMD" =~ ^cd($|[[:space:]]) ]]; then
-    local cd_target
-    # cd takes a single argument, so grab everything after 'cd ' as the target
-    # (including spaces if quoted). Not using tokenize_args because cd doesn't
-    # take multiple path arguments.
-    cd_target=$(echo "$CMD" | sed 's/^cd[[:space:]]*//')
-    # cd with no args or cd ~ goes to $HOME
-    if [[ -z "$cd_target" || "$cd_target" == "~" ]]; then
-      cd_target="$HOME"
-    else
-      cd_target=$(expand_path "$cd_target")
-    fi
-    if [[ "$cd_target" != /* ]]; then
-      cd_target="$EFFECTIVE_CWD/$cd_target"
-    fi
-    local resolved_cd
-    resolved_cd=$(resolve_path "$cd_target")
-    EFFECTIVE_CWD="$resolved_cd"
-    # STRICT: cd-outside triggers the destructive-subcommand guard.
-    # Allowlist must not weaken this — `cd memory && git clean -fd` should
-    # still block. But write-style commands (`cd memory && tee note.md`)
-    # should reach their per-command is_write_permitted check, so we track
-    # allowlist-context in a separate flag.
-    if ! is_inside_project "$resolved_cd"; then
-      export _GUARD_CD_OUTSIDE=1
-      CWD_OUTSIDE_PROJECT=1
-      if is_allowlisted "$resolved_cd"; then
-        export _GUARD_CD_IN_ALLOWLIST=1
-        CWD_IN_ALLOWLIST=1
-      else
-        export _GUARD_CD_IN_ALLOWLIST=0
-        CWD_IN_ALLOWLIST=0
-      fi
-    else
-      export _GUARD_CD_OUTSIDE=0
-      CWD_OUTSIDE_PROJECT=0
-      export _GUARD_CD_IN_ALLOWLIST=0
-      CWD_IN_ALLOWLIST=0
-    fi
+  # --- cd-outside + destructive-cwd walkers (lib/cd_destructive_walker.sh) ---
+  if handle_cd_and_track_outside_context; then
     return 0
   fi
+  block_destructive_in_outside_context
 
-  # Block destructive commands when running outside the project
-  # (either via cd in a chained command, or via cwd from the hook event)
-  local outside_context=0
-  if [[ "${_GUARD_CD_OUTSIDE:-0}" == "1" || "$CWD_OUTSIDE_PROJECT" == "1" ]]; then
-    outside_context=1
-  fi
-  local cwd_in_allowlist=0
-  if [[ "${_GUARD_CD_IN_ALLOWLIST:-0}" == "1" || "${CWD_IN_ALLOWLIST:-0}" == "1" ]]; then
-    cwd_in_allowlist=1
-  fi
+  # --- git destructive walkers (extracted to hooks/lib/git_walkers.sh) ---
+  block_git_C_destructive
+  block_git_worktree_add_outside
 
-  if [[ "$outside_context" == "1" ]]; then
-    # When cwd is in an allowlisted dir, only block TRULY destructive ops
-    # (rm/mv/chmod/chown/find+delete). Write-style commands (tee, curl -o,
-    # wget -O, cp, ln, redirects) must reach their per-command path check
-    # which uses is_write_permitted. Without this split, `cd memory && tee
-    # note.md` would be blocked even though note.md is inside an allowlisted
-    # path. `cp` and `ln` fall into the strict bucket because their own
-    # per-command checks are strict anyway, and bundling them here preserves
-    # earlier behavior.
-    local destructive_cmds
-    if [[ "$cwd_in_allowlist" == "1" ]]; then
-      # In allowlisted cwd, relax only `tee` (per-command check already
-      # validates all non-flag args via is_write_permitted). curl/wget
-      # STAY strict because their validators only cover a subset of
-      # output options (-o/--output and -O/--output-document); the
-      # directory-prefix forms `wget -P` and `curl --output-dir` are
-      # not independently checked, so leaving them open in allowlisted
-      # cwd would allow writes to /etc etc.
-      destructive_cmds="rm|mv|cp|ln|chmod|chown|find|curl|wget"
-    else
-      destructive_cmds="rm|mv|cp|ln|chmod|chown|tee|find|curl|wget"
-    fi
-    if echo "$CMD" | grep -qE "(^|[[:space:]])($destructive_cmds)($|[[:space:]])"; then
-      echo "BLOCKED: Destructive command outside project directory. Ask user for explicit permission." >&2
-      exit 2
-    fi
-    # Destructive git subcommands
-    # git clean only destructive with -f/--force AND without -n/--dry-run
-    if echo "$CMD" | grep -qE '(^|[[:space:]])git[[:space:]]+clean([[:space:]]|$)'; then
-      local has_force=0
-      local is_dry_run=0
-      if echo "$CMD" | grep -qE '(^|[[:space:]])--force([[:space:]]|$)' || \
-         echo "$CMD" | grep -qE '(^|[[:space:]])-[a-zA-Z]*f[a-zA-Z]*([[:space:]]|$)'; then
-        has_force=1
-      fi
-      if echo "$CMD" | grep -qE '(^|[[:space:]])--dry-run([[:space:]]|$)' || \
-         echo "$CMD" | grep -qE '(^|[[:space:]])-[a-zA-Z]*n[a-zA-Z]*([[:space:]]|$)'; then
-        is_dry_run=1
-      fi
-      if [[ "$has_force" == "1" && "$is_dry_run" == "0" ]]; then
-        echo "BLOCKED: Destructive 'git clean' outside project directory. Ask user for explicit permission." >&2
-        exit 2
-      fi
-    fi
-    # git checkout . and git checkout -- .
-    if echo "$CMD" | grep -qE '(^|[[:space:]])git[[:space:]]+checkout([[:space:]]+--)?[[:space:]]+\.([[:space:]]|$)'; then
-      echo "BLOCKED: Destructive 'git checkout .' outside project directory. Ask user for explicit permission." >&2
-      exit 2
-    fi
-    # git reset --hard
-    if echo "$CMD" | grep -qE '(^|[[:space:]])git[[:space:]]+reset[[:space:]]+--hard'; then
-      echo "BLOCKED: Destructive 'git reset --hard' outside project directory. Ask user for explicit permission." >&2
-      exit 2
-    fi
-    # git push --force / -f
-    if echo "$CMD" | grep -qE '(^|[[:space:]])git[[:space:]]+push[[:space:]]+.*(--force|-f)([[:space:]]|$)'; then
-      echo "BLOCKED: Destructive 'git push --force' outside project directory. Ask user for explicit permission." >&2
-      exit 2
-    fi
-    # git restore . / git restore -- . / git restore --worktree .
-    if echo "$CMD" | grep -qE '(^|[[:space:]])git[[:space:]]+restore([[:space:]]+(--worktree|--staged|--))*[[:space:]]+\.([[:space:]]|$)'; then
-      echo "BLOCKED: Destructive 'git restore .' outside project directory. Ask user for explicit permission." >&2
-      exit 2
-    fi
-    # git stash drop / clear
-    if echo "$CMD" | grep -qE '(^|[[:space:]])git[[:space:]]+stash[[:space:]]+(drop|clear)'; then
-      echo "BLOCKED: Destructive 'git stash drop/clear' outside project directory. Ask user for explicit permission." >&2
-      exit 2
-    fi
-    # git branch -D / --delete --force
-    if echo "$CMD" | grep -qE '(^|[[:space:]])git[[:space:]]+branch[[:space:]]+(-D|--delete[[:space:]]+--force)'; then
-      echo "BLOCKED: Destructive 'git branch -D' outside project directory. Ask user for explicit permission." >&2
-      exit 2
-    fi
-    # git reflog expire --all or --expire=now
-    if echo "$CMD" | grep -qE '(^|[[:space:]])git[[:space:]]+reflog[[:space:]]+expire'; then
-      echo "BLOCKED: Destructive 'git reflog expire' outside project directory. Ask user for explicit permission." >&2
-      exit 2
-    fi
-    # Destructive rails/rake subcommands
-    if echo "$CMD" | grep -qE '(^|[[:space:]])(rails|rake)[[:space:]]+db:(drop|reset)'; then
-      echo "BLOCKED: Destructive rails/rake command outside project directory. Ask user for explicit permission." >&2
-      exit 2
-    fi
-  fi
+  # --- Shell / interpreter execution walkers (lib/shell_exec_walkers.sh) ---
+  block_nested_shell_and_eval
+  block_trap_handler
 
-  # --- Block nested shell execution (bash -c, sh -c, eval) ---
-  # Match: bash -c, sh -c, bash -lc, bash -ec, /bin/bash -c, /bin/sh -c, /usr/bin/env bash -c
-  if echo "$CMD" | grep -qE '(^|[[:space:]])(/usr/bin/env[[:space:]]+)?(/bin/)?(bash|sh)[[:space:]]+-[a-zA-Z]*c[[:space:]]'; then
-    echo "BLOCKED: Nested shell execution ('bash -c' / 'sh -c') cannot be safely inspected. Ask user for explicit permission." >&2
-    exit 2
-  fi
-  if echo "$CMD" | grep -qE '(^|[[:space:]])eval[[:space:]]'; then
-    echo "BLOCKED: 'eval' cannot be safely inspected. Ask user for explicit permission." >&2
-    exit 2
-  fi
+  block_interpreter_inline_code
+  block_pipe_to_shell
 
-  # --- Block non-shell interpreters with inline code flags ---
-  # python/perl/ruby/node/php/osascript all accept code on argv. The inner
-  # string cannot be inspected, so the same fail-closed rule as `bash -c`
-  # applies. Flags covered: -c (python), -e (perl/ruby/node), --eval,
-  # --execute, -E (perl alias). A dedicated rule catches `awk 'BEGIN{system(
-  # "…")}'` and similar because awk programs are the first non-option arg,
-  # not behind a flag — so we detect the `system(` marker in the CMD_BLANKED
-  # view (heredoc bodies stripped) so a tee/cat heredoc whose body merely
-  # mentions `python -c`, `awk … system(…)`, etc. is not false-positively
-  # rejected.
-  if echo "$CMD_BLANKED" | grep -qE '(^|[[:space:]])(python|python2|python3|perl|ruby|node|nodejs|deno|bun|php|osascript|Rscript)[[:space:]]+(-[a-zA-Z]*[ceE]|--eval|--execute)([[:space:]]|=|$)'; then
-    echo "BLOCKED: Non-shell interpreter with inline code flag cannot be safely inspected. Ask user for explicit permission." >&2
-    exit 2
-  fi
-  # Dedicated PHP rule — `-r`, `-R`, `--run` execute inline code. Cannot
-  # be added to the shared regex above because `-r` is a module-preload
-  # flag in ruby/node (no code execution), so a generic `r` letter would
-  # false-positive on `ruby -r json` / `node -r dotenv`. The matcher
-  # accepts attached forms (`-rcode`, `-Rcode`), quoted-attached
-  # (`-r'code'`), clustered-ending (`-ar`, `-aR`), and the long alias
-  # `--run`. Attached form was originally missed (guard.sh:1087 regex
-  # required a boundary char immediately after the `[rR]`, so
-  # `-rsystem('x')` slipped past). Re-reported by Copilot review on
-  # commit aa6409b (guard.sh:1068).
-  if echo "$CMD_BLANKED" | grep -qE '(^|[[:space:]])php[[:space:]]+(-[rR][^[:space:]=]*|-[a-zA-Z]*[rR]|--run)([[:space:]]|=|$|'\''|")'; then
-    echo "BLOCKED: 'php -r/-R/--run' inline code cannot be safely inspected. Ask user for explicit permission." >&2
-    exit 2
-  fi
-  if echo "$CMD_BLANKED" | grep -qE '(^|[[:space:]])(g?awk|mawk|nawk)([[:space:]]|$)'; then
-    if echo "$CMD_BLANKED" | grep -qE 'system[[:space:]]*\(|\|[[:space:]]*&?[[:space:]]*"?(sh|bash)'; then
-      echo "BLOCKED: awk program with 'system()' / shell pipe cannot be safely inspected. Ask user for explicit permission." >&2
-      exit 2
-    fi
-  fi
+  block_shell_script_execution
 
-  # --- Block piping to sh/bash (e.g. echo "rm -rf /" | sh) ---
-  # Match bare shell invocations: sh, bash, /bin/sh, /bin/bash,
-  # and with flags: sh -s, bash --login, etc.
-  # But NOT: bash script.sh, bash -x script.sh (running a script file)
-  if echo "$CMD" | grep -qE '^(/bin/)?(sh|bash)$'; then
-    echo "BLOCKED: Piping to 'sh'/'bash' cannot be safely inspected. Ask user for explicit permission." >&2
-    exit 2
-  fi
-  # Match shell with only flags (no script file): sh -s, bash --login, sh -s -- args
-  if echo "$CMD" | grep -qE '^(/bin/)?(sh|bash)[[:space:]]+-'; then
-    # Check if all args are flags (start with -), not a script path
-    local shell_args
-    shell_args=$(echo "$CMD" | sed -E 's/^(\/bin\/)?(sh|bash)[[:space:]]+//')
-    local has_script=0
-    for shell_token in $shell_args; do
-      case "$shell_token" in
-        --) break ;;  # everything after -- is args to the script/stdin
-        -*) continue ;;
-        *) has_script=1; break ;;
-      esac
-    done
-    if [[ $has_script -eq 0 ]]; then
-      echo "BLOCKED: Piping to 'sh'/'bash' cannot be safely inspected. Ask user for explicit permission." >&2
-      exit 2
-    fi
-  fi
+  # --- Neutralise remote-dispatch commands before path walkers run ---
+  # Issue #21. ssh / scp / docker exec / kubectl exec / etc. dispatch
+  # their operands to a remote host or foreign (container/namespace)
+  # filesystem. The boundary plugin protects the LOCAL filesystem, so
+  # those operands must be removed before the cp/tee/rm/redirect/...
+  # walkers run — otherwise a quoted remote command like
+  # `ssh host "docker cp /tmp/x container:/y"` produces a false-positive
+  # block on `/tmp/x` (the cp regex matches the literal ` cp ` inside
+  # the quoted argument). Policy checks earlier in this function
+  # (bash -c, $VAR, $(...), heredoc-fed-shell, script execution) MUST
+  # remain on the original CMD because those events happen LOCALLY,
+  # before ssh / docker ever see the argument string. The rewrite here
+  # only narrows what the path walkers see; CMD_TOKENS / CMD_BLANKED /
+  # CMD_TOKENS_SCAN are regenerated so every detector sees a consistent
+  # view. Generic for the whole class — see hooks/lib/remote_dispatch.sh.
+  CMD=$(rewrite_remote_dispatch "$CMD")
+  CMD_BLANKED=$(rewrite_remote_dispatch "$CMD_BLANKED")
+  fill_tokens_from CMD_TOKENS "$CMD"
+  fill_tokens_from CMD_TOKENS_SCAN "$CMD_BLANKED"
+  # Refresh the verb cache: rewrite_remote_dispatch can drop or rewrite
+  # the wrapper (e.g. `ssh host "rm /etc/x"` becomes `ssh host`), which
+  # changes what command_name_is sees.
+  CMD_VERB=$(_cn_compute_verb_name "$CMD")
 
-  # --- Block executing script files outside the project ---
-  # Catches: `bash /tmp/x.sh`, `sh ~/x.sh`, `zsh|ksh|dash|fish /tmp/x.sh`,
-  # `source /tmp/x.sh`, `. /tmp/x.sh`. Inline-code forms (`bash -c ...`)
-  # are caught by the nested-shell block above; this covers the
-  # complementary case where the script is a path argument.
-  #
-  # STRICT project-root check (no allowlist). Allowlist grants WRITE to
-  # specific paths (e.g. memory/); if execute inherited that, a write-
-  # allowlisted dir would become an RCE escape hatch:
-  #   `echo 'rm -rf $HOME' > memory/x.sh && bash memory/x.sh`.
-  # Walk CMD_TOKENS to locate the shell/source invocation, possibly buried
-  # behind an `env [flags] [VAR=val]*` wrapper. Once found, scan for the
-  # script-path operand — honoring flags that consume the next token
-  # (-O / -o for bash set options). Finally, dereference symlinks on the
-  # script path so a `project/link.sh -> /tmp/evil.sh` bait is caught.
-  # Re-tokenize the command with redirect operators (< << <<< <<-) spaced
-  # out so that attached forms like `bash</tmp/x.sh`, `bash<<EOF`, and
-  # `bash<<<'rm -rf /'` don't slip past as single unsplit tokens.
-  local _exec_cmd
-  _exec_cmd=$(printf '%s' "$CMD" | sed -E 's/(<<-|<<<|<<|<)/ \1 /g')
-  local -a CMD_TOKENS_EXEC=()
-  while IFS= read -r _etok; do
-    [[ -z "$_etok" ]] && continue
-    CMD_TOKENS_EXEC+=("$_etok")
-  done < <(tokenize_args "$_exec_cmd")
-
-  # A parallel token stream built from a heredoc-blanked copy of CMD.
-  # Used ONLY by the `_saw_redir`/`exec_kind` scans below, which otherwise
-  # would treat a quoted-heredoc body byte like "bash" or "source" as a
-  # shell token and false-positive with
-  #   "Stdin redirection feeding shell cannot be safely inspected"
-  # on perfectly innocuous text like a git-commit body mentioning `bash`.
-  # Real shell-stdin attacks (`bash << /tmp/x`, `< /tmp/x bash`,
-  # `bash <<'EOF' ... EOF`, `bash <<<'rm -rf /'`, attached `bash</tmp/x>`)
-  # still appear in this stream because their shell token sits OUTSIDE
-  # any heredoc body, so the fail-closed detectors keep firing.
-  local _exec_cmd_scan
-  _exec_cmd_scan=$(blank_quoted_heredoc_bodies "$CMD" \
-                   | sed -E 's/(<<-|<<<|<<|<)/ \1 /g')
-  local -a CMD_TOKENS_EXEC_SCAN=()
-  while IFS= read -r _etok; do
-    [[ -z "$_etok" ]] && continue
-    CMD_TOKENS_EXEC_SCAN+=("$_etok")
-  done < <(tokenize_args "$_exec_cmd_scan")
-
-  local exec_kind="" exec_shell_idx=-1
-  local _ti=0 _tn=${#CMD_TOKENS_EXEC[@]}
-
-  # Fail-closed on ANY stdin redirect (< << <<< <<-) that appears before
-  # a shell/source token — regardless of leading wrappers or VAR=val.
-  # Bash allows redirections to sit anywhere in the command-prefix, so
-  # `FOO=1 < /tmp/evil.sh bash`, `nice < /tmp/evil.sh bash`, and a bare
-  # `< /tmp/evil.sh bash` all feed the shell from an uninspectable source.
-  local _rk=0 _saw_redir=0
-  local _tn_scan=${#CMD_TOKENS_EXEC_SCAN[@]}
-  while [ $_rk -lt $_tn_scan ]; do
-    local _rtok_chk
-    _rtok_chk=$(strip_quotes "${CMD_TOKENS_EXEC_SCAN[$_rk]}")
-    case "$_rtok_chk" in
-      \<|\<\<|\<\<\<|\<\<-) _saw_redir=1 ;;
-      *)
-        if [ $_saw_redir -eq 1 ] && { is_shell_token "$_rtok_chk" || is_source_token "$_rtok_chk"; }; then
-          echo "BLOCKED: Stdin redirection feeding shell cannot be safely inspected. Ask user for explicit permission." >&2
-          exit 2
-        fi
-        ;;
-    esac
-    _rk=$((_rk + 1))
-  done
-
-  # Fail-closed on `env -S <str>`, `env --split-string=<str>`, `env -C <dir>`,
-  # `env --chdir=<dir>`: all of these either hide the real command inside a
-  # split string or change the cwd so relative script paths no longer match
-  # what Bash actually executes.
-  if [ $_tn -gt 0 ]; then
-    local _env_first
-    _env_first=$(strip_quotes "${CMD_TOKENS_EXEC[0]}")
-    if [[ "$_env_first" == "env" || "$_env_first" == "/usr/bin/env" ]]; then
-      local _envk=1
-      while [ $_envk -lt $_tn ]; do
-        local _envtok
-        _envtok=$(strip_quotes "${CMD_TOKENS_EXEC[$_envk]}")
-        case "$_envtok" in
-          -S|-S*|--split-string|--split-string=*|-C|-C*|--chdir|--chdir=*)
-            echo "BLOCKED: 'env -S/--split-string/-C/--chdir' cannot be safely inspected. Ask user for explicit permission." >&2
-            exit 2 ;;
-        esac
-        _envk=$((_envk + 1))
-      done
-    fi
-  fi
-
-  # Walk past common runtime wrappers (env, command, nice, nohup, timeout,
-  # time, stdbuf, ionice, chrt, taskset) and any leftover sudo flags
-  # (sudo itself is already stripped at the top of check_single_command,
-  # but its own short flags can remain in the token stream as `-E` etc.).
-  # We only advance past token 0 when it is a recognized wrapper or looks
-  # like a flag / VAR=val — this avoids false positives on invocations
-  # like `echo bash`, where `bash` is an argument, not the command.
-  # Categorize the leading token so we know how aggressively to skip.
-  # "env_like" — env / leading flags / leading VAR=val. env has many flag
-  #   and operand forms (-i, -u NAME, FOO=bar), so we skip greedily until
-  #   a shell token appears.
-  # "wrapper" — nice/nohup/timeout/time/command/stdbuf/ionice/chrt/taskset.
-  #   These take at most a few flags + 0–1 positional (e.g. timeout's
-  #   duration). First non-flag non-numeric token is the wrapper's command
-  #   operand — stop there. Avoids false positives like
-  #   `time echo bash /tmp/x` where `bash` is echo's arg, not a shell.
-  # Greedy skip: walk past wrappers / flags / VAR=val / operands until
-  # a shell or source token appears. Known tradeoff — this over-blocks
-  # `time echo bash /tmp/x` (bash is an arg to echo, not a shell), but
-  # precise per-wrapper operand grammars would miss real bypasses like
-  # `timeout -s TERM 10 bash /tmp/x` and `stdbuf -o L bash /tmp/x` where
-  # flag operands are non-numeric. Security over precision for this case.
-  local _advance=0
-  if [ $_tn -gt 0 ]; then
-    local _t0
-    _t0=$(strip_quotes "${CMD_TOKENS_EXEC[0]}")
-    case "$_t0" in
-      env|/usr/bin/env|command|builtin|exec|nice|nohup|timeout|time|stdbuf|ionice|chrt|taskset)
-        _advance=1 ;;
-      -*|+*) _advance=1 ;;
-      *=*) _advance=1 ;;
-    esac
-  fi
-  if [ $_advance -eq 1 ]; then
-    _ti=1
-    while [ $_ti -lt $_tn ]; do
-      local _tok
-      _tok=$(strip_quotes "${CMD_TOKENS_EXEC[$_ti]}")
-      if is_shell_token "$_tok" || is_source_token "$_tok"; then
-        break
-      fi
-      _ti=$((_ti + 1))
-    done
-  fi
-  if [ $_ti -lt $_tn ]; then
-    local _cmd_tok
-    _cmd_tok=$(strip_quotes "${CMD_TOKENS_EXEC[$_ti]}")
-    if is_shell_token "$_cmd_tok"; then
-      exec_kind="shell"; exec_shell_idx=$_ti
-    elif is_source_token "$_cmd_tok"; then
-      exec_kind="source"; exec_shell_idx=$_ti
-    fi
-  fi
-  if [ -n "$exec_kind" ]; then
-    local exec_target=""
-    local ei=$((exec_shell_idx + 1)) en=${#CMD_TOKENS_EXEC[@]}
-    local seen_ddash=0
-    while [ $ei -lt $en ]; do
-      local etok
-      etok=$(strip_quotes "${CMD_TOKENS_EXEC[$ei]}")
-      if [ $seen_ddash -eq 0 ]; then
-        case "$etok" in
-          --) seen_ddash=1; ei=$((ei + 1)); continue ;;
-          # bash/sh -O/+O and -o/+o take the next token as operand
-          -O|+O|-o|+o) ei=$((ei + 2)); continue ;;
-          # Bash accepts both `-x` (enable) and `+x` (disable) forms
-          -*|+*|'') ei=$((ei + 1)); continue ;;
-          # fd prefix for a redirect operator (e.g. `bash 0<file`, `bash 2>&1`).
-          # Skip — the operator itself is handled on the next iteration.
-          [0-9]|[0-9][0-9])
-            ei=$((ei + 1)); continue ;;
-          # Stdin redirection variants: bash executes whatever is piped in.
-          # `<< EOF` / `<<< "str"` content can't be inspected — fail closed.
-          # `< file` — validate `file` as exec target (treat next token as script).
-          \<\<|\<\<-|\<\<\<)
-            echo "BLOCKED: Shell invoked with heredoc/here-string (<<, <<-, <<<) cannot be safely inspected. Ask user for explicit permission." >&2
-            exit 2 ;;
-          \<)
-            ei=$((ei + 1))
-            if [ $ei -lt $en ]; then
-              local _next_tok
-              _next_tok=$(strip_quotes "${CMD_TOKENS_EXEC[$ei]}")
-              # `bash < <(cmd)` — process substitution on stdin is a hidden
-              # command source. Fail closed.
-              case "$_next_tok" in
-                \<|\<\(*|\(*|\&*)
-                  # `< <(cmd)` process substitution, `<(...)` direct, or
-                  # `<&N` fd duplicate — all uninspectable sources.
-                  echo "BLOCKED: Shell stdin from process substitution / fd duplicate cannot be safely inspected. Ask user for explicit permission." >&2
-                  exit 2 ;;
-                *)
-                  exec_target="$_next_tok" ;;
-              esac
-            fi
-            break ;;
-        esac
-      fi
-      exec_target="$etok"
-      break
-    done
-    if [ -n "$exec_target" ]; then
-      exec_target=$(expand_path "$exec_target")
-      if [[ "$exec_target" != /* ]]; then
-        exec_target="$EFFECTIVE_CWD/$exec_target"
-      fi
-      local exec_resolved
-      exec_resolved=$(resolve_path "$exec_target")
-      # Dereference symlinks on the leaf — bash follows them at exec time,
-      # so a project-local symlink pointing outside must be caught.
-      local _exec_depth=20
-      while [[ -L "$exec_resolved" && $_exec_depth -gt 0 ]]; do
-        local _exec_link
-        _exec_link=$(readlink "$exec_resolved")
-        if [[ "$_exec_link" == /* ]]; then
-          exec_resolved=$(resolve_path "$_exec_link")
-        else
-          exec_resolved=$(resolve_path "$(dirname "$exec_resolved")/$_exec_link")
-        fi
-        _exec_depth=$((_exec_depth - 1))
-      done
-      if [[ -L "$exec_resolved" ]]; then
-        echo "BLOCKED: Script symlink chain too deep or circular at '$exec_resolved'. Ask user for explicit permission." >&2
-        exit 2
-      fi
-      if [[ "$exec_resolved/" != "$PROJECT_DIR/"* ]]; then
-        echo "BLOCKED: Executing script '$exec_resolved' is OUTSIDE project directory '$PROJECT_DIR'. Allowlist does not cover execute. Ask user for explicit permission." >&2
-        exit 2
-      fi
-    fi
-  fi
+  # --- Validate argument-as-command flag values recursively ---
+  # Tools like `tar --to-command=<cmd>` / `rsync -e <cmd>` /
+  # `git -c <exec-key>=<cmd>` execute the flag value as a local shell
+  # command. The walkers below only see flag NAMES — not VALUES — so a
+  # destructive payload would slip past them. Extract every recognised
+  # payload from this (post-split) subcommand and dispatch it through
+  # check_single_command recursively, reusing the entire detector
+  # pipeline. Generic for the whole class — see hooks/lib/subcmd_flags.sh.
+  local _sf_payload
+  while IFS= read -r _sf_payload; do
+    [ -n "$_sf_payload" ] && check_single_command "$_sf_payload"
+  done < <(extract_subcmd_flag_payloads "$_CMD_PRE_STRIP")
 
   # xargs, find-delete, rm, mv, cp, ln moved to hooks/lib/detectors/destructive.sh.
   run_destructive_detectors
 
 
-  # install, rsync, tar, unzip, cpio, tee, curl, wget, dd, redirect
-  # moved to hooks/lib/detectors/write_targets.sh.
+  # install, rsync, tar, unzip, cpio, archive: write_targets.sh.
+  # Domain splits of the former write_targets_b.sh:
+  #   download.sh           — curl -o / wget -O
+  #   redirects.sh          — tee, dd of=, `>` catch-all
+  #   db_dump.sh            — pg_dump -f, psql -o/-L/-c, mysql --tee, mysqldump
+  #   filesystem_create.sh  — mktemp -p, mkfifo, mknod
   run_write_target_detectors
+  run_download_detectors
+  run_redirect_detectors
+  run_db_dump_detectors
+  run_filesystem_create_detectors
 
 
   # sed -i / truncate detectors moved to hooks/lib/detectors/inplace.sh.

--- a/plugins/project-boundary/hooks/lib/cd_destructive_walker.sh
+++ b/plugins/project-boundary/hooks/lib/cd_destructive_walker.sh
@@ -1,0 +1,174 @@
+# shellcheck shell=bash
+# project-boundary guard — cd-outside + destructive-cwd walkers
+# ==============================================================
+# Two functions extracted from hooks/guard.sh check_single_command:
+#
+#   handle_cd_and_track_outside_context
+#       Recognises `cd <path>` invocations, normalises the path, and
+#       updates EFFECTIVE_CWD + the _GUARD_CD_OUTSIDE / _GUARD_CD_IN_
+#       ALLOWLIST cross-call flags so that the next command in a
+#       chain (`cd memory && tee note.md`) can pick up the new cwd.
+#       Returns 0 when this was a `cd` invocation (caller should
+#       return), 1 otherwise.
+#
+#   block_destructive_in_outside_context
+#       Fires when EFFECTIVE_CWD is outside the project (either via
+#       cd in a chained command or via cwd from the hook event).
+#       Blocks the bare-name destructive verbs (rm, mv, cp, ln,
+#       chmod, chown, find, curl, wget; tee outside allowlisted cwd)
+#       and the destructive git subcommands (clean -f / reset --hard
+#       / checkout . / push --force / restore . / stash drop /
+#       branch -D / reflog expire) plus rails/rake db:drop|reset.
+#       No return signal needed — `exit 2` on any violation.
+#
+# Both read CMD / EFFECTIVE_CWD / PROJECT_DIR / CWD_OUTSIDE_PROJECT /
+# CWD_IN_ALLOWLIST from caller's dynamic scope and may set/export
+# _GUARD_CD_OUTSIDE / _GUARD_CD_IN_ALLOWLIST. Helpers (expand_path,
+# resolve_path, is_inside_project, is_allowlisted) come from sibling
+# modules.
+
+handle_cd_and_track_outside_context() {
+  if ! [[ "$CMD" =~ ^cd($|[[:space:]]) ]]; then
+    return 1
+  fi
+
+  local cd_target
+  # cd takes a single argument, so grab everything after 'cd ' as the
+  # target (including spaces if quoted). Not using tokenize_args because
+  # cd doesn't take multiple path arguments.
+  cd_target=$(echo "$CMD" | sed 's/^cd[[:space:]]*//')
+  # cd with no args or cd ~ goes to $HOME
+  if [[ -z "$cd_target" || "$cd_target" == "~" ]]; then
+    cd_target="$HOME"
+  else
+    cd_target=$(expand_path "$cd_target")
+  fi
+  if [[ "$cd_target" != /* ]]; then
+    cd_target="$EFFECTIVE_CWD/$cd_target"
+  fi
+  local resolved_cd
+  resolved_cd=$(resolve_path "$cd_target")
+  EFFECTIVE_CWD="$resolved_cd"
+  # STRICT: cd-outside triggers the destructive-subcommand guard.
+  # Allowlist must not weaken this — `cd memory && git clean -fd` should
+  # still block. But write-style commands (`cd memory && tee note.md`)
+  # should reach their per-command is_write_permitted check, so we track
+  # allowlist-context in a separate flag.
+  if ! is_inside_project "$resolved_cd"; then
+    export _GUARD_CD_OUTSIDE=1
+    CWD_OUTSIDE_PROJECT=1
+    if is_allowlisted "$resolved_cd"; then
+      export _GUARD_CD_IN_ALLOWLIST=1
+      CWD_IN_ALLOWLIST=1
+    else
+      export _GUARD_CD_IN_ALLOWLIST=0
+      CWD_IN_ALLOWLIST=0
+    fi
+  else
+    export _GUARD_CD_OUTSIDE=0
+    CWD_OUTSIDE_PROJECT=0
+    export _GUARD_CD_IN_ALLOWLIST=0
+    CWD_IN_ALLOWLIST=0
+  fi
+  return 0
+}
+
+block_destructive_in_outside_context() {
+  # Block destructive commands when running outside the project
+  # (either via cd in a chained command, or via cwd from the hook event).
+  local outside_context=0
+  if [[ "${_GUARD_CD_OUTSIDE:-0}" == "1" || "$CWD_OUTSIDE_PROJECT" == "1" ]]; then
+    outside_context=1
+  fi
+  local cwd_in_allowlist=0
+  if [[ "${_GUARD_CD_IN_ALLOWLIST:-0}" == "1" || "${CWD_IN_ALLOWLIST:-0}" == "1" ]]; then
+    cwd_in_allowlist=1
+  fi
+
+  [[ "$outside_context" != "1" ]] && return 0
+
+  # When cwd is in an allowlisted dir, only block TRULY destructive ops
+  # (rm/mv/chmod/chown/find+delete). Write-style commands (tee, curl -o,
+  # wget -O, cp, ln, redirects) must reach their per-command path check
+  # which uses is_write_permitted. Without this split, `cd memory && tee
+  # note.md` would be blocked even though note.md is inside an allowlisted
+  # path. `cp` and `ln` fall into the strict bucket because their own
+  # per-command checks are strict anyway, and bundling them here preserves
+  # earlier behavior.
+  local destructive_cmds
+  if [[ "$cwd_in_allowlist" == "1" ]]; then
+    # In allowlisted cwd, relax only `tee` (per-command check already
+    # validates all non-flag args via is_write_permitted). curl/wget
+    # STAY strict because their validators only cover a subset of
+    # output options (-o/--output and -O/--output-document); the
+    # directory-prefix forms `wget -P` and `curl --output-dir` are
+    # not independently checked, so leaving them open in allowlisted
+    # cwd would allow writes to /etc etc.
+    destructive_cmds="rm|mv|cp|ln|chmod|chown|find|curl|wget"
+  else
+    destructive_cmds="rm|mv|cp|ln|chmod|chown|tee|find|curl|wget"
+  fi
+  if echo "$CMD" | grep -qE "(^|[[:space:]])($destructive_cmds)($|[[:space:]])"; then
+    echo "BLOCKED: Destructive command outside project directory. Ask user for explicit permission." >&2
+    exit 2
+  fi
+
+  # Destructive git subcommands.
+  # git clean only destructive with -f/--force AND without -n/--dry-run.
+  if echo "$CMD" | grep -qE '(^|[[:space:]])git[[:space:]]+clean([[:space:]]|$)'; then
+    local has_force=0
+    local is_dry_run=0
+    if echo "$CMD" | grep -qE '(^|[[:space:]])--force([[:space:]]|$)' || \
+       echo "$CMD" | grep -qE '(^|[[:space:]])-[a-zA-Z]*f[a-zA-Z]*([[:space:]]|$)'; then
+      has_force=1
+    fi
+    if echo "$CMD" | grep -qE '(^|[[:space:]])--dry-run([[:space:]]|$)' || \
+       echo "$CMD" | grep -qE '(^|[[:space:]])-[a-zA-Z]*n[a-zA-Z]*([[:space:]]|$)'; then
+      is_dry_run=1
+    fi
+    if [[ "$has_force" == "1" && "$is_dry_run" == "0" ]]; then
+      echo "BLOCKED: Destructive 'git clean' outside project directory. Ask user for explicit permission." >&2
+      exit 2
+    fi
+  fi
+  # git checkout . and git checkout -- .
+  if echo "$CMD" | grep -qE '(^|[[:space:]])git[[:space:]]+checkout([[:space:]]+--)?[[:space:]]+\.([[:space:]]|$)'; then
+    echo "BLOCKED: Destructive 'git checkout .' outside project directory. Ask user for explicit permission." >&2
+    exit 2
+  fi
+  # git reset --hard
+  if echo "$CMD" | grep -qE '(^|[[:space:]])git[[:space:]]+reset[[:space:]]+--hard'; then
+    echo "BLOCKED: Destructive 'git reset --hard' outside project directory. Ask user for explicit permission." >&2
+    exit 2
+  fi
+  # git push --force / -f
+  if echo "$CMD" | grep -qE '(^|[[:space:]])git[[:space:]]+push[[:space:]]+.*(--force|-f)([[:space:]]|$)'; then
+    echo "BLOCKED: Destructive 'git push --force' outside project directory. Ask user for explicit permission." >&2
+    exit 2
+  fi
+  # git restore . / git restore -- . / git restore --worktree .
+  if echo "$CMD" | grep -qE '(^|[[:space:]])git[[:space:]]+restore([[:space:]]+(--worktree|--staged|--))*[[:space:]]+\.([[:space:]]|$)'; then
+    echo "BLOCKED: Destructive 'git restore .' outside project directory. Ask user for explicit permission." >&2
+    exit 2
+  fi
+  # git stash drop / clear
+  if echo "$CMD" | grep -qE '(^|[[:space:]])git[[:space:]]+stash[[:space:]]+(drop|clear)'; then
+    echo "BLOCKED: Destructive 'git stash drop/clear' outside project directory. Ask user for explicit permission." >&2
+    exit 2
+  fi
+  # git branch -D / --delete --force
+  if echo "$CMD" | grep -qE '(^|[[:space:]])git[[:space:]]+branch[[:space:]]+(-D|--delete[[:space:]]+--force)'; then
+    echo "BLOCKED: Destructive 'git branch -D' outside project directory. Ask user for explicit permission." >&2
+    exit 2
+  fi
+  # git reflog expire --all or --expire=now
+  if echo "$CMD" | grep -qE '(^|[[:space:]])git[[:space:]]+reflog[[:space:]]+expire'; then
+    echo "BLOCKED: Destructive 'git reflog expire' outside project directory. Ask user for explicit permission." >&2
+    exit 2
+  fi
+  # Destructive rails/rake subcommands.
+  if echo "$CMD" | grep -qE '(^|[[:space:]])(rails|rake)[[:space:]]+db:(drop|reset)'; then
+    echo "BLOCKED: Destructive rails/rake command outside project directory. Ask user for explicit permission." >&2
+    exit 2
+  fi
+}

--- a/plugins/project-boundary/hooks/lib/command_name.sh
+++ b/plugins/project-boundary/hooks/lib/command_name.sh
@@ -10,6 +10,129 @@
 # command_name_is reads a CMD variable from its caller's dynamic
 # scope; other functions are pure.
 
+# --- command_name_matches PATTERN ---
+# Like command_name_is but accepts a pipe-separated list of names so a
+# detector that fires for any of several aliases (e.g. "perl|ruby" or
+# "7z|7za|7zr|7zz|7zzs") gets one anchored gate instead of a raw
+# `echo "$CMD" | grep -qE` substring match. Reads CMD from caller's
+# dynamic scope (same contract as command_name_is).
+#
+# Returns 0 iff command_name_is matches any of the alternatives.
+command_name_matches() {
+  local pattern="$1"
+  local IFS='|'
+  local -a _cn_cmds=($pattern)
+  unset IFS
+  local _cn_c
+  for _cn_c in "${_cn_cmds[@]}"; do
+    command_name_is "$_cn_c" && return 0
+  done
+  return 1
+}
+
+# --- normalize_command_view INPUT ---
+# Apply the full command-view normalization pipeline used by guard.sh
+# for both the live CMD and the heredoc-blanked CMD_BLANKED:
+#   1. trim leading/trailing whitespace
+#   2. strip subshell grouping `(...)` parens at token boundaries
+#      (preserve `$(...)` substitution form)
+#   3. strip alias-escape backslash before [a-zA-Z_]
+#   4. strip surrounding quotes from the command-name token
+#   5. strip common binary-path prefixes from the leading `/usr/bin/...`
+#      / `/opt/homebrew/bin/...` form (fallback for empty tokenizer)
+#   6. apply strip_command_name_prefix (post-wrapper aware)
+#   7. collapse duplicated whitespace
+#
+# Extracted from guard.sh in the round-5 refactor. Both CMD and
+# CMD_BLANKED now go through the same pipeline so a fix to any
+# normalization step (e.g. adding `/opt/homebrew/bin` to the prefix
+# list) lands in both views simultaneously.
+normalize_command_view() {
+  local view="$1"
+  view="$(printf '%s' "$view" | sed 's/^[[:space:]]*//' | sed 's/[[:space:]]*$//')"
+  view="$(printf '%s' "$view" | sed -E 's/(^|[[:space:]])\(+/\1/g; s/\)+($|[[:space:]])/\1/g')"
+  view="$(printf '%s' "$view" | sed -E 's/\\([a-zA-Z_])/\1/g')"
+  view="$(strip_command_name_quotes "$view")"
+  view="$(printf '%s' "$view" | sed -E 's#^/(usr/local/bin|usr/bin|bin|sbin|usr/sbin|opt/homebrew/bin)/##')"
+  view="$(strip_command_name_prefix "$view")"
+  printf '%s' "$view" | sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//'
+}
+
+# --- Strip /bin/, /sbin/, /usr/bin/, /usr/sbin/, /usr/local/bin/, ---
+# /opt/homebrew/bin/ prefix from a command-name token. The Homebrew
+# entry is required because Apple Silicon brews default to
+# /opt/homebrew/bin and command_name_is checks would otherwise miss
+# every Homebrew-installed binary (Codex round-5 P1).
+_cn_strip_path_prefix() {
+  local n="$1"
+  case "$n" in
+    /bin/*|/sbin/*|/usr/bin/*|/usr/sbin/*|/usr/local/bin/*|/opt/homebrew/bin/*) printf '%s' "${n##*/}" ;;
+    *) printf '%s' "$n" ;;
+  esac
+}
+
+# --- Find verb-token index in a tokens array, skipping wrappers / opts / VAR=val ---
+# Caller fills the local-scope `toks` array before calling. Returns the
+# 0-based index of the first non-wrapper / non-flag / non-VAR=val token,
+# or -1 if no such token exists. Skip rules:
+#
+#   - Recognised wrappers (sudo / env / nice / nohup / time / stdbuf /
+#     ionice / chrt / taskset / command / builtin / exec / timeout /
+#     /bin/env / /usr/bin/env) advance one position; the next iteration
+#     also skips a per-wrapper option-with-value pair (e.g. `-u USER`
+#     for sudo / env, `-k DUR` for timeout) when the value would
+#     otherwise be mis-identified as the verb.
+#   - `timeout` additionally takes a duration operand (`5`, `5s`,
+#     `1.5h`, `infinity`) which is consumed as a single positional.
+#   - `[A-Za-z_]*=*` (env-var prefix) and bare `-*` flags are skipped
+#     one at a time.
+#
+# Reads the caller's `toks` array via dynamic scoping (bash `local`
+# semantics); CALLERS MUST declare `local -a toks=()` before invoking.
+_cn_find_verb_idx() {
+  local i=0 n=${#toks[@]}
+  local prev_was_timeout=0 last_wrapper=""
+  while [ $i -lt $n ]; do
+    local raw="${toks[$i]}" t
+    t=$(strip_quotes "$raw")
+
+    # Wrapper opt-with-value: if the previous wrapper had options
+    # that consume the next token, advance past both the flag and
+    # its value. Without this, `sudo -u root install …` mis-
+    # identifies `root` as the verb (Codex round-4 follow-up on
+    # PR #23; same root cause as section 40's _sf_find_verb_idx fix).
+    if [ -n "$last_wrapper" ]; then
+      local opts; opts=$(_wrapper_opts_with_val "$last_wrapper")
+      if [ -n "$opts" ]; then
+        case " $opts " in
+          *" $t "*) i=$((i + 2)); continue ;;
+        esac
+      fi
+    fi
+
+    if [ $prev_was_timeout -eq 1 ]; then
+      prev_was_timeout=0
+      case "$t" in
+        [0-9]*|inf*) i=$((i + 1)); continue ;;
+      esac
+    fi
+    case "$t" in
+      timeout)
+        prev_was_timeout=1; last_wrapper="timeout"; i=$((i + 1)); continue ;;
+      sudo|env|/bin/env|/usr/bin/env|nice|nohup|time|stdbuf|ionice|chrt|taskset|command|builtin|exec)
+        last_wrapper=$(_cn_strip_path_prefix "$t")
+        i=$((i + 1)); continue ;;
+    esac
+    case "$t" in
+      [A-Za-z_]*=*) i=$((i + 1)); continue ;;
+      -*) i=$((i + 1)); continue ;;
+    esac
+    printf '%d' "$i"
+    return
+  done
+  printf -- '-1'
+}
+
 # --- Strip a binary path prefix from the command-name token ---
 # Strip a binary path prefix (/bin/, /sbin/, /usr/bin/, /usr/sbin/,
 # /usr/local/bin/) from the command-name token of CMD only — not from
@@ -32,40 +155,14 @@ strip_command_name_prefix() {
     toks+=("$t")
   done < <(tokenize_args "$cmd")
 
-  local idx=-1 i
-  local prev_was_timeout=0
-  for i in "${!toks[@]}"; do
-    local raw="${toks[$i]}"
-    local t
-    t=$(strip_quotes "$raw")
-    # `timeout` takes a duration operand (e.g. `timeout 5 cmd`,
-    # `timeout 1.5s cmd`); skip one extra token after it.
-    if [ $prev_was_timeout -eq 1 ]; then
-      prev_was_timeout=0
-      case "$t" in
-        [0-9]*) continue ;;
-      esac
-    fi
-    case "$t" in
-      timeout)
-        prev_was_timeout=1; continue ;;
-      sudo|env|/bin/env|/usr/bin/env|nice|nohup|time|stdbuf|ionice|chrt|taskset|command|builtin|exec)
-        continue ;;
-    esac
-    case "$t" in
-      [A-Za-z_]*=*) continue ;;
-      -*) continue ;;
-    esac
-    idx=$i
-    break
-  done
-
-  [[ $idx -lt 0 ]] && { printf '%s' "$cmd"; return; }
+  local idx
+  idx=$(_cn_find_verb_idx)
+  [ "$idx" -lt 0 ] && { printf '%s' "$cmd"; return; }
 
   local first
   first=$(strip_quotes "${toks[$idx]}")
   case "$first" in
-    /bin/*|/sbin/*|/usr/bin/*|/usr/sbin/*|/usr/local/bin/*) ;;
+    /bin/*|/sbin/*|/usr/bin/*|/usr/sbin/*|/usr/local/bin/*|/opt/homebrew/bin/*) ;;
     *) printf '%s' "$cmd"; return ;;
   esac
 
@@ -92,7 +189,6 @@ strip_command_name_quotes() {
   # (rm, mv, cp, ln, chmod, chown, tee, curl, wget, find, sed,
   # truncate, rsync) past the guard. Walks tokens using the same
   # wrapper / env-var / flag skipping rules as strip_command_name_prefix.
-  # Reported by Copilot review on commit 22112ba (guard.sh:1078, 1503).
   local cmd="$1"
   local -a toks=()
   while IFS= read -r t; do
@@ -100,32 +196,9 @@ strip_command_name_quotes() {
     toks+=("$t")
   done < <(tokenize_args "$cmd")
 
-  local idx=-1 i prev_was_timeout=0
-  for i in "${!toks[@]}"; do
-    local raw="${toks[$i]}"
-    local t
-    t=$(strip_quotes "$raw")
-    if [ $prev_was_timeout -eq 1 ]; then
-      prev_was_timeout=0
-      case "$t" in
-        [0-9]*) continue ;;
-      esac
-    fi
-    case "$t" in
-      timeout)
-        prev_was_timeout=1; continue ;;
-      sudo|env|/bin/env|/usr/bin/env|nice|nohup|time|stdbuf|ionice|chrt|taskset|command|builtin|exec)
-        continue ;;
-    esac
-    case "$t" in
-      [A-Za-z_]*=*) continue ;;
-      -*) continue ;;
-    esac
-    idx=$i
-    break
-  done
-
-  [[ $idx -lt 0 ]] && { printf '%s' "$cmd"; return; }
+  local idx
+  idx=$(_cn_find_verb_idx)
+  [ "$idx" -lt 0 ] && { printf '%s' "$cmd"; return; }
 
   local raw="${toks[$idx]}"
   # Only rewrite when the raw token is itself surrounded by matching
@@ -152,56 +225,264 @@ strip_command_name_quotes() {
 
 command_name_is() {
   # Return 0 iff the post-wrapper command-name token of $CMD equals $1.
-  # Walks $CMD tokens using the same rules as strip_command_name_prefix:
-  # skip `timeout <dur>`, sudo/env/nice/nohup/time/stdbuf/ionice/chrt/
-  # taskset/command/builtin/exec wrappers, VAR=val environment prefixes
-  # and -flag tokens. Any /bin/, /sbin/, /usr/bin/, /usr/sbin/,
-  # /usr/local/bin/ prefix on the command-name token is stripped before
-  # comparison, so `/usr/bin/install` is recognised as `install`.
+  # Reads CMD_VERB from the caller's dynamic scope when available — set
+  # by check_single_command after CMD normalisation and refreshed after
+  # remote_dispatch rewrite, so every detector inside that pipeline gets
+  # an O(1) string compare instead of a per-call tokenize-and-walk
+  # (Codex round-5 finding #3; ~64 call sites per command).
   #
-  # Why: several detectors (install, rsync, ...) use a bare
-  # `(^|[[:space:]])CMDNAME($|[[:space:]])` regex that matches the
-  # word anywhere in the command. For common names that are also
-  # package-manager subcommands (npm install / bundle install /
-  # poetry install / etc.) this produces false positives. Use this
-  # helper to require the actual command-name position.
+  # When CMD_VERB is unset (test harnesses or callers outside the main
+  # check_single_command pipeline), falls back to the tokenize-and-walk
+  # path — same logic as strip_command_name_prefix:
+  #   skip `timeout <dur>`, sudo/env/nice/nohup/time/stdbuf/ionice/chrt/
+  #   taskset/command/builtin/exec wrappers (and their option-with-value
+  #   pairs like `-u USER`, `-k DUR`), VAR=val environment prefixes,
+  #   and -flag tokens. Any /bin/, /sbin/, /usr/bin/, /usr/sbin/,
+  #   /usr/local/bin/, /opt/homebrew/bin/ prefix is stripped before
+  #   comparison.
   #
-  # IMPORTANT: reads $CMD from the caller's dynamic scope (bash
-  # `local` semantics). Callers MUST run inside check_single_command
-  # (or any other context that has a local CMD in scope).
+  # Why bare-name regex isn't enough: several detectors (install, rsync,
+  # ...) match a verb anywhere in CMD; that false-positives on package-
+  # manager subcommands like `npm install` / `bundle install`. This
+  # helper requires the actual command-name position.
   local target=$1
+  if [ -n "${CMD_VERB-}" ]; then
+    [ "$CMD_VERB" = "$target" ]
+    return
+  fi
   local -a toks=()
   while IFS= read -r t; do
     [[ -z "$t" ]] && continue
     toks+=("$t")
   done < <(tokenize_args "$CMD")
-  local i prev_was_timeout=0
-  for i in "${!toks[@]}"; do
+
+  local idx
+  idx=$(_cn_find_verb_idx)
+  [ "$idx" -lt 0 ] && return 1
+
+  local t
+  t=$(strip_quotes "${toks[$idx]}")
+  t=$(_cn_strip_path_prefix "$t")
+  [ "$t" = "$target" ]
+}
+
+# --- Compute the post-normalisation verb name for a command string ---
+# Tokenises once, walks _cn_find_verb_idx, strips any binary-path
+# prefix. Returns empty when no verb is recognised. Used by
+# check_single_command to fill the CMD_VERB cache that command_name_is
+# reads on every call. Cheaper than calling command_name_is once per
+# detector — collapses the per-detector tokenize work into a single
+# pass per command (and one refresh after remote_dispatch rewrite).
+_cn_compute_verb_name() {
+  local cmd="$1"
+  local -a toks=()
+  local _t
+  while IFS= read -r _t; do
+    [[ -z "$_t" ]] && continue
+    toks+=("$_t")
+  done < <(tokenize_args "$cmd")
+  local idx
+  idx=$(_cn_find_verb_idx)
+  [ "$idx" -lt 0 ] && return
+  local verb
+  verb=$(strip_quotes "${toks[$idx]}")
+  verb=$(_cn_strip_path_prefix "$verb")
+  printf '%s' "$verb"
+}
+
+# --- Strip leading `sudo` plus its option-with-value pairs from CMD ---
+# Replaces the literal `${CMD#sudo }` strip in check_single_command.
+# Without opt-stripping, `sudo -u root install …` collapsed to
+# `-u root install …` — the orphaned `-u root` then mis-led the
+# wrapper-walk in strip_command_name_prefix / strip_command_name_quotes /
+# command_name_is (sudo is no longer in the token list to anchor to,
+# so `root` was treated as the verb). env / nice / ionice / timeout
+# are NOT literal-stripped, so the per-wrapper opt-skip in
+# _cn_find_verb_idx handles those wrappers in place.
+#
+# Walks past sudo + its option-with-value pairs (-u USER, --user=USER,
+# -g GROUP, etc.), value-less short and long flags (-n, --background,
+# etc.), and emits the rest of CMD starting at the first positional.
+# tokenize_args preserves quote bytes, so reconstruction with single-
+# space joins keeps quoted operands intact (whitespace inside the
+# command is normalised in the next pass anyway — guard.sh:280).
+strip_sudo_wrapper_with_opts() {
+  local cmd="$1"
+  case "$cmd" in
+    sudo|sudo[[:space:]]*) ;;
+    *) printf '%s' "$cmd"; return ;;
+  esac
+
+  local -a toks=()
+  while IFS= read -r t; do
+    [[ -z "$t" ]] && continue
+    toks+=("$t")
+  done < <(tokenize_args "$cmd")
+
+  # toks[0] is "sudo" (or absent if cmd was bare "sudo"). Walk past
+  # sudo's option-with-value pairs and value-less flags. The value-
+  # bearing list MUST exactly match sudo's "takes-an-argument" set;
+  # mis-classifying a value-less flag (`-A`, `-K`, `-k`,
+  # `--preserve-env`, `--login`, `--shell`, etc.) consumes the real
+  # verb as the flag's value and reopens the bypass this PR closes.
+  # Codex round-1 P1 on PR #24.
+  local i=1 n=${#toks[@]}
+  while [ $i -lt $n ]; do
     local raw="${toks[$i]}" t
     t=$(strip_quotes "$raw")
-    if [ $prev_was_timeout -eq 1 ]; then
+    case "$t" in
+      -a|-c|-C|-D|-g|-h|-p|-R|-r|-t|-T|-U|-u)
+        i=$((i + 2)); continue ;;
+      --auth-type|--chdir|--chroot|--close-from|--command-timeout|--group|--host|--login-class|--other-user|--prompt|--role|--type|--user)
+        i=$((i + 2)); continue ;;
+      --*=*)
+        i=$((i + 1)); continue ;;
+      -*)
+        i=$((i + 1)); continue ;;
+      *) break ;;
+    esac
+  done
+
+  local out=""
+  while [ $i -lt $n ]; do
+    if [ -z "$out" ]; then
+      out="${toks[$i]}"
+    else
+      out="$out ${toks[$i]}"
+    fi
+    i=$((i + 1))
+  done
+  printf '%s' "$out"
+}
+
+# --- Detect a shell-opening sudo invocation ---
+# Returns 0 (success) iff the input describes a sudo invocation that
+# would open a privileged interactive shell with no command operand
+# to inspect. Recognised shapes:
+#
+#   sudo -i / sudo -s / sudo --login / sudo --shell      (standalone)
+#   sudo "-i" / sudo '-i' / sudo "--login"                (quoted —
+#                                                          tokenize_args
+#                                                          preserves quote
+#                                                          bytes; strip_quotes
+#                                                          unwraps them)
+#   sudo -ni / sudo -in / sudo -nis / sudo -A -ni         (clustered short
+#                                                          flags; sudo accepts
+#                                                          a cluster like -nis
+#                                                          for -n -i -s)
+#   <wrapper> [opts] sudo <any of the above>              (env / nice /
+#                                                          timeout / ionice /
+#                                                          chrt / nohup / time
+#                                                          / stdbuf / taskset /
+#                                                          command / builtin /
+#                                                          exec wrapping sudo)
+#
+# Returns 1 if no shell-opening sudo is detected — bare `sudo`,
+# `sudo -l` / `-V` / `-v`, `sudo -i extra-cmd` (cmd is what runs,
+# detectors walk it), and any non-sudo invocation.
+#
+# Called from check_single_command BEFORE the sudo strip so the
+# original wrapper + sudo + flag layout is still visible in the
+# token list. Reported by Codex review rounds 2–3 on PR #24.
+_cn_is_sudo_shell_opener() {
+  local cmd="$1"
+  local -a toks=()
+  while IFS= read -r t; do
+    [[ -z "$t" ]] && continue
+    toks+=("$t")
+  done < <(tokenize_args "$cmd")
+
+  local n=${#toks[@]}
+  [ "$n" -eq 0 ] && return 1
+
+  # Phase 1: walk past outer wrappers + their opt-with-value pairs.
+  # Mirrors _cn_find_verb_idx but stops on `sudo` (we're hunting
+  # specifically for sudo here, not for the verb in general). A non-
+  # wrapper non-flag token before `sudo` means the cmd isn't a
+  # sudo-shell-opener at all.
+  local i=0
+  local prev_was_timeout=0 last_wrapper=""
+  while [ "$i" -lt "$n" ]; do
+    local raw="${toks[$i]}" t
+    t=$(strip_quotes "$raw")
+
+    if [ -n "$last_wrapper" ]; then
+      local opts; opts=$(_wrapper_opts_with_val "$last_wrapper")
+      if [ -n "$opts" ]; then
+        case " $opts " in
+          *" $t "*) i=$((i + 2)); continue ;;
+        esac
+      fi
+    fi
+
+    if [ "$prev_was_timeout" -eq 1 ]; then
       prev_was_timeout=0
       case "$t" in
-        [0-9]*) continue ;;
+        [0-9]*|inf*) i=$((i + 1)); continue ;;
       esac
     fi
     case "$t" in
       timeout)
-        prev_was_timeout=1; continue ;;
-      sudo|env|/bin/env|/usr/bin/env|nice|nohup|time|stdbuf|ionice|chrt|taskset|command|builtin|exec)
-        continue ;;
+        prev_was_timeout=1; last_wrapper="timeout"; i=$((i + 1)); continue ;;
+      env|/bin/env|/usr/bin/env|nice|nohup|time|stdbuf|ionice|chrt|taskset|command|builtin|exec)
+        last_wrapper=$(_cn_strip_path_prefix "$t")
+        i=$((i + 1)); continue ;;
+      sudo)
+        break ;;
     esac
     case "$t" in
-      [A-Za-z_]*=*) continue ;;
-      -*) continue ;;
+      [A-Za-z_]*=*) i=$((i + 1)); continue ;;
+      -*) i=$((i + 1)); continue ;;
     esac
-    case "$t" in
-      /bin/*|/sbin/*|/usr/bin/*|/usr/sbin/*|/usr/local/bin/*) t="${t##*/}" ;;
-    esac
-    [ "$t" = "$target" ]
-    return
+    return 1
   done
-  return 1
+
+  # No `sudo` token found in the wrapper-walk segment.
+  [ "$i" -ge "$n" ] && return 1
+
+  # Phase 2: walk sudo's flags. Track whether we saw a shell-opening
+  # flag. A positional non-flag token after sudo means it has a real
+  # command (cmd is what runs even with -i/-s; detectors walk it).
+  i=$((i + 1))
+  local found_shell_opener=0
+  while [ "$i" -lt "$n" ]; do
+    local raw="${toks[$i]}" t
+    t=$(strip_quotes "$raw")
+    case "$t" in
+      -i|-s|--login|--shell)
+        found_shell_opener=1
+        i=$((i + 1)); continue ;;
+      -a|-c|-C|-D|-g|-h|-p|-R|-r|-t|-T|-U|-u)
+        i=$((i + 2)); continue ;;
+      --auth-type|--chdir|--chroot|--close-from|--command-timeout|--group|--host|--login-class|--other-user|--prompt|--role|--type|--user)
+        i=$((i + 2)); continue ;;
+      --*=*)
+        i=$((i + 1)); continue ;;
+      -[A-Za-z]*)
+        # Clustered short flags. Sudo accepts -nis as the cluster of
+        # -n -i -s; if the cluster body contains `i` or `s`, the
+        # invocation opens a shell. Long-form `--*=*` was already
+        # handled above; this branch only fires for short clusters.
+        local body="${t#-}"
+        case "$body" in
+          *i*|*s*) found_shell_opener=1 ;;
+        esac
+        i=$((i + 1)); continue ;;
+      -*)
+        # Long-form valueless flags (`--preserve-env`, `--background`,
+        # `--non-interactive`, `--set-home`, `--remove-timestamp`, ...)
+        # don't match `--*=*` (no `=`) nor `-[A-Za-z]*` (start with
+        # `--`). Without this catch-all they fall through to `*` and
+        # the helper bails before seeing the trailing `-i`/`-s` —
+        # bypass: `sudo --preserve-env -i`. Mirrors strip_sudo_wrapper_with_opts.
+        i=$((i + 1)); continue ;;
+      *)
+        # Positional verb after sudo — detectors walk it normally.
+        return 1 ;;
+    esac
+  done
+
+  [ "$found_shell_opener" -eq 1 ]
 }
 
 # --- Detect shell/source tokens by basename (handles any absolute path) ---
@@ -212,7 +493,7 @@ is_shell_token() {
   local _t="$1"
   local _base="${_t##*/}"
   case "$_base" in
-    bash|sh|zsh|ksh|dash|fish) return 0 ;;
+    bash|sh|zsh|ksh|dash|fish|xonsh|tcsh|csh|nu|pwsh|osh) return 0 ;;
   esac
   return 1
 }

--- a/plugins/project-boundary/hooks/lib/detectors/db_dump.sh
+++ b/plugins/project-boundary/hooks/lib/detectors/db_dump.sh
@@ -1,0 +1,212 @@
+#!/bin/bash
+# project-boundary guard — database tool write-target detectors
+# =============================================================
+# pg_dump -f, mysqldump --result-file, psql -o/-L/-c, mysql --tee
+# write SQL output / session logs to FILE, bypassing the redirect
+# walker. Split out of write_targets_b.sh by domain (Codex r5
+# finding #4).
+#
+# Same dynamic-scope contract as the rest of detectors/:
+# reads CMD, CMD_BLANKED, CMD_TOKENS, CMD_TOKENS_SCAN,
+# EFFECTIVE_CWD, PROJECT_DIR; helpers from
+# hooks/lib/tokenize.sh + paths.sh + command_name.sh +
+# options.sh. Calls `exit 2` on violation.
+
+run_db_dump_detectors() {
+  # --- pg_dump -f / mysqldump --result-file: DB dump output (r5) ---
+  # Database dump tools accept an explicit output-file flag that
+  # bypasses the redirect walker. Both write a SQL dump to FILE;
+  # outside-project FILE is a boundary violation.
+  local PG_CMD pgfile
+  for PG_CMD in pg_dump pg_dumpall; do
+    if command_name_is "$PG_CMD"; then
+      while IFS= read -r pgfile; do
+        [ -n "$pgfile" ] && validate_command_path write "$PG_CMD -f" "$pgfile"
+      done < <(extract_attached_or_split_from CMD_TOKENS_SCAN -f --file)
+    fi
+  done
+
+  # --- psql -o / -L: query output + session log (round-5 follow) ---
+  if command_name_is "psql"; then
+    local pqi=1 pqn=${#CMD_TOKENS_SCAN[@]}
+    while [ $pqi -lt $pqn ]; do
+      local pqtok
+      pqtok=$(strip_quotes "${CMD_TOKENS_SCAN[$pqi]}")
+      local pqfile="" pqkind=""
+      case "$pqtok" in
+        -o|--output)
+          pqkind="-o"
+          if [ $((pqi + 1)) -lt $pqn ]; then
+            pqfile=$(strip_quotes "${CMD_TOKENS_SCAN[$((pqi + 1))]}")
+            pqi=$((pqi + 1))
+          fi
+          ;;
+        -o?*)
+          pqkind="-o"; pqfile=$(strip_quotes "${pqtok#-o}") ;;
+        --output=*)
+          pqkind="--output"; pqfile=$(strip_quotes "${pqtok#--output=}") ;;
+        -L|--log-file)
+          pqkind="-L"
+          if [ $((pqi + 1)) -lt $pqn ]; then
+            pqfile=$(strip_quotes "${CMD_TOKENS_SCAN[$((pqi + 1))]}")
+            pqi=$((pqi + 1))
+          fi
+          ;;
+        -L?*)
+          pqkind="-L"; pqfile=$(strip_quotes "${pqtok#-L}") ;;
+        --log-file=*)
+          pqkind="--log-file"; pqfile=$(strip_quotes "${pqtok#--log-file=}") ;;
+        -c|--command)
+          # Codex r5 round-3 P2: the -c value can carry backslash
+          # meta-commands (\o, \g, \gx, \w, \s, \copy, \!) that write
+          # local files or execute shell commands without using -o.
+          # Path payloads after the meta are too fragile to parse
+          # safely from bash — fail-closed on any presence.
+          if [ $((pqi + 1)) -lt $pqn ]; then
+            local pqsql
+            pqsql=$(strip_quotes "${CMD_TOKENS_SCAN[$((pqi + 1))]}")
+            # Note: guard's alias-escape pass strips a backslash before
+            # [a-zA-Z_], so `\o` / `\g` / `\w` / `\s` / `\copy` arrive
+            # as bare `o` / `g` / `w` / `s` / `copy` at the start of the
+            # value. `\!` keeps its backslash (! is non-alphanumeric).
+            # Match either form anchored at the start of the value.
+            # Codex r5 round-4 (Q1B): ANSI-C quoting `$'...'` is not
+            # unwrapped by strip_quotes; fail-closed on the prefix.
+            if [[ "$pqsql" == \$\'* ]]; then
+              echo "BLOCKED: 'psql -c' value uses ANSI-C quoting (\$'...') which can encode arbitrary escape sequences. Cannot be safely inspected. Ask user for explicit permission." >&2
+              exit 2
+            fi
+            # Codex r5 round-4 (Q1A): no-space meta args like
+            # `\o/tmp/out` and `\o|cmd` — extend the separator class
+            # to cover `/` (path attached) and `|` (pipe attached) and
+            # `\\` (next meta attached) on top of whitespace.
+            # \! always opens an interactive shell or executes attached
+            # shell command — fail-closed regardless of arg shape.
+            #
+            # Codex#1 HIGH: psql executes meta-commands wherever they
+            # appear in the -c value, so the same patterns must also
+            # match after a `;` statement separator. Multi-statement
+            # payloads that mix `\copy ... to stdout` with unsafe metas
+            # require statement-aware parsing we don't do — fail-closed
+            # on any post-separator meta (no safe exception).
+            if echo "$pqsql" | grep -qE '(^|;)[[:space:]]*\\!'; then
+              echo "BLOCKED: 'psql -c' contains the \\! meta-command which executes a shell. Cannot be safely inspected. Ask user for explicit permission." >&2
+              exit 2
+            fi
+            # Post-separator meta with payload — block unconditionally
+            # (no leading-position safe exception).
+            if echo "$pqsql" | grep -qE ';[[:space:]]*(o|g|gx|w|s|copy)([[:space:]]+[^[:space:]]|/|\||\\)'; then
+              echo "BLOCKED: 'psql -c' contains a backslash meta-command (\\o / \\g / \\gx / \\w / \\s / \\copy) after a statement separator with a file or pipe payload. Cannot be safely inspected. Ask user for explicit permission." >&2
+              exit 2
+            fi
+            # \o / \g / \gx / \w / \s / \copy with an ATTACHED payload —
+            # space + non-space (split file path), `/` (path attached),
+            # `|` (pipe attached), or `\` (next meta attached) — write
+            # or read a file we cannot validate. Bare meta with no
+            # payload is read-only / send-and-go and stays ALLOWED:
+            #   \g    send query (alias of ;)
+            #   \o    reset output to stdout
+            #   \gx   send query, expanded display
+            #   \w    error without arg, no side effect
+            #   \s    print history to stdout (no arg = stdout)
+            #   \copy error without args
+            if echo "$pqsql" | grep -qE '^(o|g|gx|w|s|copy)([[:space:]]+[^[:space:]]|/|\||\\)'; then
+              # \copy ... (to|from) (stdin|stdout|pstdin|pstdout) writes
+              # NOTHING to the local filesystem — the endpoints are the
+              # caller's stdio, not files. Modifies/reads DB rows only,
+              # which is the normal operation of psql and outside the
+              # boundary's scope. The other meta-commands (o/g/gx/w/s)
+              # have no analogous safe form and stay blocked.
+              if ! echo "$pqsql" | grep -iqE '^copy[[:space:]].*[[:space:]](from|to)[[:space:]]+p?std(in|out)([[:space:]]|\(|;|$)'; then
+                echo "BLOCKED: 'psql -c' contains a backslash meta-command (\\o / \\g / \\gx / \\w / \\s / \\copy) with a file or pipe payload. Cannot be safely inspected. Ask user for explicit permission." >&2
+                exit 2
+              fi
+            fi
+            pqi=$((pqi + 1))
+          fi
+          ;;
+        -c?*|--command=*)
+          local pqsql
+          if [[ "$pqtok" == --command=* ]]; then
+            pqsql=$(strip_quotes "${pqtok#--command=}")
+          else
+            pqsql=$(strip_quotes "${pqtok#-c}")
+          fi
+          # See note above. Round-4 fix: also check ANSI-C $'...' prefix
+          # and extend separator class to cover no-space attached args.
+          if [[ "$pqsql" == \$\'* ]]; then
+            echo "BLOCKED: 'psql -c' value uses ANSI-C quoting (\$'...') which can encode arbitrary escape sequences. Cannot be safely inspected. Ask user for explicit permission." >&2
+            exit 2
+          fi
+          # \! always opens a shell — fail-closed regardless of arg shape.
+          # Codex#1 HIGH: also catch \! after `;` separator (mirror of
+          # the split -c VALUE branch above).
+          if echo "$pqsql" | grep -qE '(^|;)[[:space:]]*\\!'; then
+            echo "BLOCKED: 'psql -c' contains the \\! meta-command which executes a shell. Cannot be safely inspected. Ask user for explicit permission." >&2
+            exit 2
+          fi
+          # Post-separator meta with payload — block unconditionally.
+          if echo "$pqsql" | grep -qE ';[[:space:]]*(o|g|gx|w|s|copy)([[:space:]]+[^[:space:]]|/|\||\\)'; then
+            echo "BLOCKED: 'psql -c' contains a backslash meta-command (\\o / \\g / \\gx / \\w / \\s / \\copy) after a statement separator with a file or pipe payload. Cannot be safely inspected. Ask user for explicit permission." >&2
+            exit 2
+          fi
+          # \o / \g / \gx / \w / \s / \copy with an attached payload only —
+          # bare forms have no file write side-effect and stay ALLOWED.
+          if echo "$pqsql" | grep -qE '^(o|g|gx|w|s|copy)([[:space:]]+[^[:space:]]|/|\||\\)'; then
+            # \copy ... (to|from) (stdin|stdout|pstdin|pstdout) endpoints
+            # write nothing to the local filesystem (mirror of the same
+            # exception in the split -c VALUE branch above). Other metas
+            # have no analogous safe form and stay blocked.
+            if ! echo "$pqsql" | grep -iqE '^copy[[:space:]].*[[:space:]](from|to)[[:space:]]+p?std(in|out)([[:space:]]|\(|;|$)'; then
+              echo "BLOCKED: 'psql -c' contains a backslash meta-command (\\o / \\g / \\gx / \\w / \\s / \\copy) with a file or pipe payload. Cannot be safely inspected. Ask user for explicit permission." >&2
+              exit 2
+            fi
+          fi
+          ;;
+      esac
+      if [ -n "$pqfile" ]; then
+        # Codex r5 round-3 P1: a value beginning with `|` is interpreted
+        # by psql as a pipe-to-shell-command, not a file path. Same
+        # un-inspectable surface as `bash -c` — fail-closed.
+        if [[ "$pqfile" == \|* ]]; then
+          echo "BLOCKED: 'psql $pqkind' pipe operand '$pqfile' executes a shell command and cannot be safely inspected. Ask user for explicit permission." >&2
+          exit 2
+        fi
+        validate_command_path write "psql $pqkind" "$pqfile"
+      fi
+      pqi=$((pqi + 1))
+    done
+  fi
+
+  # --- mysql --tee=FILE: session echo to file (round-5 follow) ---
+  if command_name_is "mysql"; then
+    local msi=1 msn=${#CMD_TOKENS_SCAN[@]}
+    while [ $msi -lt $msn ]; do
+      local mstok
+      mstok=$(strip_quotes "${CMD_TOKENS_SCAN[$msi]}")
+      local msfile=""
+      case "$mstok" in
+        --tee)
+          if [ $((msi + 1)) -lt $msn ]; then
+            local msnext
+            msnext=$(strip_quotes "${CMD_TOKENS_SCAN[$((msi + 1))]}")
+            case "$msnext" in
+              -*) ;;
+              *) msfile="$msnext"; msi=$((msi + 1)) ;;
+            esac
+          fi
+          ;;
+        --tee=*)
+          msfile="${mstok#--tee=}" ;;
+      esac
+      [ -n "$msfile" ] && validate_command_path write "mysql --tee" "$msfile"
+      msi=$((msi + 1))
+    done
+  fi
+  if command_name_is "mysqldump"; then
+    local myfile
+    while IFS= read -r myfile; do
+      [ -n "$myfile" ] && validate_command_path write "mysqldump --result-file" "$myfile"
+    done < <(extract_attached_or_split_from CMD_TOKENS_SCAN -r --result-file)
+  fi
+}

--- a/plugins/project-boundary/hooks/lib/detectors/destructive.sh
+++ b/plugins/project-boundary/hooks/lib/detectors/destructive.sh
@@ -16,7 +16,7 @@
 
 run_destructive_detectors() {
   # --- xargs with dangerous commands ---
-  if echo "$CMD" | grep -qE '(^|[[:space:]])xargs($|[[:space:]])'; then
+  if command_name_is "xargs"; then
     # Check if xargs is followed by a dangerous command
     local xargs_cmd
     xargs_cmd=$(echo "$CMD" | sed -E 's/.*xargs[[:space:]]+((-[^ ]*[[:space:]]+)*)//' | awk '{print $1}')
@@ -29,8 +29,8 @@ run_destructive_detectors() {
   fi
 
   # --- find with -delete or -exec rm/mv outside project ---
-  if echo "$CMD" | grep -qE '(^|[[:space:]])find($|[[:space:]])'; then
-    if echo "$CMD" | grep -qE '(-delete|-exec[[:space:]]+(rm|mv))'; then
+  if command_name_is "find"; then
+    if echo "$CMD" | grep -qE '(-delete|-(exec|execdir|ok|okdir)[[:space:]]+['\''"]?([^[:space:]'\''"]+/)?(rm|mv)['\''"]?([[:space:]]|$))'; then
       # Extract ALL find paths (non-option arguments after 'find')
       # Skip options like -L, -H, -P that come before the paths
       local -a find_paths=()
@@ -52,24 +52,100 @@ run_destructive_detectors() {
       done < <(tokenize_args "$find_args")
       [[ ${#find_paths[@]} -eq 0 ]] && find_paths=(".")
       local find_path
+      # STRICT: find -delete/-exec rm are destructive; allowlist must not apply.
       for find_path in "${find_paths[@]}"; do
-        find_path=$(expand_path "$find_path")
-        if [[ "$find_path" != /* ]]; then
-          find_path="$EFFECTIVE_CWD/$find_path"
-        fi
-        local resolved_find
-        resolved_find=$(resolve_path "$find_path")
-        # STRICT: find -delete/-exec rm are destructive; allowlist must not apply.
-        if ! is_inside_project "$resolved_find"; then
-          echo "BLOCKED: 'find' with destructive action targets '$resolved_find' which is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
-          exit 2
-        fi
+        validate_command_path strict "find with destructive action" "$find_path"
+      done
+    fi
+
+    # --- find -fprint / -fls / -fprintf write target (round-5) ---
+    # `find ... -fprint FILE` truncates FILE and writes matching
+    # paths into it (find opens with O_WRONLY|O_CREAT|O_TRUNC).
+    # `-fls` (long-listing) and `-fprintf FILE FORMAT` have the
+    # same write semantics. The find walker above only handled
+    # destructive-action verbs (-delete / -exec rm); the print-to-
+    # file actions slipped through.
+    if echo "$CMD" | grep -qE '(\-fprint|\-fls|\-fprintf)([[:space:]]|$)'; then
+      local fpi=1 fpn=${#CMD_TOKENS_SCAN[@]}
+      while [ $fpi -lt $fpn ]; do
+        local fptok
+        fptok=$(strip_quotes "${CMD_TOKENS_SCAN[$fpi]}")
+        case "$fptok" in
+          -fprint|-fls|-fprintf)
+            if [ $((fpi + 1)) -lt $fpn ]; then
+              local fpval
+              fpval=$(strip_quotes "${CMD_TOKENS_SCAN[$((fpi + 1))]}")
+              validate_command_path write "find ${fptok}" "$fpval"
+            fi
+            ;;
+        esac
+        fpi=$((fpi + 1))
       done
     fi
   fi
 
+  # --- shred / wipe / srm / bcwipe: destructive overwrite (and ---
+  # optional unlink with -u). Same destruction semantics as rm/dd,
+  # so STRICT boundary (allowlist must not grant DESTROY-CONTENTS).
+  # `wipe` (Berke Durak), `srm` (Sourceforge secure-delete) and
+  # `bcwipe` (Jetico) are popular drop-in alternatives — round-5
+  # pentest found the trigger missed all three.
+  # Walker accepts -n N / -s N / --iterations / --size as flag+value
+  # pairs and consumes bare flags otherwise; remaining positionals
+  # are FILE operands. /usr/bin/, /bin/, /usr/local/bin/, and
+  # /opt/homebrew/bin/ absolute-path forms also match.
+  # Anchor on command_name_is so substrings ("echo wipe", "npm run
+  # wipe", "printf 'srm: %s'") don't false-positive on the trigger
+  # (Codex round-5 P2). _cn_strip_path_prefix already normalises
+  # /opt/homebrew/bin/ etc. so absolute-path forms still match.
+  local destr_cmd=""
+  local _DC
+  for _DC in shred wipe srm bcwipe; do
+    if command_name_is "$_DC"; then
+      destr_cmd="$_DC"
+      break
+    fi
+  done
+  if [ -n "$destr_cmd" ]; then
+    local shi=1 shn=${#CMD_TOKENS_SCAN[@]}
+    local shred_seen_dashdash=0
+    while [ $shi -lt $shn ]; do
+      local shtok
+      shtok=$(strip_quotes "${CMD_TOKENS_SCAN[$shi]}")
+      if [ $shred_seen_dashdash -eq 0 ]; then
+        case "$shtok" in
+          --)
+            shred_seen_dashdash=1; shi=$((shi + 1)); continue ;;
+          -n|-s|--iterations|--size|--random-source)
+            shi=$((shi + 2)); continue ;;
+          -*|'')
+            shi=$((shi + 1)); continue ;;
+        esac
+      fi
+      validate_command_path strict "$destr_cmd" "$shtok"
+      shi=$((shi + 1))
+    done
+  fi
+
   # --- File deletion: allowed inside project, blocked outside ---
-  if echo "$CMD" | grep -qE '(^|[[:space:]])rm($|[[:space:]])'; then
+  # Substring regex (NOT command_name_is) by design for the wrapper-
+  # carry case: `nsenter rm /etc/x`, `chroot rm /etc/x`, `docker run
+  # alpine rm /` deliberately over-block because host-mount parsing
+  # is not in scope. command_name_is would only fire on a post-wrapper
+  # `rm` verb and miss those forms. CMD_BLANKED (heredoc bodies wiped)
+  # so a quoted-heredoc body that merely mentions `rm` is not tripped —
+  # Codex round-4 P3 (sec 99).
+  #
+  # VERB-GATE on a positive list of verbs that can legitimately host an
+  # `rm` argument: rm itself + remote-dispatch wrappers (docker /
+  # podman / kubectl / oc / crictl / lxc / ssh / nsenter / chroot) +
+  # xargs (rm-by-input). Other verbs (git / gh / echo / printf / cat /
+  # ...) skip: substring `rm` in their args is content of a commit
+  # message / tag annotation / PR body / docs file, not a real exec.
+  # The gate keeps the wrapper-carry over-block intact while removing
+  # the false-positive on text-as-arg in metadata-bearing tooling.
+  if [[ "${CMD_VERB-}" =~ ^(rm|docker|podman|kubectl|oc|crictl|lxc|ssh|nsenter|chroot|xargs)$ ]] && \
+     echo "$CMD_BLANKED" | grep -qE '(^|[[:space:]])rm($|[[:space:]])'; then
     # Extract paths from rm command (skip flags)
     local rm_raw
     rm_raw=$(echo "$CMD" | grep -oE '(^|[[:space:]])rm[[:space:]]+.*' | sed 's/^[[:space:]]*rm[[:space:]]*//' || true)
@@ -77,18 +153,9 @@ run_destructive_detectors() {
     local TARGET RESOLVED
     while IFS= read -r TARGET; do
       [[ -z "$TARGET" || "$TARGET" == -* ]] && continue
-      TARGET=$(expand_path "$TARGET")
-      # Resolve to absolute path
-      if [[ "$TARGET" != /* ]]; then
-        TARGET="$EFFECTIVE_CWD/$TARGET"
-      fi
-      RESOLVED=$(resolve_path "$TARGET")
-
       # STRICT: rm is destructive; allowlist grants WRITE, not DELETE.
-      if ! is_inside_project "$RESOLVED"; then
-        echo "BLOCKED: 'rm' targets '$RESOLVED' which is OUTSIDE project directory '$PROJECT_DIR'. File deletion is only allowed within the project. Ask user for explicit permission." >&2
-        exit 2
-      fi
+      validate_command_path strict rm "$TARGET"
+      RESOLVED=$(resolve_command_path "$TARGET")
 
       # Block deleting the project root itself
       if [[ "$RESOLVED" == "$PROJECT_DIR" ]]; then
@@ -99,136 +166,57 @@ run_destructive_detectors() {
   fi
 
   # --- Moving files outside project ---
-  if echo "$CMD" | grep -qE '(^|[[:space:]])mv($|[[:space:]])'; then
+  if command_name_is "mv"; then
     # Check -t / --target-directory
     local mv_target_dir
+    # STRICT: mv with -t still deletes sources from their original paths.
+    # Allowing an allowlisted dir as dest could pair with an outside-project
+    # source (caught by the per-arg strict loop below) — keep both ends tight.
     while IFS= read -r mv_target_dir; do
       [ -z "$mv_target_dir" ] && continue
-      mv_target_dir=$(expand_path "$mv_target_dir")
-      [[ "$mv_target_dir" != /* ]] && mv_target_dir="$EFFECTIVE_CWD/$mv_target_dir"
-      local resolved_mv_td
-      resolved_mv_td=$(resolve_path "$mv_target_dir")
-      # STRICT: mv with -t still deletes sources from their original paths.
-      # Allowing an allowlisted dir as dest could pair with an outside-project
-      # source (caught by the per-arg strict loop below) — keep both ends tight.
-      if ! is_inside_project "$resolved_mv_td"; then
-        echo "BLOCKED: 'mv --target-directory' targets '$resolved_mv_td' which is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
-        exit 2
-      fi
+      validate_command_path strict "mv --target-directory" "$mv_target_dir"
     done < <(extract_option_values "-t" "--target-directory" || true)
     local mv_raw
     mv_raw=$(echo "$CMD" | grep -oE '(^|[[:space:]])mv[[:space:]]+.*' | sed 's/^[[:space:]]*mv[[:space:]]*//' || true)
 
-    local TARGET RESOLVED
+    # STRICT: mv deletes the source; allowlist must not apply, otherwise
+    # `mv memory/foo project/foo` would destructively empty the memory dir
+    # (allowlist grants WRITE, not move/delete).
+    local TARGET
     while IFS= read -r TARGET; do
       [[ -z "$TARGET" || "$TARGET" == -* ]] && continue
-      TARGET=$(expand_path "$TARGET")
-      if [[ "$TARGET" != /* ]]; then
-        TARGET="$EFFECTIVE_CWD/$TARGET"
-      fi
-      RESOLVED=$(resolve_path "$TARGET")
-
-      # STRICT: mv deletes the source; allowlist must not apply, otherwise
-      # `mv memory/foo project/foo` would destructively empty the memory dir
-      # (allowlist grants WRITE, not move/delete).
-      if ! is_inside_project "$RESOLVED"; then
-        echo "BLOCKED: 'mv' argument '$RESOLVED' is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
-        exit 2
-      fi
+      validate_command_path strict mv "$TARGET"
     done < <(tokenize_args "$mv_raw")
   fi
 
   # --- cp command: check all non-flag arguments ---
-  if echo "$CMD" | grep -qE '(^|[[:space:]])cp($|[[:space:]])'; then
+  if command_name_is "cp"; then
     # Check -t / --target-directory
     local cp_target_dir
     while IFS= read -r cp_target_dir; do
       [ -z "$cp_target_dir" ] && continue
-      cp_target_dir=$(expand_path "$cp_target_dir")
-      [[ "$cp_target_dir" != /* ]] && cp_target_dir="$EFFECTIVE_CWD/$cp_target_dir"
-      local resolved_cp_td
-      resolved_cp_td=$(resolve_path "$cp_target_dir")
-      if ! is_inside_project "$resolved_cp_td"; then
-        echo "BLOCKED: 'cp --target-directory' targets '$resolved_cp_td' which is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
-        exit 2
-      fi
+      validate_command_path strict "cp --target-directory" "$cp_target_dir"
     done < <(extract_option_values "-t" "--target-directory" || true)
     local cp_raw
     cp_raw=$(echo "$CMD" | grep -oE '(^|[[:space:]])cp[[:space:]]+.*' | sed 's/^[[:space:]]*cp[[:space:]]*//' || true)
 
-    local TARGET RESOLVED
+    local TARGET
     while IFS= read -r TARGET; do
       [[ -z "$TARGET" || "$TARGET" == -* ]] && continue
-      TARGET=$(expand_path "$TARGET")
-      if [[ "$TARGET" != /* ]]; then
-        TARGET="$EFFECTIVE_CWD/$TARGET"
-      fi
-      RESOLVED=$(resolve_path "$TARGET")
-
-      if ! is_inside_project "$RESOLVED"; then
-        echo "BLOCKED: 'cp' argument '$RESOLVED' is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
-        exit 2
-      fi
+      validate_command_path strict cp "$TARGET"
     done < <(tokenize_args "$cp_raw")
   fi
 
   # --- ln command: check all non-flag arguments ---
-  if echo "$CMD" | grep -qE '(^|[[:space:]])ln($|[[:space:]])'; then
+  if command_name_is "ln"; then
     local ln_raw
     ln_raw=$(echo "$CMD" | grep -oE '(^|[[:space:]])ln[[:space:]]+.*' | sed 's/^[[:space:]]*ln[[:space:]]*//' || true)
 
-    local TARGET RESOLVED
+    local TARGET
     while IFS= read -r TARGET; do
       [[ -z "$TARGET" || "$TARGET" == -* ]] && continue
-      TARGET=$(expand_path "$TARGET")
-      if [[ "$TARGET" != /* ]]; then
-        TARGET="$EFFECTIVE_CWD/$TARGET"
-      fi
-      RESOLVED=$(resolve_path "$TARGET")
-
-      if ! is_inside_project "$RESOLVED"; then
-        echo "BLOCKED: 'ln' argument '$RESOLVED' is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
-        exit 2
-      fi
+      validate_command_path strict ln "$TARGET"
     done < <(tokenize_args "$ln_raw")
   fi
 }
 
-# --- chmod / chown boundary check ---
-# Weaponizable permission changes on files outside the project are
-# blocked. STRICT: allowlist does not apply because an attacker who
-# can chmod an allowlisted dir's sibling path can still pivot.
-# Separate function because chmod/chown originally run at a later
-# position in check_single_command than the xargs..ln cluster; this
-# lets us preserve the original evaluation order from the caller.
-run_permissions_detectors() {
-  local CMD_NAME TARGET RESOLVED
-  for CMD_NAME in chmod chown; do
-    if echo "$CMD" | grep -qE "(^|[[:space:]])${CMD_NAME}($|[[:space:]])"; then
-      # Extract args after command name, skip flags, then skip the first
-      # non-flag token (mode for chmod, owner[:group] for chown)
-      local perm_raw
-      perm_raw=$(echo "$CMD" | grep -oE "(^|[[:space:]])${CMD_NAME}[[:space:]]+.*" | sed "s/^[[:space:]]*${CMD_NAME}[[:space:]]*//" || true)
-      local skipped_first=0
-
-      while IFS= read -r TARGET; do
-        [[ -z "$TARGET" || "$TARGET" == -* ]] && continue
-        if [[ $skipped_first -eq 0 ]]; then
-          skipped_first=1
-          continue
-        fi
-        TARGET=$(expand_path "$TARGET")
-        if [[ "$TARGET" != /* ]]; then
-          TARGET="$EFFECTIVE_CWD/$TARGET"
-        fi
-        RESOLVED=$(resolve_path "$TARGET")
-
-        # STRICT: chmod/chown can weaponize permissions; allowlist must not apply.
-        if ! is_inside_project "$RESOLVED"; then
-          echo "BLOCKED: '${CMD_NAME}' targets '$RESOLVED' which is OUTSIDE project directory. Ask user for explicit permission." >&2
-          exit 2
-        fi
-      done < <(tokenize_args "$perm_raw")
-    fi
-  done
-}

--- a/plugins/project-boundary/hooks/lib/detectors/download.sh
+++ b/plugins/project-boundary/hooks/lib/detectors/download.sh
@@ -1,0 +1,187 @@
+#!/bin/bash
+# project-boundary guard — download write-target detectors
+# =========================================================
+# curl -o / wget -O download targets. Split out of
+# write_targets_b.sh by domain (Codex r5 finding #4).
+#
+# Same dynamic-scope contract as the rest of detectors/:
+# reads CMD, CMD_BLANKED, CMD_TOKENS, CMD_TOKENS_SCAN,
+# EFFECTIVE_CWD, PROJECT_DIR; helpers from
+# hooks/lib/tokenize.sh + paths.sh + command_name.sh +
+# options.sh. Calls `exit 2` on violation.
+
+run_download_detectors() {
+  local TARGET RESOLVED
+
+  # --- curl -o / curl --output outside project ---
+  # curl -o is positional: `curl -o out1 URL1 -o out2 URL2` writes each URL
+  # to its corresponding output. Validate EVERY occurrence.
+  if command_name_is "curl"; then
+    local curl_output resolved_curl
+    while IFS= read -r curl_output; do
+      [ -z "$curl_output" ] && continue
+      resolved_curl=$(resolve_command_path "$curl_output")
+      # /dev/null is a discard sink for HTTP probes (`curl -o /dev/null -w %{http_code}`).
+      is_discard_target "$resolved_curl" && continue
+      block_unless_path_allowed write "curl output file" "$resolved_curl"
+    done < <(extract_option_values "-o" "--output" || true)
+
+    # curl --output-dir DIR prepends DIR to the per-URL output filename
+    # selected by -O/--remote-name (URL basename) or a relative -o path.
+    # The -o walker above only sees the explicit -o value, so
+    # `curl --output-dir /tmp -O URL` and the attached `--output-dir=`
+    # form bypassed the boundary entirely.
+    #
+    # Gate: --output-dir is only used by curl when -O/--remote-name is
+    # present OR -o has a relative value. Without those, curl ignores
+    # --output-dir entirely (HEAD-only `-I`, `-o /abs/path`, plain GET
+    # to stdout, etc.). Validating unconditionally false-positived
+    # those cases.
+    local curl_outdir_active=0
+    local _coi=1 _con=${#CMD_TOKENS[@]}
+    while [ $_coi -lt $_con ]; do
+      local _cotok
+      _cotok=$(strip_quotes "${CMD_TOKENS[$_coi]}")
+      case "$_cotok" in
+        --) break ;;
+        -O|--remote-name|--remote-name-all)
+          curl_outdir_active=1; break ;;
+        -o|--output)
+          if [ $((_coi + 1)) -lt $_con ]; then
+            local _coval
+            _coval=$(strip_quotes "${CMD_TOKENS[$((_coi + 1))]}")
+            case "$_coval" in
+              /*) : ;;
+              *)  curl_outdir_active=1; break ;;
+            esac
+          fi
+          _coi=$((_coi + 2)); continue ;;
+        --output=*)
+          local _coval="${_cotok#--output=}"
+          case "$_coval" in
+            /*) : ;;
+            *)  curl_outdir_active=1; break ;;
+          esac
+          ;;
+        -o?*)
+          local _coval="${_cotok#-o}"
+          case "$_coval" in
+            /*) : ;;
+            *)  curl_outdir_active=1; break ;;
+          esac
+          ;;
+      esac
+      _coi=$((_coi + 1))
+    done
+    if [ "$curl_outdir_active" -eq 1 ]; then
+      local curl_outdir
+      while IFS= read -r curl_outdir; do
+        [ -z "$curl_outdir" ] && continue
+        validate_command_path write "curl --output-dir" "$curl_outdir"
+      done < <(extract_option_values "" "--output-dir" || true)
+    fi
+  fi
+
+  # --- wget -O / wget --output-document outside project ---
+  if command_name_is "wget"; then
+    local wget_output
+    while IFS= read -r wget_output; do
+      [ -z "$wget_output" ] && continue
+      local resolved_wget
+      resolved_wget=$(resolve_command_path "$wget_output")
+      # /dev/null is a discard sink (`wget -O /dev/null URL`).
+      is_discard_target "$resolved_wget" && continue
+      block_unless_path_allowed write "wget output file" "$resolved_wget"
+    done < <(extract_option_values "-O" "--output-document" || true)
+
+    # wget -P / --directory-prefix DIR prepends DIR to the URL-derived
+    # output filename. Without -O, every downloaded file lands under DIR;
+    # an outside-project DIR is a real boundary write. The -O walker
+    # above does not cover this — `wget -P /tmp URL` slipped through
+    # entirely (cd_destructive_walker comment at lib/cd_destructive_walker.sh
+    # already flagged this gap for allowlisted-cwd, but the unguarded
+    # in-project case was never wired up).
+    #
+    # Gate: -P is ignored by wget when --spider is set (no download)
+    # or when -O/--output-document is set (wget writes to the literal
+    # -O path, not into the prefix dir; the -O walker above already
+    # validates that path). Validating -P unconditionally
+    # false-positived these cases.
+    local wget_pdir_active=1
+    local _wpi=1 _wpn=${#CMD_TOKENS[@]}
+    while [ $_wpi -lt $_wpn ]; do
+      local _wptok
+      _wptok=$(strip_quotes "${CMD_TOKENS[$_wpi]}")
+      case "$_wptok" in
+        --) break ;;
+        --spider) wget_pdir_active=0; break ;;
+        -O|--output-document)
+          if [ $((_wpi + 1)) -lt $_wpn ]; then
+            wget_pdir_active=0; break
+          fi
+          ;;
+        --output-document=*) wget_pdir_active=0; break ;;
+        # Codex#3 LOW: attached short form `-O-` / `-O/dev/null` /
+        # `-O/path` is also a literal -O target — wget ignores -P
+        # when -O is set, regardless of split-vs-attached form.
+        -O?*) wget_pdir_active=0; break ;;
+      esac
+      _wpi=$((_wpi + 1))
+    done
+    if [ "$wget_pdir_active" -eq 1 ]; then
+      # Custom walker. extract_option_values misses the attached short
+      # form `-P/tmp` (Codex#2 bypass) — it only handles `-P VALUE`,
+      # `--directory-prefix VALUE`, and `--directory-prefix=VALUE`.
+      local _wpvi=1 _wpvn=${#CMD_TOKENS[@]}
+      while [ $_wpvi -lt $_wpvn ]; do
+        local _wpvtok
+        _wpvtok=$(strip_quotes "${CMD_TOKENS[$_wpvi]}")
+        local _wpval=""
+        local _wpv_consumed=0
+        case "$_wpvtok" in
+          --) break ;;
+          --directory-prefix=*)
+            _wpval="${_wpvtok#--directory-prefix=}" ;;
+          --directory-prefix)
+            if [ $((_wpvi + 1)) -lt $_wpvn ]; then
+              _wpval=$(strip_quotes "${CMD_TOKENS[$((_wpvi + 1))]}")
+              _wpv_consumed=1
+            fi
+            ;;
+          --*) ;;
+          -*)
+            # Codex re-review B: cluster `-qP/tmp`, `-vqP/etc`, etc.
+            # Find 'P' anywhere in the short cluster; reset of the
+            # token after P is the attached value, or the next token
+            # when P is at end-of-cluster. Mirrors the unzip -d
+            # walker (sec 102) — same shape gap.
+            local _wpvrest="${_wpvtok#-}"
+            local _wpvpos=0 _wpvlen=${#_wpvrest} _wpvch _wpvf_p=-1
+            while [ $_wpvpos -lt $_wpvlen ]; do
+              _wpvch="${_wpvrest:$_wpvpos:1}"
+              if [ "$_wpvch" = "P" ]; then _wpvf_p=$_wpvpos; break; fi
+              _wpvpos=$((_wpvpos + 1))
+            done
+            if [ $_wpvf_p -ge 0 ]; then
+              local _wpvafter="${_wpvrest:$((_wpvf_p + 1))}"
+              if [ -n "$_wpvafter" ]; then
+                _wpval="$_wpvafter"
+              elif [ $((_wpvi + 1)) -lt $_wpvn ]; then
+                _wpval=$(strip_quotes "${CMD_TOKENS[$((_wpvi + 1))]}")
+                _wpv_consumed=1
+              fi
+            fi
+            ;;
+        esac
+        if [ -n "$_wpval" ]; then
+          validate_command_path write "wget -P" "$_wpval"
+        fi
+        if [ $_wpv_consumed -eq 1 ]; then
+          _wpvi=$((_wpvi + 2))
+        else
+          _wpvi=$((_wpvi + 1))
+        fi
+      done
+    fi
+  fi
+}

--- a/plugins/project-boundary/hooks/lib/detectors/filesystem_create.sh
+++ b/plugins/project-boundary/hooks/lib/detectors/filesystem_create.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# project-boundary guard — filesystem-entry creation detectors
+# ============================================================
+# mktemp -p<dir> / --tmpdir, mkfifo, mknod create a temp file or
+# special FS entry whose location can land outside the project.
+# Split out of write_targets_b.sh by domain (Codex r5 finding #4).
+#
+# Same dynamic-scope contract as the rest of detectors/:
+# reads CMD, CMD_BLANKED, CMD_TOKENS, CMD_TOKENS_SCAN,
+# EFFECTIVE_CWD, PROJECT_DIR; helpers from
+# hooks/lib/tokenize.sh + paths.sh + command_name.sh +
+# options.sh. Calls `exit 2` on violation.
+
+run_filesystem_create_detectors() {
+  # --- mktemp -p<dir> / --tmpdir=<dir>: temp file/dir creation ---
+  # `mktemp -p DIR TEMPLATE` and `mktemp --tmpdir=DIR TEMPLATE`
+  # create a temp file or directory inside DIR. Outside-project DIR
+  # is a write outside the boundary. Bare `mktemp` (no -p / --tmpdir)
+  # uses the default temp dir (/tmp or $TMPDIR) and is left ALLOWED —
+  # test harnesses (incl. helpers.sh) rely on the default form.
+  if command_name_is "mktemp"; then
+    local mtdir
+    # -p / --tmpdir / --tmpdir=DIR — explicit destination flag.
+    while IFS= read -r mtdir; do
+      [ -n "$mtdir" ] && validate_command_path write "mktemp dir" "$mtdir"
+    done < <(extract_attached_or_split_from CMD_TOKENS_SCAN -p --tmpdir)
+    # Positional template with embedded path component:
+    # mktemp /etc/tmp.XXX writes into /etc. Validate the template's
+    # dirname (Codex r5 P1). The flag walker above ignores positionals;
+    # we re-walk here for the path-bearing template form.
+    local mti=1 mtn=${#CMD_TOKENS_SCAN[@]}
+    while [ $mti -lt $mtn ]; do
+      local mttok
+      mttok=$(strip_quotes "${CMD_TOKENS_SCAN[$mti]}")
+      case "$mttok" in
+        -p|--tmpdir) mti=$((mti + 2)); continue ;;
+        -p?*|--tmpdir=*) mti=$((mti + 1)); continue ;;
+        -*) mti=$((mti + 1)); continue ;;
+        */*) validate_command_path write "mktemp dir" "$(dirname -- "$mttok")" ;;
+      esac
+      mti=$((mti + 1))
+    done
+  fi
+
+  # --- mkfifo / mknod: create special filesystem entry (round-5) ---
+  # `mkfifo PATH...` creates a named pipe at each PATH; `mknod PATH
+  # TYPE MAJOR MINOR` creates a device node at PATH (only the first
+  # positional is a path — the rest are spec). Outside-project PATH
+  # is a real boundary violation, but no walker covered it.
+  # Value-bearing flags: -m / --mode (and `--mode=...`), -Z /
+  # --context (SELinux on GNU). is_write_permitted (allowlist OK).
+  local SPECIAL_CMD
+  for SPECIAL_CMD in mkfifo mknod; do
+    if command_name_is "$SPECIAL_CMD"; then
+      # mknod adds `-F FORMAT` (BSD `mknod -F bsd|freebsd|linux|solaris`);
+      # mkfifo has no -F so we must NOT pair-skip it there.
+      local _sf="-m --mode -Z --context"
+      [ "$SPECIAL_CMD" = "mknod" ] && _sf="$_sf -F"
+      local _path
+      while IFS= read -r _path; do
+        [ -z "$_path" ] && continue
+        validate_command_path write "$SPECIAL_CMD" "$_path"
+        # mknod has only one PATH positional; mkfifo accepts many.
+        [ "$SPECIAL_CMD" = "mknod" ] && break
+      done < <(walk_path_operands_from CMD_TOKENS_SCAN "$_sf" "--mode --context")
+    fi
+  done
+}

--- a/plugins/project-boundary/hooks/lib/detectors/inplace.sh
+++ b/plugins/project-boundary/hooks/lib/detectors/inplace.sh
@@ -21,7 +21,7 @@ run_inplace_detectors() {
   # alone. We only engage when -i / --in-place is actually present.
   # Use the heredoc-blanked view here: a commit-message body that
   # mentions "sed -i" must not be parsed as a real sed call.
-  if echo "$CMD_BLANKED" | grep -qE '(^|[[:space:]])sed($|[[:space:]])'; then
+  if command_name_is "sed"; then
     local sed_has_i=0
     local raw_tok
     for raw_tok in "${CMD_TOKENS_SCAN[@]}"; do
@@ -85,17 +85,7 @@ run_inplace_detectors() {
           script_skipped=1
           si=$((si + 1)); continue
         fi
-        local sexp
-        sexp=$(expand_path "$stok")
-        if [[ "$sexp" != /* ]]; then
-          sexp="$EFFECTIVE_CWD/$sexp"
-        fi
-        local sresolved
-        sresolved=$(resolve_path "$sexp")
-        if ! is_write_permitted "$sresolved"; then
-          echo "BLOCKED: 'sed -i' targets '$sresolved' which is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
-          exit 2
-        fi
+        validate_command_path write "sed -i" "$stok"
         si=$((si + 1))
       done
     fi
@@ -104,7 +94,7 @@ run_inplace_detectors() {
   # --- truncate: always rewrites the target file(s) ---
   # Heredoc-blanked view as above — body bytes mentioning "truncate" are
   # not a real call.
-  if echo "$CMD_BLANKED" | grep -qE '(^|[[:space:]])truncate($|[[:space:]])'; then
+  if command_name_is "truncate"; then
     local tri=1 trn=${#CMD_TOKENS_SCAN[@]}
     local trunc_seen_dashdash=0
     while [ $tri -lt $trn ]; do
@@ -129,18 +119,117 @@ run_inplace_detectors() {
       # The previous `^[+=<>%]?[0-9]` skip wrongly dropped digit-leading
       # filenames like `123.log` or `2024-04-22.log`, letting the target
       # escape the boundary check (Codex round — P2 bypass).
-      local trexp
-      trexp=$(expand_path "$trtok")
-      if [[ "$trexp" != /* ]]; then
-        trexp="$EFFECTIVE_CWD/$trexp"
-      fi
-      local trresolved
-      trresolved=$(resolve_path "$trexp")
-      if ! is_write_permitted "$trresolved"; then
-        echo "BLOCKED: 'truncate' targets '$trresolved' which is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
-        exit 2
-      fi
+      validate_command_path write truncate "$trtok"
       tri=$((tri + 1))
     done
+  fi
+
+  # --- perl/ruby in-place edit (-i / -pi / -i.bak) ---
+  # perl `-i`, `-pi`, `-i.bak`, ruby `-i`, `-i.bak` rewrite each FILE
+  # operand in place with the same write semantics as `sed -i`. The
+  # generic interpreter-with-inline-code walker (guard.sh:626) blocks
+  # bare `perl -e` / `ruby -e`, but mis-classifies `-pi` / `-i` (which
+  # don't end in c/e/E) as "not inline code" and lets the call through.
+  # File operands then escape boundary validation entirely. Pentest
+  # reported this as a real bypass for /etc/<file> targets.
+  #
+  # Walker engages only when an `-i*` / `-pi*` / `--in-place*` token
+  # is present, then walks every positional after consuming flag/value
+  # pairs (`-e CODE`, `-E CODE`, `-M MOD`, `--`). Mirrors the sed -i
+  # walker's POSIX `--` handling.
+  if command_name_matches "perl|ruby"; then
+    local pr_has_inplace=0
+    local pr_tok
+    for pr_tok in "${CMD_TOKENS_SCAN[@]}"; do
+      local pr_t
+      pr_t=$(strip_quotes "$pr_tok")
+      case "$pr_t" in
+        -i|-i.*|-pi|-pi.*|--in-place|--in-place=*)
+          pr_has_inplace=1; break ;;
+      esac
+    done
+    if [ "$pr_has_inplace" -eq 1 ]; then
+      local pri=1 prn=${#CMD_TOKENS_SCAN[@]}
+      local pr_seen_dashdash=0
+      while [ $pri -lt $prn ]; do
+        local prtok
+        prtok=$(strip_quotes "${CMD_TOKENS_SCAN[$pri]}")
+        if [ $pr_seen_dashdash -eq 0 ]; then
+          case "$prtok" in
+            --)
+              pr_seen_dashdash=1; pri=$((pri + 1)); continue ;;
+            -e|-E|-M|-I|-x)
+              pri=$((pri + 2)); continue ;;
+            -*|'')
+              pri=$((pri + 1)); continue ;;
+          esac
+        fi
+        validate_command_path write "perl -i / ruby -i" "$prtok"
+        pri=$((pri + 1))
+      done
+    fi
+  fi
+
+  # --- awk -i inplace: gawk in-place edit (round-4 pentest) ---
+  # gawk's `-i inplace` (or `--include=inplace`) loads the inplace
+  # extension library and rewrites every FILE positional in place via
+  # temp-file + rename — same write semantics as `sed -i` / `perl -i`.
+  # Walker engages only when the inplace library is actually loaded;
+  # plain `awk PROG file` is read-only and stays ALLOWED.
+  #
+  # awk grammar:
+  #   awk [opts] 'PROG' file1 file2 ...        (positional PROG)
+  #   awk [opts] -f script.awk file1 ...       (no positional PROG)
+  #   awk [opts] -E script.awk file1 ...       (no positional PROG)
+  #   awk [opts] --source='PROG' file1 ...     (no positional PROG)
+  if command_name_matches "awk|gawk|mawk|nawk"; then
+    local awk_inplace=0
+    local awk_explicit_prog=0
+    local awk_t=1 awk_n=${#CMD_TOKENS_SCAN[@]}
+    while [ $awk_t -lt $awk_n ]; do
+      local atok
+      atok=$(strip_quotes "${CMD_TOKENS_SCAN[$awk_t]}")
+      case "$atok" in
+        -i|--include)
+          if [ $((awk_t + 1)) -lt $awk_n ]; then
+            local libtok
+            libtok=$(strip_quotes "${CMD_TOKENS_SCAN[$((awk_t + 1))]}")
+            [ "$libtok" = "inplace" ] && awk_inplace=1
+          fi
+          ;;
+        -iinplace|--include=inplace|--inplace|--inplace=*)
+          awk_inplace=1 ;;
+        -f|-E|--file|--exec|--source)
+          awk_explicit_prog=1 ;;
+        --file=*|--exec=*|--source=*)
+          awk_explicit_prog=1 ;;
+      esac
+      awk_t=$((awk_t + 1))
+    done
+    if [ "$awk_inplace" -eq 1 ]; then
+      local awk_prog_skipped=0
+      local awk_seen_dashdash=0
+      local wi=1 wn=${#CMD_TOKENS_SCAN[@]}
+      while [ $wi -lt $wn ]; do
+        local wtok
+        wtok=$(strip_quotes "${CMD_TOKENS_SCAN[$wi]}")
+        if [ $awk_seen_dashdash -eq 0 ]; then
+          case "$wtok" in
+            --)
+              awk_seen_dashdash=1; wi=$((wi + 1)); continue ;;
+            -F|-v|-f|-i|-l|-E|--field-separator|--assign|--file|--include|--load|--exec|--source)
+              wi=$((wi + 2)); continue ;;
+            -*|'')
+              wi=$((wi + 1)); continue ;;
+          esac
+        fi
+        if [ "$awk_explicit_prog" -eq 0 ] && [ "$awk_prog_skipped" -eq 0 ]; then
+          awk_prog_skipped=1
+          wi=$((wi + 1)); continue
+        fi
+        validate_command_path write "awk -i inplace" "$wtok"
+        wi=$((wi + 1))
+      done
+    fi
   fi
 }

--- a/plugins/project-boundary/hooks/lib/detectors/permissions.sh
+++ b/plugins/project-boundary/hooks/lib/detectors/permissions.sh
@@ -1,0 +1,219 @@
+#!/bin/bash
+# project-boundary guard — permissions / metadata detectors
+# =========================================================
+# Split out of hooks/lib/detectors/destructive.sh for the 500-line
+# file budget. This module groups every walker that mutates file
+# metadata (mode, owner, group, xattrs, BSD flags, capabilities,
+# Linux ext attrs). All STRICT — allowlist must not apply because
+# an attacker who can flip metadata on an allowlisted dir's
+# sibling path can still pivot.
+#
+# Same dynamic-scope contract as the rest of the detector cluster:
+# reads CMD, CMD_BLANKED, CMD_TOKENS_SCAN, EFFECTIVE_CWD,
+# PROJECT_DIR; helpers from hooks/lib/tokenize.sh + paths.sh +
+# command_name.sh. Each detector calls `exit 2` on a violation.
+
+# --- chmod / chown / chgrp boundary check ---
+# Weaponizable permission changes on files outside the project are
+# blocked. Separate function because chmod/chown originally run at
+# a later position in check_single_command than the xargs..ln
+# cluster; this lets us preserve the original evaluation order
+# from the caller.
+run_permissions_detectors() {
+  local CMD_NAME TARGET RESOLVED
+  for CMD_NAME in chmod chown chgrp; do
+    if echo "$CMD" | grep -qE "(^|[[:space:]])${CMD_NAME}($|[[:space:]])"; then
+      # Extract args after command name, skip flags, then skip the first
+      # non-flag token (mode for chmod, owner[:group] for chown)
+      local perm_raw
+      perm_raw=$(echo "$CMD" | grep -oE "(^|[[:space:]])${CMD_NAME}[[:space:]]+.*" | sed "s/^[[:space:]]*${CMD_NAME}[[:space:]]*//" || true)
+      local skipped_first=0
+      local skip_next=0
+      local has_reference=0
+      # When `--reference` (any form) is present, the spec operand
+      # is supplied via the referenced file — there is NO positional
+      # spec. Skipping the first positional as spec would silently
+      # let the actual TARGET escape the boundary check (Codex r5 P1).
+      if echo "$perm_raw" | grep -qE '(^|[[:space:]])\-\-reference(=|[[:space:]]|$)'; then
+        has_reference=1
+      fi
+
+      while IFS= read -r TARGET; do
+        [[ -z "$TARGET" ]] && continue
+        if [[ $skip_next -eq 1 ]]; then
+          skip_next=0
+          continue
+        fi
+        case "$TARGET" in
+          --reference) skip_next=1; continue ;;
+          --reference=*) continue ;;
+          -*) continue ;;
+        esac
+        if [[ $skipped_first -eq 0 && $has_reference -eq 0 ]]; then
+          skipped_first=1
+          continue
+        fi
+        # STRICT: chmod/chown can weaponize permissions; allowlist must not apply.
+        validate_command_path strict "$CMD_NAME" "$TARGET"
+      done < <(tokenize_args "$perm_raw")
+    fi
+  done
+
+  # --- setfattr: Linux extended attributes (round-5 pentest) ---
+  # Modifies xattrs in user.* / system.* namespaces; an attacker
+  # who can flip these on /etc/shadow can pivot. STRICT.
+  # Grammar: setfattr -n NAME -v VALUE FILE | -x NAME FILE
+  # Value-bearing flags: -n / --name, -v / --value, -x / --remove
+  # (and the `--name=` / `--value=` / `--remove=` long-attached
+  # forms). `--restore=DUMP` uses an embedded value — the FILE
+  # operand list is then empty, so leave that case untouched.
+  if command_name_is "setfattr"; then
+    local sfi=1 sfn=${#CMD_TOKENS_SCAN[@]}
+    local sf_seen_dashdash=0
+    while [ $sfi -lt $sfn ]; do
+      local sftok
+      sftok=$(strip_quotes "${CMD_TOKENS_SCAN[$sfi]}")
+      if [ $sf_seen_dashdash -eq 0 ]; then
+        case "$sftok" in
+          --) sf_seen_dashdash=1; sfi=$((sfi + 1)); continue ;;
+          -n|--name|-v|--value|-x|--remove) sfi=$((sfi + 2)); continue ;;
+          --name=*|--value=*|--remove=*|--restore=*) sfi=$((sfi + 1)); continue ;;
+          -*|'') sfi=$((sfi + 1)); continue ;;
+        esac
+      fi
+      validate_command_path strict setfattr "$sftok"
+      sfi=$((sfi + 1))
+    done
+  fi
+
+  # --- chflags: BSD/macOS file flags (round-5 pentest) ---
+  # Modifies uchg/schg/uappnd/etc. flags. Same threat profile
+  # as chmod. STRICT.
+  # Grammar: chflags [-R|-H|-L|-P|-h] FLAGS FILE...
+  # First non-flag positional is FLAGS spec (skip), rest are FILEs.
+  if command_name_is "chflags"; then
+    local cfi=1 cfn=${#CMD_TOKENS_SCAN[@]}
+    local cf_seen_dashdash=0
+    local cf_skipped_flags=0
+    while [ $cfi -lt $cfn ]; do
+      local cftok
+      cftok=$(strip_quotes "${CMD_TOKENS_SCAN[$cfi]}")
+      if [ $cf_seen_dashdash -eq 0 ]; then
+        case "$cftok" in
+          --) cf_seen_dashdash=1; cfi=$((cfi + 1)); continue ;;
+          -*|'') cfi=$((cfi + 1)); continue ;;
+        esac
+      fi
+      if [ $cf_skipped_flags -eq 0 ]; then
+        cf_skipped_flags=1
+        cfi=$((cfi + 1)); continue
+      fi
+      validate_command_path strict chflags "$cftok"
+      cfi=$((cfi + 1))
+    done
+  fi
+
+  # --- setcap: Linux capabilities (round-5 P3) ---
+  # `setcap CAP_SPEC FILE` grants capabilities (cap_net_bind_service,
+  # cap_sys_admin, ...) on FILE — privilege escalation primitive.
+  # `setcap -r FILE` removes all caps. STRICT.
+  # Bare flags: -q (quiet), -v (verify), -h (help), -n (no rootid),
+  # -e (existing cap), -f (cap from file). `-r` is the remove
+  # subcommand and changes positional shape (no spec operand).
+  if command_name_is "setcap"; then
+    local sci=1 scn=${#CMD_TOKENS_SCAN[@]}
+    local sc_seen_dashdash=0
+    local sc_remove=0
+    local sc_skipped_spec=0
+    # Pre-scan for -r (remove): no CAP_SPEC positional in that shape.
+    local _i
+    for ((_i=1; _i<scn; _i++)); do
+      case "$(strip_quotes "${CMD_TOKENS_SCAN[$_i]}")" in
+        -r|--remove) sc_remove=1; break ;;
+      esac
+    done
+    while [ $sci -lt $scn ]; do
+      local sctok
+      sctok=$(strip_quotes "${CMD_TOKENS_SCAN[$sci]}")
+      if [ $sc_seen_dashdash -eq 0 ]; then
+        case "$sctok" in
+          --) sc_seen_dashdash=1; sci=$((sci + 1)); continue ;;
+          -*|'') sci=$((sci + 1)); continue ;;
+        esac
+      fi
+      if [ $sc_remove -eq 0 ] && [ $sc_skipped_spec -eq 0 ]; then
+        sc_skipped_spec=1; sci=$((sci + 1)); continue
+      fi
+      validate_command_path strict setcap "$sctok"
+      sci=$((sci + 1))
+    done
+  fi
+
+  # --- chattr: Linux ext file attributes (round-5 P3) ---
+  # `chattr +i FILE` makes immutable; `+a` append-only; etc. Same
+  # weaponize-permissions threat as chmod. STRICT.
+  # Value-bearing pairs: -v VERSION (set version), -p PROJECT (project ID).
+  # Bare flags: -R (recursive), -V (verbose), -f (no errors), -h (help).
+  # First non-flag positional is MODE_SPEC (`+i`, `-a`, `=AS`); skip it.
+  if command_name_is "chattr"; then
+    local cai=1 can=${#CMD_TOKENS_SCAN[@]}
+    local ca_seen_dashdash=0
+    local ca_skipped_spec=0
+    while [ $cai -lt $can ]; do
+      local catok
+      catok=$(strip_quotes "${CMD_TOKENS_SCAN[$cai]}")
+      if [ $ca_seen_dashdash -eq 0 ]; then
+        case "$catok" in
+          --) ca_seen_dashdash=1; cai=$((cai + 1)); continue ;;
+          -v|-p) cai=$((cai + 2)); continue ;;
+          -R|-V|-f|-h) cai=$((cai + 1)); continue ;;
+          [+=]*|-[a-zA-Z]*)
+            # Mode spec — `+i`, `-i`, `=AS`, multi-letter combos.
+            # Codex round-5b P1: previously these matched the `-*`
+            # branch and were skipped as flags, leaving the FILE
+            # to be eaten by the spec-skip and never validated.
+            ca_skipped_spec=1
+            cai=$((cai + 1)); continue ;;
+          -*|'') cai=$((cai + 1)); continue ;;
+        esac
+      fi
+      if [ $ca_skipped_spec -eq 0 ]; then
+        ca_skipped_spec=1; cai=$((cai + 1)); continue
+      fi
+      validate_command_path strict chattr "$catok"
+      cai=$((cai + 1))
+    done
+  fi
+
+  # --- attr: alternative xattr setter (round-5 P3) ---
+  # `attr -s NAME -V VALUE FILE` sets, `attr -r NAME FILE` removes.
+  # Read actions (`-g`, `-l`) stay ALLOWED — gate the walker on
+  # presence of `-s` / `-r` in the token list.
+  if command_name_is "attr"; then
+    local atr_write=0
+    local _j
+    for ((_j=1; _j<${#CMD_TOKENS_SCAN[@]}; _j++)); do
+      case "$(strip_quotes "${CMD_TOKENS_SCAN[$_j]}")" in
+        -s|-r|--set|--remove|--set=*|--remove=*|-s?*|-r?*) atr_write=1; break ;;
+      esac
+    done
+    if [ $atr_write -eq 1 ]; then
+      local atri=1 atrn=${#CMD_TOKENS_SCAN[@]}
+      local atr_seen_dashdash=0
+      while [ $atri -lt $atrn ]; do
+        local atrtok
+        atrtok=$(strip_quotes "${CMD_TOKENS_SCAN[$atri]}")
+        if [ $atr_seen_dashdash -eq 0 ]; then
+          case "$atrtok" in
+            --) atr_seen_dashdash=1; atri=$((atri + 1)); continue ;;
+            -s|-V|-r|-g|--set|--value|--remove|--get) atri=$((atri + 2)); continue ;;
+            --set=*|--value=*|--remove=*|--get=*|-s?*|-r?*|-g?*|-V?*) atri=$((atri + 1)); continue ;;
+            -*|'') atri=$((atri + 1)); continue ;;
+          esac
+        fi
+        validate_command_path strict attr "$atrtok"
+        atri=$((atri + 1))
+      done
+    fi
+  fi
+}

--- a/plugins/project-boundary/hooks/lib/detectors/redirects.sh
+++ b/plugins/project-boundary/hooks/lib/detectors/redirects.sh
@@ -1,0 +1,192 @@
+#!/bin/bash
+# project-boundary guard — redirect/output write-target detectors
+# ===============================================================
+# tee, dd of=, and the catch-all unquoted-`>` redirect walker.
+# Split out of write_targets_b.sh by domain (Codex r5 finding #4).
+#
+# Same dynamic-scope contract as the rest of detectors/:
+# reads CMD, CMD_BLANKED, CMD_TOKENS, CMD_TOKENS_SCAN,
+# EFFECTIVE_CWD, PROJECT_DIR; helpers from
+# hooks/lib/tokenize.sh + paths.sh + command_name.sh +
+# options.sh. Calls `exit 2` on violation.
+
+run_redirect_detectors() {
+  local TARGET RESOLVED
+
+  # --- tee command: extract file arguments, block if outside project ---
+  # Substring regex (NOT command_name_is) by design for the wrapper-
+  # carry case: `docker run --rm -v /tmp:/data alpine tee /data/x.md`
+  # deliberately over-blocks because host-mount parsing is not in
+  # scope. CMD_BLANKED so a quoted-heredoc body that mentions `tee`
+  # is not tripped — Codex round-4 P3 (sec 99).
+  #
+  # VERB-GATE on a positive list — same reasoning as the rm walker in
+  # destructive.sh. tee itself + remote-dispatch wrappers (docker /
+  # podman / kubectl / oc / crictl / lxc / ssh / nsenter / chroot) +
+  # xargs (tee-by-input). Other verbs (git / gh / echo / printf /
+  # ...) skip — substring is text content.
+  if [[ "${CMD_VERB-}" =~ ^(tee|docker|podman|kubectl|oc|crictl|lxc|ssh|nsenter|chroot|xargs)$ ]] && \
+     echo "$CMD_BLANKED" | grep -qE '(^|[[:space:]])tee($|[[:space:]])'; then
+    local tee_raw
+    tee_raw=$(echo "$CMD" | grep -oE '(^|[[:space:]])tee[[:space:]]+.*' | sed 's/^[[:space:]]*tee[[:space:]]*//' || true)
+
+    while IFS= read -r TARGET; do
+      [[ -z "$TARGET" || "$TARGET" == -* ]] && continue
+      RESOLVED=$(resolve_command_path "$TARGET")
+      # /dev/null is a discard sink for tee (`echo x | tee /dev/null`).
+      is_discard_target "$RESOLVED" && continue
+      block_unless_path_allowed write tee "$RESOLVED"
+    done < <(tokenize_args "$tee_raw")
+  fi
+
+  # --- dd of= outside project ---
+  # dd accepts repeated key=value operands and the last one wins, so we must
+  # validate every of= occurrence — not just the first.
+  if command_name_is "dd"; then
+    local raw_tok
+    for raw_tok in "${CMD_TOKENS[@]}"; do
+      local tok
+      tok=$(strip_quotes "$raw_tok")
+      if [[ "$tok" == of=* ]]; then
+        local dd_output="${tok#of=}"
+        if [ -n "$dd_output" ]; then
+          local resolved_dd
+          resolved_dd=$(resolve_command_path "$dd_output")
+          # /dev/null is a discard sink (`dd if=x of=/dev/null`).
+          is_discard_target "$resolved_dd" && continue
+          block_unless_path_allowed write "dd output" "$resolved_dd"
+        fi
+      fi
+    done
+  fi
+
+  # --- Writing to files outside project via redirection ---
+  # Walk tokens and scan each one for an unquoted > operator anywhere
+  # (not just at the start). This catches both separated forms (`> file`,
+  # `2>> file`) and attached forms (`>file`, `x>file`, `"a">file`).
+  # Skips fd-to-fd redirects like 2>&1 (target starts with &).
+  #
+  # Iterate the heredoc-blanked token stream so a quoted-heredoc body
+  # mentioning "> /etc/foo" is not mistaken for a real redirect. Real
+  # redirects sit OUTSIDE any heredoc body and survive the blanking
+  # pass; an unquoted heredoc opener like `cat > /etc/x <<EOF ...EOF`
+  # still has the `>` and `/etc/x` in the command-context portion that
+  # is not blanked, so it stays caught.
+  local ri=0 rn=${#CMD_TOKENS_SCAN[@]}
+  while [ $ri -lt $rn ]; do
+    local rtok="${CMD_TOKENS_SCAN[$ri]}"
+    local REDIR_TARGET=""
+
+    # Scan the token for an unquoted > (respecting ' and " quotes and
+    # backslash escapes). `\>` outside single quotes is a literal >, not
+    # a redirect operator.
+    local j=0 tlen=${#rtok}
+    local tin_sq=0 tin_dq=0
+    local tin_esc=0
+    local redir_pos=-1
+    while [ $j -lt $tlen ]; do
+      local tc="${rtok:$j:1}"
+      if [ $tin_esc -eq 1 ]; then
+        tin_esc=0
+        j=$((j + 1))
+        continue
+      fi
+      if [ "$tc" = "\\" ] && [ $tin_sq -eq 0 ]; then
+        tin_esc=1
+        j=$((j + 1))
+        continue
+      fi
+      if [ "$tc" = "'" ] && [ $tin_dq -eq 0 ]; then
+        tin_sq=$(( 1 - tin_sq ))
+      elif [ "$tc" = '"' ] && [ $tin_sq -eq 0 ]; then
+        tin_dq=$(( 1 - tin_dq ))
+      elif [ "$tc" = ">" ] && [ $tin_sq -eq 0 ] && [ $tin_dq -eq 0 ]; then
+        redir_pos=$j
+        break
+      fi
+      j=$((j + 1))
+    done
+
+    if [ $redir_pos -lt 0 ]; then
+      ri=$((ri + 1))
+      continue
+    fi
+
+    # Found > at redir_pos. Extend past a second > if present (>>).
+    local op_end=$((redir_pos + 1))
+    if [ $op_end -lt $tlen ] && [ "${rtok:$op_end:1}" = ">" ]; then
+      op_end=$((op_end + 1))
+    fi
+    # Also consume a trailing | (Bash clobber operator: >| or >>|).
+    if [ $op_end -lt $tlen ] && [ "${rtok:$op_end:1}" = "|" ]; then
+      op_end=$((op_end + 1))
+    fi
+
+    # Extract target: rest of token if any, otherwise next token
+    local rest="${rtok:$op_end}"
+    if [ -z "$rest" ]; then
+      if [ $((ri + 1)) -lt $rn ]; then
+        REDIR_TARGET="${CMD_TOKENS_SCAN[$((ri + 1))]}"
+        ri=$((ri + 2))
+      else
+        ri=$((ri + 1))
+      fi
+    elif [[ "$rest" == \&* ]]; then
+      # fd-to-fd redirect like 2>&1, no file target
+      ri=$((ri + 1))
+    else
+      REDIR_TARGET="$rest"
+      ri=$((ri + 1))
+    fi
+
+    if [ -n "$REDIR_TARGET" ]; then
+      # Block process substitution — `> >(cmd)` runs `cmd` which the guard
+      # cannot safely inspect, similar to nested shells.
+      if [[ "$REDIR_TARGET" == \(* ]] || [[ "$REDIR_TARGET" == \>\(* ]] || [[ "$REDIR_TARGET" == \<\(* ]]; then
+        echo "BLOCKED: Process substitution redirect '$REDIR_TARGET' cannot be safely inspected. Ask user for explicit permission." >&2
+        exit 2
+      fi
+      local resolved_redir
+      resolved_redir=$(resolve_command_path "$REDIR_TARGET")
+      # Follow symlinks so that `echo x > project/link` where
+      # `link -> /etc/passwd` is caught. resolve_path only canonicalizes
+      # the dirname, not the basename — a symlink leaf slips through.
+      #
+      # Stop the chase at known discard sinks (kernel-managed fd
+      # aliases). On Linux `/dev/stdout` -> `/proc/self/fd/1` -> the
+      # real underlying fd target (a pipe, a log file, etc.); chasing
+      # past `/proc/self/fd/1` would mis-classify a stdout redirect
+      # as an outside-project write. macOS doesn't hit this because
+      # `/dev/fd/N` there is a character device, not a symlink, so
+      # the chase already stops naturally.
+      local redir_depth=20
+      local redir_hit_discard=0
+      while [[ -L "$resolved_redir" && $redir_depth -gt 0 ]]; do
+        if is_discard_target "$resolved_redir"; then
+          redir_hit_discard=1
+          break
+        fi
+        local redir_link
+        redir_link=$(readlink "$resolved_redir")
+        if [[ "$redir_link" == /* ]]; then
+          resolved_redir=$(resolve_path "$redir_link")
+        else
+          resolved_redir=$(resolve_path "$(dirname "$resolved_redir")/$redir_link")
+        fi
+        redir_depth=$((redir_depth - 1))
+      done
+      # A residual symlink after the chase means we exhausted depth or
+      # hit a cycle — fail closed. Discard sinks reach this point with
+      # their symlink intact, so the explicit early-exit flag suppresses
+      # the too-deep error.
+      if [[ -L "$resolved_redir" && $redir_hit_discard -eq 0 ]]; then
+        echo "BLOCKED: Redirect target symlink chain too deep or circular at '$resolved_redir'. Ask user for explicit permission." >&2
+        exit 2
+      fi
+      # /dev/null is a discard sink for every redirect form
+      # (`> /dev/null`, `2> /dev/null`, `&> /dev/null`, `2>&1 > /dev/null`).
+      is_discard_target "$resolved_redir" || \
+        block_unless_path_allowed write "Redirect target" "$resolved_redir"
+    fi
+  done
+}

--- a/plugins/project-boundary/hooks/lib/detectors/write_targets.sh
+++ b/plugins/project-boundary/hooks/lib/detectors/write_targets.sh
@@ -38,26 +38,24 @@ run_write_target_detectors() {
   # is the actual command-name token.
   if command_name_is install; then
     local install_raw
-    install_raw=$(echo "$CMD" | grep -oE '(^|[[:space:]])install[[:space:]]+.*' | sed 's/^[[:space:]]*install[[:space:]]*//' || true)
-    # Track whether the previous token was a flag whose VALUE we must
-    # skip on the next iteration. The previous walker also skipped any
-    # token matching the mode regex ^[0-9]+$ or owner[:group] regex
-    # ^[a-zA-Z_][a-zA-Z0-9_]*(:...)?$ unconditionally — that
-    # discarded legitimate file operands whose bare name happened to
-    # match (e.g. `install src 0755`, `install src root_wheel`),
-    # and when EFFECTIVE_CWD sat outside the project the unvalidated
-    # destination became a boundary bypass. install grammar puts
-    # mode/owner/group ONLY as the value of -m/--mode / -o/--owner /
-    # -g/--group, so positional skipping is safe to remove once the
-    # flag-value pairs are tracked explicitly.
-    # Reported by Copilot review on commit b6de687 (write_targets.sh:47).
+    # Scan CMD_BLANKED (heredoc-body wiped) so a quoted heredoc whose
+    # body mentions `install /etc/x` doesn't false-fire (issue #20,
+    # same shape as sec 99 for rm/tee).
+    install_raw=$(echo "$CMD_BLANKED" | grep -oE '(^|[[:space:]])install[[:space:]]+.*' | sed 's/^[[:space:]]*install[[:space:]]*//' || true)
+    # Skip the next token when the current one is a value-bearing flag
+    # (-m/--mode, -o/--owner, -g/--group). An earlier walker skipped
+    # tokens matching mode regex ^[0-9]+$ or owner[:group] regex
+    # unconditionally — that discarded legitimate file operands whose
+    # bare name happened to match (e.g. `install src 0755`,
+    # `install src root_wheel`) and became a boundary bypass when
+    # EFFECTIVE_CWD sat outside the project. install grammar puts
+    # mode/owner/group ONLY as the value of those flags, so explicit
+    # pair-tracking is safe.
     #
     # POSIX `--` end-of-options is also tracked: after the terminator,
     # every token is a positional operand even when its name begins
     # with `-`. Without this, a file operand like `-owned` slipped
     # past the flag-skip case and never reached is_inside_project.
-    # Same shape as the rsync POSIX `--` fix in this branch.
-    # Reported by Copilot review on commit c4a70e0 (write_targets.sh:67).
     local install_skip_next=0
     local install_seen_dashdash=0
     while IFS= read -r TARGET; do
@@ -67,19 +65,13 @@ run_write_target_detectors() {
       fi
       [[ -z "$TARGET" ]] && continue
       # Strip quotes for every flag test so `"--help"` and `--help`
-      # behave identically (bash strips quotes at exec time). For
-      # the attached form `--name=value` the walker only validates
-      # the value when name is on the WHITE-LIST of options that
-      # actually point at a write target — currently
-      # `--target-directory=`. All other -* tokens (including
-      # `--mode=`, `--owner=`, `--group=`, etc.) are skipped as
-      # flags — their values aren't paths, and even when they
-      # syntactically look like one (e.g. `--mode=/0644`), they
-      # never become a write destination. The white-list approach
-      # replaced an earlier
-      # `=*/*` heuristic that both missed relative values and
-      # over-matched benign options carrying `/` (Codex review on
-      # commit f76ec34, write_targets.sh:100 + 161).
+      # behave identically (bash strips quotes at exec time). The
+      # attached form `--name=value` is validated only when `name`
+      # is on a white-list of options that actually point at a write
+      # target — currently `--target-directory=`. All other -*
+      # tokens (--mode=, --owner=, --group=, ...) are skipped as
+      # flags; their values are not paths even when syntactically
+      # path-shaped (e.g. `--mode=/0644`).
       if [ $install_seen_dashdash -eq 0 ]; then
         local install_tok
         install_tok=$(strip_quotes "$TARGET")
@@ -89,17 +81,18 @@ run_write_target_detectors() {
         fi
         if [[ "$install_tok" == -* ]]; then
           if [[ "$install_tok" == --target-directory=* ]]; then
-            local install_attached_val="${install_tok#*=}"
-            install_attached_val=$(expand_path "$install_attached_val")
-            if [[ "$install_attached_val" != /* ]]; then
-              install_attached_val="$EFFECTIVE_CWD/$install_attached_val"
-            fi
-            local install_attached_resolved
-            install_attached_resolved=$(resolve_path "$install_attached_val")
-            if ! is_inside_project "$install_attached_resolved"; then
-              echo "BLOCKED: 'install --target-directory' targets '$install_attached_resolved' which is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
-              exit 2
-            fi
+            validate_command_path strict "install --target-directory" "${install_tok#*=}"
+            continue
+          fi
+          # Attached short `-t<dir>` (Codex sweep 5 Q4): the
+          # generic `-*` skip below treated this as a plain flag,
+          # so `install -t/tmp src.txt dst.txt` slipped past the
+          # boundary entirely. Split form `install -t /tmp src`
+          # already blocks because the next-token positional walk
+          # validates `/tmp` as a target; only the attached form
+          # needs explicit handling here.
+          if [[ "$install_tok" == -t?* ]]; then
+            validate_command_path strict "install -t" "${install_tok#-t}"
             continue
           fi
           case "$install_tok" in
@@ -109,30 +102,100 @@ run_write_target_detectors() {
           continue
         fi
       fi
-      TARGET=$(expand_path "$TARGET")
-      if [[ "$TARGET" != /* ]]; then
-        TARGET="$EFFECTIVE_CWD/$TARGET"
-      fi
-      RESOLVED=$(resolve_path "$TARGET")
-      if ! is_inside_project "$RESOLVED"; then
-        echo "BLOCKED: 'install' argument '$RESOLVED' is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
-        exit 2
-      fi
+      validate_command_path strict install "$TARGET"
     done < <(tokenize_args "$install_raw")
   fi
 
+  # --- mkdir: directory creation outside project ---
+  # `mkdir <path>` (and `mkdir -p`) creates filesystem structure
+  # outside the project — a "dropper" enabling later writes there.
+  # The plugin's contract is "blocks outside, allows inside", so
+  # creating directories outside violates the boundary even though
+  # mkdir doesn't destroy existing files.
+  #
+  # Uses command_name_is to avoid false-positives on subcommands
+  # named `mkdir` (none in widespread use, but consistent with the
+  # `install` walker pattern).
+  #
+  # Walker handles -m MODE / -Z CTX / --mode= / --context= flag
+  # forms and POSIX `--`. Boundary uses is_inside_project: STRICT
+  # (creating dirs outside isn't a write to a known target file,
+  # so allowlist semantics don't naturally apply — fail closed).
+  if command_name_is mkdir; then
+    local mkdir_raw
+    mkdir_raw=$(echo "$CMD" | grep -oE '(^|[[:space:]])mkdir[[:space:]]+.*' | sed 's/^[[:space:]]*mkdir[[:space:]]*//' || true)
+    # Strip leading wrappers (sudo, env, /bin/) so the tokenize parses
+    # the post-mkdir args. command_name_is already matched mkdir so the
+    # token is real.
+    local mkdir_skip_next=0
+    local mkdir_seen_dashdash=0
+    while IFS= read -r TARGET; do
+      if [ "$mkdir_skip_next" -eq 1 ]; then
+        mkdir_skip_next=0
+        continue
+      fi
+      [[ -z "$TARGET" ]] && continue
+      if [ $mkdir_seen_dashdash -eq 0 ]; then
+        local mkdir_tok
+        mkdir_tok=$(strip_quotes "$TARGET")
+        if [ "$mkdir_tok" = "--" ]; then
+          mkdir_seen_dashdash=1
+          continue
+        fi
+        if [[ "$mkdir_tok" == -* ]]; then
+          case "$mkdir_tok" in
+            -m|--mode|-Z|--context)
+              mkdir_skip_next=1 ;;
+            --mode=*|--context=*)
+              : ;;
+          esac
+          continue
+        fi
+      fi
+      validate_command_path strict mkdir "$TARGET"
+    done < <(tokenize_args "$mkdir_raw")
+  fi
+
   # --- rsync command: check all non-flag path arguments ---
-  if echo "$CMD" | grep -qE '(^|[[:space:]])rsync($|[[:space:]])'; then
+  if command_name_is "rsync"; then
     local rsync_raw
-    rsync_raw=$(echo "$CMD" | grep -oE '(^|[[:space:]])rsync[[:space:]]+.*' | sed 's/^[[:space:]]*rsync[[:space:]]*//' || true)
+    # Scan CMD_BLANKED so heredoc bodies mentioning `rsync /etc/foo`
+    # don't false-fire (issue #20).
+    rsync_raw=$(echo "$CMD_BLANKED" | grep -oE '(^|[[:space:]])rsync[[:space:]]+.*' | sed 's/^[[:space:]]*rsync[[:space:]]*//' || true)
+
+    # Pre-pass: detect dry-run. With --dry-run / -n rsync simulates
+    # the transfer and does NOT write to the destination, so the
+    # positional path validation false-positives `rsync --dry-run
+    # README.md /tmp/out` and the cluster form `rsync -avn ...`.
+    # The explicit write-shaped flags (--log-file=, --write-batch=,
+    # --backup-dir=, --partial-dir=, --temp-dir=, --only-write-batch=)
+    # MAY still write under --dry-run, so they keep their per-flag
+    # validation below.
+    local rsync_dryrun=0
+    local _rdr_tok
+    while IFS= read -r _rdr_tok; do
+      _rdr_tok=$(strip_quotes "$_rdr_tok")
+      [ -z "$_rdr_tok" ] && continue
+      case "$_rdr_tok" in
+        --) break ;;
+        --dry-run) rsync_dryrun=1; break ;;
+        --*) ;;
+        -*)
+          local _rdr_rest="${_rdr_tok#-}" _rdr_ch
+          while [ -n "$_rdr_rest" ]; do
+            _rdr_ch="${_rdr_rest:0:1}"
+            _rdr_rest="${_rdr_rest:1}"
+            if [ "$_rdr_ch" = "n" ]; then rsync_dryrun=1; break; fi
+          done
+          ;;
+      esac
+    done < <(tokenize_args "$rsync_raw")
+
     # Track POSIX `--` end-of-options. After it, every token is a
     # positional operand even when its name begins with `-`. Without
     # this, a file operand like `-owned` slipped past the
     # `[[ "$TARGET" == -* ]] && continue` flag-skip and never
-    # reached is_inside_project. Same shape as the sed-i and
-    # truncate POSIX `--` fix shipped in PR #12 for those two
-    # walkers. Reported by Copilot review on commit b6de687
-    # (write_targets.sh:66).
+    # reached is_inside_project.
     local rsync_seen_dashdash=0
     while IFS= read -r TARGET; do
       [[ -z "$TARGET" ]] && continue
@@ -151,9 +214,7 @@ run_write_target_detectors() {
         # --rsync-path=REMOTE_BIN, --read-batch=PATH (read-only),
         # and the read-only --*-from= filter file flags are
         # skipped as ordinary flags so the detector does not
-        # over-match (Codex review on commit f76ec34,
-        # write_targets.sh:161, with --write-batch=/--only-write-
-        # batch= added per Codex review on commit 00d7300).
+        # over-match.
         local rsync_tok
         rsync_tok=$(strip_quotes "$TARGET")
         if [ "$rsync_tok" = "--" ]; then
@@ -163,17 +224,7 @@ run_write_target_detectors() {
         if [[ "$rsync_tok" == -* ]]; then
           case "$rsync_tok" in
             --log-file=*|--partial-dir=*|--backup-dir=*|--temp-dir=*|--write-batch=*|--only-write-batch=*)
-              local rsync_attached_val="${rsync_tok#*=}"
-              rsync_attached_val=$(expand_path "$rsync_attached_val")
-              if [[ "$rsync_attached_val" != /* ]]; then
-                rsync_attached_val="$EFFECTIVE_CWD/$rsync_attached_val"
-              fi
-              local rsync_attached_resolved
-              rsync_attached_resolved=$(resolve_path "$rsync_attached_val")
-              if ! is_inside_project "$rsync_attached_resolved"; then
-                echo "BLOCKED: 'rsync ${rsync_tok%%=*}' targets '$rsync_attached_resolved' which is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
-                exit 2
-              fi
+              validate_command_path strict "rsync ${rsync_tok%%=*}" "${rsync_tok#*=}"
               ;;
           esac
           continue
@@ -186,7 +237,7 @@ run_write_target_detectors() {
       #   rsync://host/path   (URL form)
       # A local path may legitimately contain `:` AFTER a slash
       # (e.g. `../tmp/a:b`); a raw `=~ :` test would skip it and bypass
-      # the boundary check. Reported by Copilot review on PR #137.
+      # the boundary check.
       case "$TARGET" in
         rsync://*) continue ;;
       esac
@@ -195,303 +246,388 @@ run_write_target_detectors() {
         *:*) continue ;;
       esac
       unset _rsync_first_seg
-      TARGET=$(expand_path "$TARGET")
-      if [[ "$TARGET" != /* ]]; then
-        TARGET="$EFFECTIVE_CWD/$TARGET"
-      fi
-      RESOLVED=$(resolve_path "$TARGET")
-      if ! is_inside_project "$RESOLVED"; then
-        echo "BLOCKED: 'rsync' argument '$RESOLVED' is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
-        exit 2
-      fi
+      # In dry-run, no writes happen at the destination — skip
+      # positional validation. Per-flag write-target checks (above)
+      # still run because rsync writes the log/batch/backup files
+      # even in dry-run.
+      [ "$rsync_dryrun" -eq 1 ] && continue
+      validate_command_path strict rsync "$TARGET"
     done < <(tokenize_args "$rsync_raw")
   fi
 
   # --- tar: check every -C / --directory=PATH for extraction ---
   # tar allows multiple -C switches and the *last* one wins, so we must
   # validate every occurrence — not just the first.
-  if echo "$CMD" | grep -qE '(^|[[:space:]])tar($|[[:space:]])'; then
-    local ti=0 tn=${#CMD_TOKENS[@]}
-    while [ $ti -lt $tn ]; do
-      local ttok
-      ttok=$(strip_quotes "${CMD_TOKENS[$ti]}")
-      local tar_dir=""
-      if [ "$ttok" = "-C" ] || [ "$ttok" = "--directory" ]; then
-        if [ $((ti + 1)) -lt $tn ]; then
-          tar_dir="${CMD_TOKENS[$((ti + 1))]}"
-          ti=$((ti + 2))
+  #
+  # Mode-aware: -C is only a write target in EXTRACT mode (-x / --extract
+  # / --get). For -c/--create, -r/--append, -u/--update, -A/--catenate,
+  # tar READS source files from -C; for -t/--list and -d/--diff/--compare
+  # tar reads only — none of these write into -C. The previous unconditional
+  # check false-positived legitimate `tar -tf archive.tar -C /tmp`,
+  # `tar -cf out.tar -C /tmp file`, etc.
+  #
+  # Conservative default: when the mode flag is absent or unrecognised,
+  # KEEP the prior block — preserves coverage of any tar invocation
+  # whose mode this walker didn't classify.
+  if command_name_is "tar"; then
+    # Use CMD_TOKENS_SCAN (heredoc-body wiped) so a quoted heredoc
+    # whose body mentions `tar -xf x -C /etc/foo` doesn't fool the
+    # mode pre-pass or the -C / -f validation passes (issue #20).
+    local tar_mode="" tar_writes_archive=0 ti=1 tn=${#CMD_TOKENS_SCAN[@]}
+    while [ $ti -lt $tn ] && [ -z "$tar_mode" ]; do
+      local mtok
+      mtok=$(strip_quotes "${CMD_TOKENS_SCAN[$ti]}")
+      case "$mtok" in
+        --extract|--get)
+          tar_mode=extract ;;
+        --create|--append|--update|--catenate|--concatenate|--delete)
+          tar_mode=read_or_nonC; tar_writes_archive=1 ;;
+        --list|--diff|--compare|--test-label)
+          tar_mode=read_or_nonC ;;
+        --*)
+          : ;;
+        -*)
+          # Short cluster: scan letters. Mode chars are mutually exclusive
+          # in tar grammar, so the first one we hit wins.
+          local _rest="${mtok#-}" _ch
+          while [ -n "$_rest" ]; do
+            _ch="${_rest:0:1}"
+            _rest="${_rest:1}"
+            case "$_ch" in
+              x) tar_mode=extract; break ;;
+              c|r|u|A) tar_mode=read_or_nonC; tar_writes_archive=1; break ;;
+              t|d) tar_mode=read_or_nonC; break ;;
+            esac
+          done
+          ;;
+      esac
+      ti=$((ti + 1))
+    done
+
+    # Only enforce -C when mode=extract OR mode=unknown (fail-closed for
+    # uncategorised invocations).
+    if [ "$tar_mode" != "read_or_nonC" ]; then
+      ti=0
+      while [ $ti -lt $tn ]; do
+        local ttok
+        ttok=$(strip_quotes "${CMD_TOKENS_SCAN[$ti]}")
+        local tar_dir=""
+        if [ "$ttok" = "-C" ] || [ "$ttok" = "--directory" ]; then
+          if [ $((ti + 1)) -lt $tn ]; then
+            tar_dir="${CMD_TOKENS_SCAN[$((ti + 1))]}"
+            ti=$((ti + 2))
+          else
+            ti=$((ti + 1))
+          fi
+        elif [[ "$ttok" == "--directory="* ]]; then
+          tar_dir="${ttok#--directory=}"
+          ti=$((ti + 1))
         else
           ti=$((ti + 1))
+          continue
         fi
-      elif [[ "$ttok" == "--directory="* ]]; then
-        tar_dir="${ttok#--directory=}"
-        ti=$((ti + 1))
-      else
-        ti=$((ti + 1))
-        continue
-      fi
-      if [ -n "$tar_dir" ]; then
-        tar_dir=$(expand_path "$tar_dir")
-        if [[ "$tar_dir" != /* ]]; then
-          tar_dir="$EFFECTIVE_CWD/$tar_dir"
+        [ -n "$tar_dir" ] && validate_command_path write "tar -C" "$tar_dir"
+      done
+    fi
+
+    # -f / --file is a write target in archive-write modes (c/r/u/A and
+    # --delete which rewrites in place). Read modes (t/d) and extract
+    # (x) read -f and don't need this check. The previous walker never
+    # validated -f, so `tar -cf /tmp/out.tar src`,
+    # `tar --delete -f /tmp/archive.tar member`, etc. bypassed the
+    # boundary entirely (Codex bonus finding).
+    if [ "$tar_writes_archive" -eq 1 ]; then
+      local _tfi=1
+      while [ $_tfi -lt $tn ]; do
+        local _tftok
+        _tftok=$(strip_quotes "${CMD_TOKENS_SCAN[$_tfi]}")
+        local _tfval="" _tf_consumed=0
+        case "$_tftok" in
+          --) break ;;
+          --file=*)
+            _tfval="${_tftok#--file=}" ;;
+          --file)
+            if [ $((_tfi + 1)) -lt $tn ]; then
+              _tfval=$(strip_quotes "${CMD_TOKENS_SCAN[$((_tfi + 1))]}")
+              _tf_consumed=1
+            fi
+            ;;
+          -*)
+            # Find 'f' anywhere in the cluster. Per GNU tar grammar an
+            # option that takes an argument always reads the NEXT argv
+            # element when in a short cluster, regardless of where in
+            # the cluster it sits — so `-cf out.tar`, `-cvf out.tar`,
+            # `-czf out.tar.gz`, and `-cfz out.tar` all consume the
+            # next token as the archive path.
+            local _tfrest="${_tftok#-}" _tfpos=0 _tflen=${#_tftok} _tfch _tff_seen=0
+            _tflen=${#_tfrest}
+            while [ $_tfpos -lt $_tflen ]; do
+              _tfch="${_tfrest:$_tfpos:1}"
+              if [ "$_tfch" = "f" ]; then _tff_seen=1; break; fi
+              _tfpos=$((_tfpos + 1))
+            done
+            if [ $_tff_seen -eq 1 ] && [ $((_tfi + 1)) -lt $tn ]; then
+              _tfval=$(strip_quotes "${CMD_TOKENS_SCAN[$((_tfi + 1))]}")
+              _tf_consumed=1
+            fi
+            ;;
+        esac
+        if [ -n "$_tfval" ] && [ "$_tfval" != "-" ]; then
+          # `-f -` is the stdout sink — discard endpoint, allow.
+          validate_command_path write "tar -f" "$_tfval"
         fi
-        local resolved_tar
-        resolved_tar=$(resolve_path "$tar_dir")
-        if ! is_write_permitted "$resolved_tar"; then
-          echo "BLOCKED: 'tar -C' targets '$resolved_tar' which is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
-          exit 2
+        if [ $_tf_consumed -eq 1 ]; then
+          _tfi=$((_tfi + 2))
+        else
+          _tfi=$((_tfi + 1))
         fi
-      fi
-    done
+      done
+    fi
   fi
 
   # --- unzip -d PATH ---
-  if echo "$CMD" | grep -qE '(^|[[:space:]])unzip($|[[:space:]])'; then
-    local unzip_dir
-    while IFS= read -r unzip_dir; do
-      [ -z "$unzip_dir" ] && continue
-      unzip_dir=$(expand_path "$unzip_dir")
-      if [[ "$unzip_dir" != /* ]]; then
-        unzip_dir="$EFFECTIVE_CWD/$unzip_dir"
-      fi
-      local resolved_unzip
-      resolved_unzip=$(resolve_path "$unzip_dir")
-      if ! is_write_permitted "$resolved_unzip"; then
-        echo "BLOCKED: 'unzip -d' targets '$resolved_unzip' which is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
-        exit 2
-      fi
-    done < <(extract_option_values "-d" "" || true)
+  # unzip writes into -d only when extracting. The read-only mode
+  # flags don't extract anything:
+  #   -l   list contents
+  #   -v   verbose list
+  #   -t   test archive integrity
+  #   -p   pipe extract to stdout
+  #   -Z   zipinfo mode (entirely different option grammar)
+  # In these modes -d is either ignored or has unrelated semantics.
+  # Skip the walker so `unzip -l archive.zip -d /tmp` doesn't false-fire.
+  if command_name_is "unzip"; then
+    # Scan heredoc-body-blanked tokens (issue #20) so a quoted
+    # heredoc whose body mentions `unzip ... -d /etc` doesn't
+    # false-fire.
+    local unzip_readonly=0 ui=1 un=${#CMD_TOKENS_SCAN[@]}
+    while [ $ui -lt $un ]; do
+      local utok
+      utok=$(strip_quotes "${CMD_TOKENS_SCAN[$ui]}")
+      case "$utok" in
+        --) break ;;
+        -*)
+          # short cluster: scan letters; stop when we hit a value-bearing
+          # flag (d/P/x consume the rest as their value). Without the
+          # stop, `-d/tmp` would scan `t` and `p` from the path bytes
+          # and mark the invocation as read-only — masking the
+          # extraction.
+          local _u_rest="${utok#-}" _u_ch
+          while [ -n "$_u_rest" ]; do
+            _u_ch="${_u_rest:0:1}"
+            _u_rest="${_u_rest:1}"
+            case "$_u_ch" in
+              d|P|x) break ;;
+              l|v|t|p|Z) unzip_readonly=1 ;;
+            esac
+          done
+          ;;
+      esac
+      ui=$((ui + 1))
+    done
+    if [ "$unzip_readonly" -eq 0 ]; then
+      # Custom walker for -d. extract_option_values only handles split
+      # short (`-d VAL`) and `--long=VAL`, missing the shapes that real
+      # unzip accepts:
+      #   -d/tmp           attached value
+      #   -od /tmp         cluster end, split value
+      #   -od/tmp          cluster end, attached value
+      #   -do/tmp          d mid-cluster, attached value (rest after d)
+      # extract_option_values' coverage gap was a real bypass, not a
+      # FP4 regression — predates this walker.
+      local di=1 dn=${#CMD_TOKENS_SCAN[@]}
+      while [ $di -lt $dn ]; do
+        local dtok
+        dtok=$(strip_quotes "${CMD_TOKENS_SCAN[$di]}")
+        local dval=""
+        local _consumed_next=0
+        case "$dtok" in
+          --) break ;;
+          --*) di=$((di + 1)); continue ;;
+          -*)
+            local _drest="${dtok#-}"
+            # Find first 'd' in the cluster.
+            local _dpos=0 _dlen=${#_drest} _dch _df_d=-1
+            while [ $_dpos -lt $_dlen ]; do
+              _dch="${_drest:$_dpos:1}"
+              if [ "$_dch" = "d" ]; then _df_d=$_dpos; break; fi
+              _dpos=$((_dpos + 1))
+            done
+            if [ $_df_d -ge 0 ]; then
+              local _after="${_drest:$((_df_d + 1))}"
+              if [ -n "$_after" ]; then
+                dval="$_after"
+              elif [ $((di + 1)) -lt $dn ]; then
+                dval=$(strip_quotes "${CMD_TOKENS_SCAN[$((di + 1))]}")
+                _consumed_next=1
+              fi
+            fi
+            ;;
+          *)
+            di=$((di + 1)); continue ;;
+        esac
+        if [ -n "$dval" ]; then
+          validate_command_path write "unzip -d" "$dval"
+        fi
+        if [ $_consumed_next -eq 1 ]; then
+          di=$((di + 2))
+        else
+          di=$((di + 1))
+        fi
+      done
+    fi
   fi
 
   # --- cpio -D PATH ---
-  if echo "$CMD" | grep -qE '(^|[[:space:]])cpio($|[[:space:]])'; then
-    local cpio_dir
-    while IFS= read -r cpio_dir; do
-      [ -z "$cpio_dir" ] && continue
-      cpio_dir=$(expand_path "$cpio_dir")
-      if [[ "$cpio_dir" != /* ]]; then
-        cpio_dir="$EFFECTIVE_CWD/$cpio_dir"
-      fi
-      local resolved_cpio
-      resolved_cpio=$(resolve_path "$cpio_dir")
-      if ! is_write_permitted "$resolved_cpio"; then
-        echo "BLOCKED: 'cpio -D' targets '$resolved_cpio' which is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
-        exit 2
-      fi
-    done < <(extract_option_values "-D" "" || true)
-  fi
-
-  # --- tee command: extract file arguments, block if outside project ---
-  if echo "$CMD" | grep -qE '(^|[[:space:]])tee($|[[:space:]])'; then
-    local tee_raw
-    tee_raw=$(echo "$CMD" | grep -oE '(^|[[:space:]])tee[[:space:]]+.*' | sed 's/^[[:space:]]*tee[[:space:]]*//' || true)
-
-    while IFS= read -r TARGET; do
-      [[ -z "$TARGET" || "$TARGET" == -* ]] && continue
-      TARGET=$(expand_path "$TARGET")
-      if [[ "$TARGET" != /* ]]; then
-        TARGET="$EFFECTIVE_CWD/$TARGET"
-      fi
-      RESOLVED=$(resolve_path "$TARGET")
-
-      # /dev/null is a discard sink for tee (`echo x | tee /dev/null`).
-      is_discard_target "$RESOLVED" && continue
-      if ! is_write_permitted "$RESOLVED"; then
-        echo "BLOCKED: 'tee' targets '$RESOLVED' which is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
-        exit 2
-      fi
-    done < <(tokenize_args "$tee_raw")
-  fi
-
-  # --- curl -o / curl --output outside project ---
-  # curl -o is positional: `curl -o out1 URL1 -o out2 URL2` writes each URL
-  # to its corresponding output. Validate EVERY occurrence.
-  if echo "$CMD" | grep -qE '(^|[[:space:]])curl($|[[:space:]])'; then
-    local curl_output
-    while IFS= read -r curl_output; do
-      [ -z "$curl_output" ] && continue
-      curl_output=$(expand_path "$curl_output")
-      if [[ "$curl_output" != /* ]]; then
-        curl_output="$EFFECTIVE_CWD/$curl_output"
-      fi
-      local resolved_curl
-      resolved_curl=$(resolve_path "$curl_output")
-      # /dev/null is a discard sink for HTTP probes (`curl -o /dev/null -w %{http_code}`).
-      is_discard_target "$resolved_curl" && continue
-      if ! is_write_permitted "$resolved_curl"; then
-        echo "BLOCKED: 'curl' output file '$resolved_curl' is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
-        exit 2
-      fi
-    done < <(extract_option_values "-o" "--output" || true)
-  fi
-
-  # --- wget -O / wget --output-document outside project ---
-  if echo "$CMD" | grep -qE '(^|[[:space:]])wget($|[[:space:]])'; then
-    local wget_output
-    while IFS= read -r wget_output; do
-      [ -z "$wget_output" ] && continue
-      wget_output=$(expand_path "$wget_output")
-      if [[ "$wget_output" != /* ]]; then
-        wget_output="$EFFECTIVE_CWD/$wget_output"
-      fi
-      local resolved_wget
-      resolved_wget=$(resolve_path "$wget_output")
-      # /dev/null is a discard sink (`wget -O /dev/null URL`).
-      is_discard_target "$resolved_wget" && continue
-      if ! is_write_permitted "$resolved_wget"; then
-        echo "BLOCKED: 'wget' output file '$resolved_wget' is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
-        exit 2
-      fi
-    done < <(extract_option_values "-O" "--output-document" || true)
-  fi
-
-  # --- dd of= outside project ---
-  # dd accepts repeated key=value operands and the last one wins, so we must
-  # validate every of= occurrence — not just the first.
-  if echo "$CMD" | grep -qE '(^|[[:space:]])dd($|[[:space:]])'; then
-    local raw_tok
-    for raw_tok in "${CMD_TOKENS[@]}"; do
-      local tok
-      tok=$(strip_quotes "$raw_tok")
-      if [[ "$tok" == of=* ]]; then
-        local dd_output="${tok#of=}"
-        if [ -n "$dd_output" ]; then
-          dd_output=$(expand_path "$dd_output")
-          if [[ "$dd_output" != /* ]]; then
-            dd_output="$EFFECTIVE_CWD/$dd_output"
-          fi
-          local resolved_dd
-          resolved_dd=$(resolve_path "$dd_output")
-          # /dev/null is a discard sink (`dd if=x of=/dev/null`).
-          if ! is_discard_target "$resolved_dd"; then
-            if ! is_write_permitted "$resolved_dd"; then
-              echo "BLOCKED: 'dd' output '$resolved_dd' is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
-              exit 2
-            fi
-          fi
-        fi
-      fi
-    done
-  fi
-
-  # --- Writing to files outside project via redirection ---
-  # Walk tokens and scan each one for an unquoted > operator anywhere
-  # (not just at the start). This catches both separated forms (`> file`,
-  # `2>> file`) and attached forms (`>file`, `x>file`, `"a">file`).
-  # Skips fd-to-fd redirects like 2>&1 (target starts with &).
+  # cpio's -D is the destination dir only in copy-in extract mode
+  # (`-i` without `-t`). In list mode (`-it` / `-i -t`) no files are
+  # extracted, so -D is unused — `cpio -it -D /tmp < archive` was a
+  # false positive.
   #
-  # Iterate the heredoc-blanked token stream so a quoted-heredoc body
-  # mentioning "> /etc/foo" is not mistaken for a real redirect. Real
-  # redirects sit OUTSIDE any heredoc body and survive the blanking
-  # pass; an unquoted heredoc opener like `cat > /etc/x <<EOF ...EOF`
-  # still has the `>` and `/etc/x` in the command-context portion that
-  # is not blanked, so it stays caught.
-  local ri=0 rn=${#CMD_TOKENS_SCAN[@]}
-  while [ $ri -lt $rn ]; do
-    local rtok="${CMD_TOKENS_SCAN[$ri]}"
-    local REDIR_TARGET=""
-
-    # Scan the token for an unquoted > (respecting ' and " quotes and
-    # backslash escapes). `\>` outside single quotes is a literal >, not
-    # a redirect operator.
-    local j=0 tlen=${#rtok}
-    local tin_sq=0 tin_dq=0
-    local tin_esc=0
-    local redir_pos=-1
-    while [ $j -lt $tlen ]; do
-      local tc="${rtok:$j:1}"
-      if [ $tin_esc -eq 1 ]; then
-        tin_esc=0
-        j=$((j + 1))
-        continue
-      fi
-      if [ "$tc" = "\\" ] && [ $tin_sq -eq 0 ]; then
-        tin_esc=1
-        j=$((j + 1))
-        continue
-      fi
-      if [ "$tc" = "'" ] && [ $tin_dq -eq 0 ]; then
-        tin_sq=$(( 1 - tin_sq ))
-      elif [ "$tc" = '"' ] && [ $tin_sq -eq 0 ]; then
-        tin_dq=$(( 1 - tin_dq ))
-      elif [ "$tc" = ">" ] && [ $tin_sq -eq 0 ] && [ $tin_dq -eq 0 ]; then
-        redir_pos=$j
-        break
-      fi
-      j=$((j + 1))
+  # Copy-out (`-o`) reads from -D into the archive; copy-pass (`-p`)
+  # writes copies into a destination passed as a positional, not via
+  # -D. This patch only addresses the `-t` (list) FP; other modes
+  # keep current behavior (write policy + allowlist).
+  if command_name_is "cpio"; then
+    # Scan heredoc-body-blanked tokens (issue #20).
+    local cpio_listmode=0 ci=1 cn=${#CMD_TOKENS_SCAN[@]}
+    while [ $ci -lt $cn ]; do
+      local ctok
+      ctok=$(strip_quotes "${CMD_TOKENS_SCAN[$ci]}")
+      case "$ctok" in
+        --) break ;;
+        --list) cpio_listmode=1 ;;
+        -*)
+          # Stop at value-bearing flags (cpio: -D dir, -F file,
+          # -H fmt, -R owner, -M msg, -O archive, -I archive,
+          # -K maxlen). Without the stop, `-D/tmp` would scan `t`
+          # from the path bytes and flip listmode incorrectly —
+          # same pre-pass bug fixed for unzip in sec 102.
+          local _c_rest="${ctok#-}" _c_ch
+          while [ -n "$_c_rest" ]; do
+            _c_ch="${_c_rest:0:1}"
+            _c_rest="${_c_rest:1}"
+            case "$_c_ch" in
+              D|F|H|R|M|O|I|K) break ;;
+              t) cpio_listmode=1 ;;
+            esac
+          done
+          ;;
+      esac
+      ci=$((ci + 1))
     done
+    if [ "$cpio_listmode" -eq 0 ]; then
+      local cpio_dir
+      while IFS= read -r cpio_dir; do
+        [ -z "$cpio_dir" ] && continue
+        validate_command_path write "cpio -D" "$cpio_dir"
+      done < <(extract_attached_or_split_from CMD_TOKENS_SCAN -D "" || true)
+    fi
+  fi
 
-    if [ $redir_pos -lt 0 ]; then
-      ri=$((ri + 1))
-      continue
-    fi
+  # --- 7z / 7za / 7zr / 7zz: -o<dir> extract dest + a/u/d/rn archive ---
+  # 7-Zip's spec mandates ATTACHED form `-o<dir>` (no space). The unzip
+  # walker uses extract_option_values which only matches separated
+  # `-o VAL` / `--output=VAL`, so the attached form slipped through
+  # entirely. Round-4 pentest discovered the gap.
+  #
+  # Two write paths to cover:
+  #   - extraction destination: any token of the form `-o<dir>`
+  #   - write-mode verbs: a (add), u (update), d (delete), rn (rename)
+  #     — the next non-flag positional after the verb is the ARCHIVE
+  #     and is created/rewritten in place.
+  #
+  # Read-only verbs (x/e w/o -o, l, t, b, h, i) write at most into
+  # the existing in-project cwd, which is already bounded by the
+  # project-boundary check on EFFECTIVE_CWD.
+  if command_name_matches "7z|7za|7zr|7zz|7zzs"; then
+    # Pre-pass: locate verb (first non-flag positional after binary).
+    # The verb gates Pass 1 (-o<dir>) and Pass 1b (-w<path>): for
+    # read-only verbs (l/t/h/i/b) -o is unused (no extraction) and -w
+    # is unused (no temp work). Previously these passes ran for every
+    # verb and false-positived `7z l archive.7z -o/tmp` and
+    # `7z t archive.7z -o/tmp`.
+    local zn=${#CMD_TOKENS_SCAN[@]}
+    local zci=1 zcmd=""
+    while [ $zci -lt $zn ]; do
+      local zct
+      zct=$(strip_quotes "${CMD_TOKENS_SCAN[$zci]}")
+      case "$zct" in
+        # Codex#4 LOW: bare `-o` / `-w` (split form) takes the next
+        # token as its value. Without skipping that next token here
+        # the verb-detector consumes the value as the verb, so
+        # `7z -w /tmp l archive` mis-classified `/tmp` as the verb
+        # and Pass 1b validated `-w` despite the read-only `l`.
+        -o|-w)
+          zci=$((zci + 2)); continue ;;
+        -*|'') zci=$((zci + 1)); continue ;;
+        *)     zcmd="$zct"; break ;;
+      esac
+    done
+    local z_readonly_verb=0
+    case "$zcmd" in
+      l|t|h|i|b) z_readonly_verb=1 ;;
+    esac
 
-    # Found > at redir_pos. Extend past a second > if present (>>).
-    local op_end=$((redir_pos + 1))
-    if [ $op_end -lt $tlen ] && [ "${rtok:$op_end:1}" = ">" ]; then
-      op_end=$((op_end + 1))
+    # Pass 1: -o<dir> extraction destination — both attached
+    # (`-o<dir>`, no space) and split (`-o <dir>`, space) forms.
+    # 7-Zip docs mandate attached, but most builds also accept split,
+    # so fail-closed covers both.
+    if [ "$z_readonly_verb" -eq 0 ]; then
+    local zi=1
+    while [ $zi -lt $zn ]; do
+      local ztok
+      ztok=$(strip_quotes "${CMD_TOKENS_SCAN[$zi]}")
+      local zdir=""
+      if [[ "$ztok" == -o?* ]]; then
+        zdir="${ztok#-o}"
+      elif [ "$ztok" = "-o" ] && [ $((zi + 1)) -lt $zn ]; then
+        zdir=$(strip_quotes "${CMD_TOKENS_SCAN[$((zi + 1))]}")
+        zi=$((zi + 1))
+      fi
+      [ -n "$zdir" ] && validate_command_path write "7z -o<dir>" "$zdir"
+      zi=$((zi + 1))
+    done
+    # Pass 1b: -w<path> working-directory (Codex round-4 follow-up).
+    # `-w[<path>]` selects 7z's temp/work dir for intermediate files.
+    # An outside-project <path> is a real boundary violation (analogous
+    # to `-o<dir>`). Bare `-w` with no value uses the system default
+    # and is left ALLOWED. Both attached and split forms are covered.
+    local wzi=1
+    while [ $wzi -lt $zn ]; do
+      local wztok
+      wztok=$(strip_quotes "${CMD_TOKENS_SCAN[$wzi]}")
+      local wdir=""
+      if [[ "$wztok" == -w?* ]]; then
+        wdir="${wztok#-w}"
+      elif [ "$wztok" = "-w" ] && [ $((wzi + 1)) -lt $zn ]; then
+        wdir=$(strip_quotes "${CMD_TOKENS_SCAN[$((wzi + 1))]}")
+        wzi=$((wzi + 1))
+      fi
+      [ -n "$wdir" ] && validate_command_path write "7z -w<path>" "$wdir"
+      wzi=$((wzi + 1))
+    done
     fi
-    # Also consume a trailing | (Bash clobber operator: >| or >>|).
-    if [ $op_end -lt $tlen ] && [ "${rtok:$op_end:1}" = "|" ]; then
-      op_end=$((op_end + 1))
-    fi
+    # Pass 2: if verb is a write-mode verb, validate the next positional
+    # as ARCHIVE. zci/zcmd were already resolved in the pre-pass above.
+    case "$zcmd" in
+      a|u|d|rn)
+        local zai=$((zci + 1))
+        local zai_seen_dashdash=0
+        while [ $zai -lt $zn ]; do
+          local zat
+          zat=$(strip_quotes "${CMD_TOKENS_SCAN[$zai]}")
+          if [ $zai_seen_dashdash -eq 0 ]; then
+            case "$zat" in
+              --)
+                zai_seen_dashdash=1; zai=$((zai + 1)); continue ;;
+              -*|'') zai=$((zai + 1)); continue ;;
+            esac
+          fi
+          validate_command_path write "7z $zcmd archive" "$zat"
+          break
+        done
+        ;;
+    esac
+  fi
 
-    # Extract target: rest of token if any, otherwise next token
-    local rest="${rtok:$op_end}"
-    if [ -z "$rest" ]; then
-      if [ $((ri + 1)) -lt $rn ]; then
-        REDIR_TARGET="${CMD_TOKENS_SCAN[$((ri + 1))]}"
-        ri=$((ri + 2))
-      else
-        ri=$((ri + 1))
-      fi
-    elif [[ "$rest" == \&* ]]; then
-      # fd-to-fd redirect like 2>&1, no file target
-      ri=$((ri + 1))
-    else
-      REDIR_TARGET="$rest"
-      ri=$((ri + 1))
-    fi
-
-    if [ -n "$REDIR_TARGET" ]; then
-      # Block process substitution — `> >(cmd)` runs `cmd` which the guard
-      # cannot safely inspect, similar to nested shells.
-      if [[ "$REDIR_TARGET" == \(* ]] || [[ "$REDIR_TARGET" == \>\(* ]] || [[ "$REDIR_TARGET" == \<\(* ]]; then
-        echo "BLOCKED: Process substitution redirect '$REDIR_TARGET' cannot be safely inspected. Ask user for explicit permission." >&2
-        exit 2
-      fi
-      REDIR_TARGET=$(expand_path "$REDIR_TARGET")
-      if [[ "$REDIR_TARGET" != /* ]]; then
-        REDIR_TARGET="$EFFECTIVE_CWD/$REDIR_TARGET"
-      fi
-      local resolved_redir
-      resolved_redir=$(resolve_path "$REDIR_TARGET")
-      # Follow symlinks so that `echo x > project/link` where
-      # `link -> /etc/passwd` is caught. resolve_path only canonicalizes
-      # the dirname, not the basename — a symlink leaf slips through.
-      local redir_depth=20
-      while [[ -L "$resolved_redir" && $redir_depth -gt 0 ]]; do
-        local redir_link
-        redir_link=$(readlink "$resolved_redir")
-        if [[ "$redir_link" == /* ]]; then
-          resolved_redir=$(resolve_path "$redir_link")
-        else
-          resolved_redir=$(resolve_path "$(dirname "$resolved_redir")/$redir_link")
-        fi
-        redir_depth=$((redir_depth - 1))
-      done
-      if [[ -L "$resolved_redir" ]]; then
-        echo "BLOCKED: Redirect target symlink chain too deep or circular at '$resolved_redir'. Ask user for explicit permission." >&2
-        exit 2
-      fi
-      # /dev/null is a discard sink for every redirect form
-      # (`> /dev/null`, `2> /dev/null`, `&> /dev/null`, `2>&1 > /dev/null`).
-      if ! is_discard_target "$resolved_redir"; then
-        if ! is_write_permitted "$resolved_redir"; then
-          echo "BLOCKED: Redirect target '$resolved_redir' is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
-          exit 2
-        fi
-      fi
-    fi
-  done
 }

--- a/plugins/project-boundary/hooks/lib/expansion_blocks.sh
+++ b/plugins/project-boundary/hooks/lib/expansion_blocks.sh
@@ -1,0 +1,121 @@
+# shellcheck shell=bash
+# project-boundary guard — variable / command-substitution blocks
+# ===============================================================
+# Two fail-closed scanners extracted from hooks/guard.sh:
+#
+#   block_unexpanded_var
+#       Scans CMD_EXPAND_SCAN for `$VAR`, `${VAR}`, `$1`..`$9`, `$@`,
+#       `$*`, `$#`, `$?`, `$$`, `$!`, `$-` outside single quotes.
+#       expand_path only resolves ~ / $HOME / ${HOME}; any other
+#       expansion would be evaluated by bash at exec time without
+#       guard inspection, so refuse.
+#
+#   block_command_substitution
+#       Scans CMD_EXPAND_SCAN for backticks and `$(...)` outside
+#       single quotes. Arithmetic `$((...))` is allowed (numeric,
+#       no command).
+#
+# Both read CMD_EXPAND_SCAN from caller's dynamic scope and call
+# `exit 2` on a violation. Helpers come from sibling modules.
+
+block_unexpanded_var() {
+  # `expand_path` only handles ~, $HOME, ${HOME}. Any other $VAR is kept
+  # verbatim and then joined under $EFFECTIVE_CWD, so it looks "inside the
+  # project" to the guard while Bash expands it at exec time. Treat it like
+  # `$(…)`: if the value cannot be inspected, refuse.
+  local vi=0 vlen=${#CMD_EXPAND_SCAN}
+  local vin_sq=0 vin_dq=0 vin_esc=0
+  while [ $vi -lt $vlen ]; do
+    local vc="${CMD_EXPAND_SCAN:$vi:1}"
+    if [ $vin_esc -eq 1 ]; then vin_esc=0; vi=$((vi+1)); continue; fi
+    if [ "$vc" = "\\" ] && [ $vin_sq -eq 0 ]; then vin_esc=1; vi=$((vi+1)); continue; fi
+    if [ "$vc" = "'" ] && [ $vin_dq -eq 0 ]; then vin_sq=$((1-vin_sq)); vi=$((vi+1)); continue; fi
+    if [ "$vc" = '"' ] && [ $vin_sq -eq 0 ]; then vin_dq=$((1-vin_dq)); vi=$((vi+1)); continue; fi
+    if [ $vin_sq -eq 0 ] && [ "$vc" = "\$" ] && [ $((vi+1)) -lt $vlen ]; then
+      local vnext="${CMD_EXPAND_SCAN:$((vi+1)):1}"
+      # Explicit passthroughs — NOT parameter expansions:
+      #   $(...)   — command substitution, caught by the substitution detector
+      #   $'...'   — ANSI-C quoted literal (escape decoding, no expansion)
+      #   $"..."   — i18n string literal (no parameter expansion)
+      # Arithmetic `$((...))` is handled by the substitution detector.
+      if [ "$vnext" = "(" ] || [ "$vnext" = "'" ] || [ "$vnext" = '"' ]; then
+        :
+      # Allow $HOME / ${HOME} — expand_path handles them.
+      elif [[ "$vnext" =~ [A-Za-z_] ]]; then
+        local rest="${CMD_EXPAND_SCAN:$((vi+1))}"
+        local vname="${rest%%[^A-Za-z0-9_]*}"
+        if [ "$vname" != "HOME" ]; then
+          echo "BLOCKED: Variable expansion '\$${vname}' cannot be safely inspected. Ask user for explicit permission." >&2
+          exit 2
+        fi
+      elif [ "$vnext" = "{" ]; then
+        local rest="${CMD_EXPAND_SCAN:$((vi+2))}"
+        local vname="${rest%%\}*}"
+        if [ "$vname" != "HOME" ]; then
+          echo "BLOCKED: Variable expansion '\${${vname}}' cannot be safely inspected. Ask user for explicit permission." >&2
+          exit 2
+        fi
+      # Positional ($0..$9) and special ($@ $* $# $? $$ $! $-) parameters.
+      # These expand at exec time to values the guard cannot inspect —
+      # e.g. `set -- /etc/passwd; rm $1` looks like `rm $1` (treated as a
+      # relative filename inside cwd) to the regex checks, but bash
+      # expands $1 to /etc/passwd at execution. Same fail-closed rule as
+      # $FOO applies — every non-HOME expansion is refused.
+      elif [[ "$vnext" =~ [0-9@*#?!\$\-] ]]; then
+        echo "BLOCKED: Shell parameter expansion '\$${vnext}' cannot be safely inspected. Ask user for explicit permission." >&2
+        exit 2
+      fi
+    fi
+    vi=$((vi+1))
+  done
+}
+
+block_command_substitution() {
+  # `$(...)` and backticks are expanded by bash (even inside double quotes),
+  # so the guard cannot know the final target. Single quotes keep them literal,
+  # so only block when they appear outside single quotes. Arithmetic expansion
+  # `$((...))` is allowed — it's a numeric computation, not a command.
+  # Similar rationale to blocking `bash -c` / `eval` — the inner command is
+  # uninspectable.
+  local ci=0 clen=${#CMD_EXPAND_SCAN}
+  local cin_sq=0 cin_dq=0 cin_esc=0
+  while [ $ci -lt $clen ]; do
+    local cc="${CMD_EXPAND_SCAN:$ci:1}"
+    if [ $cin_esc -eq 1 ]; then
+      cin_esc=0
+      ci=$((ci + 1))
+      continue
+    fi
+    if [ "$cc" = "\\" ] && [ $cin_sq -eq 0 ]; then
+      cin_esc=1
+      ci=$((ci + 1))
+      continue
+    fi
+    # Single quotes are only delimiters when NOT inside double quotes
+    if [ "$cc" = "'" ] && [ $cin_dq -eq 0 ]; then
+      cin_sq=$(( 1 - cin_sq ))
+      ci=$((ci + 1))
+      continue
+    fi
+    # Double quotes are only delimiters when NOT inside single quotes
+    if [ "$cc" = '"' ] && [ $cin_sq -eq 0 ]; then
+      cin_dq=$(( 1 - cin_dq ))
+      ci=$((ci + 1))
+      continue
+    fi
+    if [ $cin_sq -eq 0 ]; then
+      if [ "$cc" = "\`" ]; then
+        echo "BLOCKED: Command substitution with backticks cannot be safely inspected. Ask user for explicit permission." >&2
+        exit 2
+      fi
+      if [ "$cc" = "\$" ] && [ $((ci + 1)) -lt $clen ] && [ "${CMD_EXPAND_SCAN:$((ci + 1)):1}" = "(" ]; then
+        # Skip arithmetic expansion $((...)): next-next char is also (
+        if [ $((ci + 2)) -ge $clen ] || [ "${CMD_EXPAND_SCAN:$((ci + 2)):1}" != "(" ]; then
+          echo "BLOCKED: Command substitution '\$(...)' cannot be safely inspected. Ask user for explicit permission." >&2
+          exit 2
+        fi
+      fi
+    fi
+    ci=$((ci + 1))
+  done
+}

--- a/plugins/project-boundary/hooks/lib/git_walkers.sh
+++ b/plugins/project-boundary/hooks/lib/git_walkers.sh
@@ -1,0 +1,187 @@
+# shellcheck shell=bash
+# project-boundary guard — git destructive walkers
+# =================================================
+# Two walkers extracted from hooks/guard.sh:
+#
+#   block_git_C_destructive
+#       Handles `git -C <path>`, `--git-dir=<path>`, `--work-tree=<path>`
+#       — when the path resolves outside the project AND the
+#       subcommand is destructive (clean -f / reset --hard /
+#       checkout . / restore . / push --force[-with-lease|-if-includes]
+#       / stash drop|clear / branch -D / reflog expire / rm -f /
+#       worktree remove / submodule deinit -f / filter-branch /
+#       replace -d). Subcommand-aware so `commit -m '...submodule
+#       deinit -f...'` doesn't false-positive (Codex round-2, sec 60).
+#
+#   block_git_worktree_add_outside
+#       Handles `git worktree add <path>` — independent of -C. Creates
+#       a working tree at the destination path, same boundary-violation
+#       pattern as `mkdir <outside>`. Codex round-3, sec 65.
+#
+# Both functions read from caller's dynamic scope: $CMD, $CMD_BLANKED,
+# $CMD_TOKENS_SCAN[], $EFFECTIVE_CWD, $PROJECT_DIR. Helpers
+# (strip_quotes, expand_path, resolve_path, is_inside_project) come
+# from sibling modules. Each calls `exit 2` on a boundary violation.
+
+block_git_C_destructive() {
+  if ! echo "$CMD" | grep -qE '(^|[[:space:]])(/usr/bin/|/bin/)?git([[:space:]]|$)'; then
+    return 0
+  fi
+
+  local git_C_path=""
+  local _gi=0 _gn=${#CMD_TOKENS_SCAN[@]}
+  local _git_seen=0
+  local _git_C_anchor=-1
+  while [ $_gi -lt $_gn ]; do
+    local _gtok
+    _gtok=$(strip_quotes "${CMD_TOKENS_SCAN[$_gi]}")
+    if [ $_git_seen -eq 0 ]; then
+      case "$_gtok" in
+        git|/usr/bin/git|/bin/git) _git_seen=1 ;;
+      esac
+      _gi=$((_gi + 1)); continue
+    fi
+    case "$_gtok" in
+      -C|--git-dir|--work-tree)
+        _gi=$((_gi + 1))
+        if [ $_gi -lt $_gn ]; then
+          git_C_path=$(strip_quotes "${CMD_TOKENS_SCAN[$_gi]}")
+          _git_C_anchor=$((_gi + 1))
+        fi
+        break ;;
+      --git-dir=*|--work-tree=*)
+        git_C_path="${_gtok#*=}"
+        _git_C_anchor=$((_gi + 1))
+        break ;;
+      -c|-C*)
+        # `-c key=val` (config override) — skip pair; clustered `-C`
+        # can't happen in git's grammar so treat -C* as the boundary.
+        _gi=$((_gi + 2)); continue ;;
+      -*) _gi=$((_gi + 1)); continue ;;
+      *)  break ;;
+    esac
+  done
+
+  [ -z "$git_C_path" ] && return 0
+
+  local _git_C_exp _git_C_resolved
+  _git_C_exp=$(expand_path "$git_C_path")
+  if [[ "$_git_C_exp" != /* ]]; then
+    _git_C_exp="$EFFECTIVE_CWD/$_git_C_exp"
+  fi
+  _git_C_resolved=$(resolve_path "$_git_C_exp")
+  is_inside_project "$_git_C_resolved" && return 0
+
+  # Subcommand-aware destructive check. Walking tokens after the
+  # -C anchor and identifying the verb avoids false-positives on
+  # `git -C /tmp commit -m 'fix: avoid submodule deinit -f'` —
+  # the `-m` message body would otherwise trigger the destructive
+  # regex even though `commit` is benign. Codex round-2 (sec 60).
+  local _gj=$_git_C_anchor _git_verb=""
+  while [ $_gj -lt $_gn ]; do
+    local _gjtok
+    _gjtok=$(strip_quotes "${CMD_TOKENS_SCAN[$_gj]}")
+    case "$_gjtok" in
+      -*) _gj=$((_gj + 1)); continue ;;
+      *)  _git_verb="$_gjtok"; break ;;
+    esac
+  done
+
+  # Reconstruct args-after-verb (verb's own flags only, never
+  # commit msgs from a different subcommand).
+  local _git_args=""
+  local _gk=$((_gj + 1))
+  while [ $_gk -lt $_gn ]; do
+    if [ -z "$_git_args" ]; then
+      _git_args="${CMD_TOKENS_SCAN[$_gk]}"
+    else
+      _git_args="$_git_args ${CMD_TOKENS_SCAN[$_gk]}"
+    fi
+    _gk=$((_gk + 1))
+  done
+
+  local _git_destructive=0
+  case "$_git_verb" in
+    clean)
+      # Dry-run regex parallel-bumped to match `n` anywhere in
+      # the cluster (`-ndf`, `-fnd`, `-dnf` all dry-run forms).
+      # Codex round-3 (sec 62).
+      if echo "$_git_args" | grep -qE '(^|[[:space:]])(-[a-zA-Z]*f[a-zA-Z]*|--force)([[:space:]]|$)' && \
+         ! echo "$_git_args" | grep -qE '(^|[[:space:]])(-[a-zA-Z]*n[a-zA-Z]*|--dry-run)([[:space:]]|$)'; then
+        _git_destructive=1
+      fi ;;
+    reset)
+      echo "$_git_args" | grep -qE '(^|[[:space:]])--hard([[:space:]]|$)' && _git_destructive=1 ;;
+    checkout|restore)
+      echo "$_git_args" | grep -qE '(^|[[:space:]])\.([[:space:]]|$)' && _git_destructive=1 ;;
+    push)
+      echo "$_git_args" | grep -qE '(^|[[:space:]])(--force|--force-with-lease|--force-if-includes|-f)([[:space:]]|$)' && _git_destructive=1 ;;
+    stash)
+      echo "$_git_args" | grep -qE '(^|[[:space:]])(drop|clear)([[:space:]]|$)' && _git_destructive=1 ;;
+    branch)
+      echo "$_git_args" | grep -qE '(^|[[:space:]])(-D|--delete[[:space:]]+--force)([[:space:]]|$)' && _git_destructive=1 ;;
+    reflog)
+      echo "$_git_args" | grep -qE '(^|[[:space:]])expire([[:space:]]|$)' && _git_destructive=1 ;;
+    rm)
+      echo "$_git_args" | grep -qE '(^|[[:space:]])(-[a-zA-Z]*f[a-zA-Z]*|--force)([[:space:]]|$)' && _git_destructive=1 ;;
+    worktree)
+      echo "$_git_args" | grep -qE '(^|[[:space:]])remove([[:space:]]|$)' && _git_destructive=1 ;;
+    submodule)
+      echo "$_git_args" | grep -qE '(^|[[:space:]])deinit([[:space:]]|$)' && \
+        echo "$_git_args" | grep -qE '(^|[[:space:]])(-[a-zA-Z]*f[a-zA-Z]*|--force)([[:space:]]|$)' && _git_destructive=1 ;;
+    filter-branch)
+      _git_destructive=1 ;;
+    replace)
+      echo "$_git_args" | grep -qE '(^|[[:space:]])(-d|--delete)([[:space:]]|$)' && _git_destructive=1 ;;
+  esac
+
+  if [ "$_git_destructive" -eq 1 ]; then
+    echo "BLOCKED: Destructive git operation '$_git_verb' with '-C' / '--git-dir' pointing OUTSIDE project directory '$PROJECT_DIR' (target: '$_git_C_resolved'). Ask user for explicit permission." >&2
+    exit 2
+  fi
+}
+
+block_git_worktree_add_outside() {
+  # `git worktree add <path>` creates a worktree directory at <path>
+  # — same boundary-violation pattern as `mkdir <outside>` (sec 52).
+  # Sec 53/60 only fired on `git -C` invocations + `worktree remove`,
+  # not on the `add` destination path argument. Codex round-3 (sec 65).
+  if ! echo "$CMD_BLANKED" | grep -qE '(^|[[:space:]])git[[:space:]]+worktree[[:space:]]+add([[:space:]]|$)'; then
+    return 0
+  fi
+
+  local _wi=0 _wn=${#CMD_TOKENS_SCAN[@]}
+  local _wt_seen=0
+  local _wt_skip_next=0
+  while [ $_wi -lt $_wn ]; do
+    local _wtok
+    _wtok=$(strip_quotes "${CMD_TOKENS_SCAN[$_wi]}")
+    if [ "$_wt_skip_next" -eq 1 ]; then
+      _wt_skip_next=0; _wi=$((_wi + 1)); continue
+    fi
+    if [ $_wt_seen -eq 0 ]; then
+      case "$_wtok" in
+        add) _wt_seen=1 ;;
+      esac
+      _wi=$((_wi + 1)); continue
+    fi
+    case "$_wtok" in
+      -b|-B|--reason)
+        _wt_skip_next=1; _wi=$((_wi + 1)); continue ;;
+      --*=*|-*)
+        _wi=$((_wi + 1)); continue ;;
+    esac
+    # First positional after `add` (and after consumed flags) = destination.
+    local _wt_exp _wt_resolved
+    _wt_exp=$(expand_path "$_wtok")
+    if [[ "$_wt_exp" != /* ]]; then
+      _wt_exp="$EFFECTIVE_CWD/$_wt_exp"
+    fi
+    _wt_resolved=$(resolve_path "$_wt_exp")
+    if ! is_inside_project "$_wt_resolved"; then
+      echo "BLOCKED: 'git worktree add' targets '$_wt_resolved' which is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
+      exit 2
+    fi
+    break
+  done
+}

--- a/plugins/project-boundary/hooks/lib/heredoc.sh
+++ b/plugins/project-boundary/hooks/lib/heredoc.sh
@@ -122,7 +122,6 @@ blank_quoted_heredoc_bodies() {
       # on this line, so a later quoted heredoc's blank range covered
       # bytes belonging to an earlier unquoted body, hiding $(...) /
       # backtick / $VAR in the unquoted body from fail-closed scans.
-      # Reported by Copilot review on commit aa6409b.
       if [ ${#HB[@]} -gt 0 ] && [ "${HB[0]}" = "-1" ]; then
         HB[0]=$((lend+1))
         [ $li -eq $((num_lines-1)) ] && HB[0]=$n
@@ -175,8 +174,7 @@ blank_quoted_heredoc_bodies() {
   # The previous inner loop did `out+=" "` once per body byte; on bash
   # 3.2 (macOS default) that path is O(n²) due to repeated string
   # reallocation, which slows PreToolUse on large heredocs. Per-range
-  # chunked emit via printf + tr keeps total work O(n). Reported by
-  # Copilot review on PR #137.
+  # chunked emit via printf + tr keeps total work O(n).
   local blank_nl="${2:-preserve}"
   local out="" pos=0 bi=0 nb=${#BS[@]}
   while [ $bi -lt $nb ]; do

--- a/plugins/project-boundary/hooks/lib/options.sh
+++ b/plugins/project-boundary/hooks/lib/options.sh
@@ -55,9 +55,20 @@ extract_option_values() {
     local raw_tok="${CMD_TOKENS[$i]}"
     local tok
     tok=$(strip_quotes "$raw_tok")
-    if [ -n "$short" ] && [ "$tok" = "$short" ] && [ $((i + 1)) -lt $n ]; then
-      printf '%s\n' "${CMD_TOKENS[$((i + 1))]}"
-      found=0
+    if [ -n "$short" ]; then
+      if [ "$tok" = "$short" ] && [ $((i + 1)) -lt $n ]; then
+        printf '%s\n' "${CMD_TOKENS[$((i + 1))]}"
+        found=0
+      # Attached short form (sec 112): `-o<val>` / `-O<val>` /
+      # `-t<dir>` / `-D<dir>`. Previously missed — same shape gap
+      # that custom walkers fixed individually for unzip -d
+      # (sec 102) and wget -P (sec 104); closing it here covers
+      # every caller. `${short}?*` requires at least one char
+      # after the flag so bare `-o` doesn't accidentally match.
+      elif [[ "$tok" == "${short}"?* ]]; then
+        printf '%s\n' "${tok#$short}"
+        found=0
+      fi
     fi
     if [ -n "$long" ]; then
       if [ "$tok" = "$long" ] && [ $((i + 1)) -lt $n ]; then
@@ -72,6 +83,118 @@ extract_option_values() {
     i=$((i + 1))
   done
   return $found
+}
+
+# --- Extract option values from a NAMED array ---
+# Like extract_option_values, but operates on any array name (most
+# detectors walk CMD_TOKENS_SCAN, not CMD_TOKENS — the heredoc-blanked
+# token stream — so they cannot reuse extract_option_values).
+#
+# Usage: extract_attached_or_split_from <array_name> <short> <long>
+#   short: e.g. "-f", "" to skip
+#   long:  e.g. "--file", "" to skip
+# Recognises:
+#   -f VAL          (split short)
+#   -fVAL           (attached short — `?*` glob)
+#   --file VAL      (split long)
+#   --file=VAL      (attached long with `=`)
+# Quotes are stripped from each emitted value.
+# Bash 3.2 compatible — uses `eval` for indirect array access (macOS
+# /bin/bash 3.2 has no `local -n` namerefs). Array name is a literal
+# identifier from the caller, never user-controlled.
+extract_attached_or_split_from() {
+  local _arr_name="$1"
+  local _short="$2"
+  local _long="$3"
+  local _n
+  eval "_n=\${#${_arr_name}[@]}"
+  local _i=0
+  while [ $_i -lt $_n ]; do
+    local _raw
+    eval "_raw=\"\${${_arr_name}[\$_i]}\""
+    local _tok
+    _tok=$(strip_quotes "$_raw")
+    if [ -n "$_short" ]; then
+      if [ "$_tok" = "$_short" ] && [ $((_i + 1)) -lt $_n ]; then
+        local _nxt
+        eval "_nxt=\"\${${_arr_name}[\$((_i + 1))]}\""
+        printf '%s\n' "$(strip_quotes "$_nxt")"
+        _i=$((_i + 2)); continue
+      fi
+      if [[ "$_tok" == "${_short}"?* ]]; then
+        printf '%s\n' "${_tok#$_short}"
+      fi
+    fi
+    if [ -n "$_long" ]; then
+      if [ "$_tok" = "$_long" ] && [ $((_i + 1)) -lt $_n ]; then
+        local _nxt
+        eval "_nxt=\"\${${_arr_name}[\$((_i + 1))]}\""
+        printf '%s\n' "$(strip_quotes "$_nxt")"
+        _i=$((_i + 2)); continue
+      fi
+      if [[ "$_tok" == "${_long}="* ]]; then
+        printf '%s\n' "${_tok#${_long}=}"
+      fi
+    fi
+    _i=$((_i + 1))
+  done
+}
+
+# --- Walk path operands of a positional verb ---
+# For tools whose payload is a list of positional PATHs guarded by a
+# fixed set of skip-the-next-token flags (mkfifo, mknod, mkdir, ...).
+# Flag-stripping respects the POSIX `--` separator.
+#
+# Usage: walk_path_operands_from <array_name> <skip_value_flags> <attached_value_flags>
+#   skip_value_flags:     space-separated flag names that consume the
+#                         NEXT token as a value (e.g. "-m --mode -Z").
+#   attached_value_flags: space-separated long flag names whose `=VAL`
+#                         attached form should be skipped (e.g.
+#                         "--mode --context").
+# Walks from index 1 (assumes verb at index 0 — true for CMD_TOKENS /
+# CMD_TOKENS_SCAN after wrapper-stripping). Prints each non-flag
+# positional on its own line, with quotes stripped.
+walk_path_operands_from() {
+  local _arr_name="$1"
+  local _skip_value="$2"
+  local _attached_value="$3"
+  local _n
+  eval "_n=\${#${_arr_name}[@]}"
+  local _i=1
+  local _seen_dd=0
+  while [ $_i -lt $_n ]; do
+    local _raw
+    eval "_raw=\"\${${_arr_name}[\$_i]}\""
+    local _tok
+    _tok=$(strip_quotes "$_raw")
+    if [ $_seen_dd -eq 0 ]; then
+      if [ "$_tok" = "--" ]; then
+        _seen_dd=1; _i=$((_i + 1)); continue
+      fi
+      if [ -z "$_tok" ]; then
+        _i=$((_i + 1)); continue
+      fi
+      local _sf _matched=0
+      for _sf in $_skip_value; do
+        if [ "$_tok" = "$_sf" ]; then _matched=1; break; fi
+      done
+      if [ $_matched -eq 1 ]; then
+        _i=$((_i + 2)); continue
+      fi
+      local _af
+      for _af in $_attached_value; do
+        if [[ "$_tok" == "${_af}="* ]]; then _matched=1; break; fi
+      done
+      if [ $_matched -eq 1 ]; then
+        _i=$((_i + 1)); continue
+      fi
+      if [[ "$_tok" == -* ]]; then
+        _i=$((_i + 1)); continue
+      fi
+    fi
+    printf '%s\n' "$_tok"
+    _i=$((_i + 1))
+  done
 }
 
 # --- Split command into sub-commands and check each ---

--- a/plugins/project-boundary/hooks/lib/paths.sh
+++ b/plugins/project-boundary/hooks/lib/paths.sh
@@ -59,6 +59,13 @@ resolve_path() {
     # resolves to `/etc`. This is essential: if left unresolved, the
     # subsequent lexical `..` pass would incorrectly pop `linkdir` and
     # leave the caller inside the allowlisted dir.
+    # On MSYS2, `cd -P` is also the load-bearing NTFS reparse-point
+    # protection (#31): Win32 SetCurrentDirectory traverses junctions
+    # and symbolic links, so `pwd -P` returns the physical target —
+    # an in-project junction -> C:\Windows resolves to /c/Windows here
+    # before is_write_permitted runs. The dedicated readlink-based
+    # symlink-chase loop in guard.sh / below is irrelevant for NTFS
+    # reparse points (readlink returns nothing for junctions).
     local real_ancestor
     real_ancestor=$(cd -P "$check" && pwd -P)
     combined="${real_ancestor}${tail}"
@@ -106,16 +113,39 @@ resolve_path() {
 # --- Expand ~ and $HOME in a command argument ---
 expand_path() {
   local p="$1"
+  # Detect quoted ~ BEFORE stripping quotes. Bash leaves a quoted
+  # tilde literal (`"~root"/.bashrc` is the literal path
+  # `~root/.bashrc`, not user root's home). Without this check
+  # the strip-then-match logic below would substitute the sentinel
+  # for a literal-name path and block legitimate in-project
+  # filenames containing `~`. Codex review of PR #25 (sec 59).
+  local _quoted_tilde=0
+  case "$p" in
+    \"~*|\'~*) _quoted_tilde=1 ;;
+  esac
   # Remove surrounding quotes (single or double)
   p="${p%\"}"
   p="${p#\"}"
   p="${p%\'}"
   p="${p#\'}"
-  # Expand ~ at start
-  if [[ "$p" == "~/"* ]]; then
-    p="$HOME/${p#\~/}"
-  elif [[ "$p" == "~" ]]; then
-    p="$HOME"
+  # Expand ~ at start (skipped entirely for quoted-tilde forms).
+  if [ $_quoted_tilde -eq 0 ]; then
+    if [[ "$p" == "~/"* ]]; then
+      p="$HOME/${p#\~/}"
+    elif [[ "$p" == "~" ]]; then
+      p="$HOME"
+    elif [[ "$p" =~ ^~[a-zA-Z_][a-zA-Z0-9_.-]* ]]; then
+      # `~user/path` — bash expands to the named user's home dir at
+      # exec time (e.g. `~root` → `/var/root` on macOS, `/root` on
+      # Linux). Without exec'ing getent/dscl/eval we can't safely
+      # resolve to the actual home, but the result is NEVER inside
+      # the project dir. Substitute a sentinel absolute path so
+      # is_inside_project / is_write_permitted naturally fail-closed.
+      # Pentest-reported bypass: `rm ~root/.bashrc` was treated as a
+      # relative path `~root/.bashrc` and prepended with EFFECTIVE_CWD
+      # → in-project → ALLOWED.
+      p="/__tilde_other_user/${p#\~}"
+    fi
   fi
   # Expand $HOME / ${HOME} but NOT when the `$` is backslash-escaped.
   # Bash treats `\$HOME` as literal "$HOME" — no parameter expansion runs —
@@ -234,18 +264,25 @@ is_write_permitted() {
 }
 
 # --- Classify POSIX bit-bucket write targets ---
-# Return 0 iff $1 is a POSIX bit-bucket write target whose bytes are
-# guaranteed to be discarded with no real filesystem write.
+# Return 0 iff $1 is a POSIX device passthrough whose bytes do NOT
+# materialise as a filesystem write under any project boundary:
 #
-# /dev/null is the canonical bit-bucket on every POSIX system
-# (Linux, macOS, BSD) at the same path. Writes to it are accepted
-# by the kernel and dropped — there is no filesystem target, no
-# parent directory mutation, no symlink side-effect. Callers that
-# KNOW they are writing a target (redirect operators, `tee`,
-# `curl -o`, `wget -O`, `dd of=`) can short-circuit here before
-# invoking is_write_permitted, so probe and silencing workflows
-# like `curl -o /dev/null` and `2>/dev/null` don't require a
-# per-project allowlist entry.
+#   /dev/null              kernel bit-bucket (canonical discard)
+#   /dev/stdout, /dev/fd/1, /proc/self/fd/1
+#                          fd-1 alias — bytes flow to the caller's
+#                          stdout, never to a file in /dev or /proc
+#   /dev/stderr, /dev/fd/2, /proc/self/fd/2
+#                          fd-2 alias — same, for stderr
+#
+# Linux exposes /dev/stdout etc. as symlinks to /proc/self/fd/N;
+# macOS/BSD provide them via devfs. In every case the kernel
+# routes the write to an existing file descriptor — there is no
+# filesystem mutation under /dev or /proc to enforce a boundary
+# on. Callers that KNOW they are writing a target (redirect
+# operators, `tee`, `curl -o`, `wget -O`, `dd of=`) can
+# short-circuit here before invoking is_write_permitted so
+# `curl -o /dev/stdout`, `2>/dev/null`, `wget -O /dev/fd/1`
+# don't require allowlist entries (Codex re-review D).
 #
 # IMPORTANT: this must NOT be used from call sites that do an
 # in-place edit via temp-file + rename (`sed -i`, `truncate`) or
@@ -255,5 +292,66 @@ is_write_permitted() {
 # boundary check must still fire there. See is_write_permitted
 # docstring for the full separation of write semantics.
 is_discard_target() {
-  [ "$1" = "/dev/null" ]
+  case "$1" in
+    /dev/null|/dev/stdout|/dev/stderr) return 0 ;;
+    /dev/fd/1|/dev/fd/2) return 0 ;;
+    /proc/self/fd/1|/proc/self/fd/2) return 0 ;;
+  esac
+  # On Linux, `cd -P` through /dev/fd (symlink to /proc/self/fd) and
+  # /proc/self (symlink to /proc/<pid>) canonicalises both to the
+  # caller's actual PID — `wget -O /dev/fd/1` reaches is_discard_target
+  # as `/proc/12345/fd/1`. Match the per-process form here so the
+  # discard semantics survive `resolve_path` canonicalisation.
+  if [[ "$1" =~ ^/proc/[0-9]+/fd/[12]$ ]]; then
+    return 0
+  fi
+  return 1
+}
+
+# --- DRY helpers for the detector cluster --------------------------
+#
+# Most walkers share the same path pipeline:
+#   raw → expand_path → (prepend EFFECTIVE_CWD if relative) → resolve_path
+# followed by an is_write_permitted / is_inside_project gate and a
+# canned BLOCKED stderr line + exit 2. These helpers fold the
+# boilerplate so a one-liner replaces ~10 lines per walker.
+
+# resolve_command_path RAW
+# Echoes the absolute, symlink-resolved path of RAW.
+# Reads EFFECTIVE_CWD from the caller's dynamic scope (same contract
+# as the detectors themselves).
+resolve_command_path() {
+  local p="$1"
+  p=$(expand_path "$p")
+  if [[ "$p" != /* ]]; then
+    p="$EFFECTIVE_CWD/$p"
+  fi
+  resolve_path "$p"
+}
+
+# block_unless_path_allowed POLICY LABEL RESOLVED_PATH
+#   POLICY = write   → is_write_permitted (allowlist applies)
+#   POLICY = strict  → is_inside_project (no allowlist exception)
+# On boundary violation: prints BLOCKED line to stderr and exit 2.
+# LABEL is the verb name + flag for the message (e.g. "tee",
+# "find -fprint", "7z -o<dir>").
+block_unless_path_allowed() {
+  local policy="$1" label="$2" path="$3"
+  case "$policy" in
+    write)
+      is_write_permitted "$path" && return 0 ;;
+    strict)
+      is_inside_project "$path" && return 0 ;;
+  esac
+  echo "BLOCKED: '$label' targets '$path' which is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
+  exit 2
+}
+
+# validate_command_path POLICY LABEL RAW_PATH
+# Convenience wrapper: resolve + check in one call. Most call-sites
+# only need this single helper.
+validate_command_path() {
+  local resolved
+  resolved=$(resolve_command_path "$3")
+  block_unless_path_allowed "$1" "$2" "$resolved"
 }

--- a/plugins/project-boundary/hooks/lib/remote_dispatch.sh
+++ b/plugins/project-boundary/hooks/lib/remote_dispatch.sh
@@ -1,0 +1,316 @@
+#!/bin/bash
+# project-boundary guard — remote_dispatch module
+# ================================================
+# Generic neutralisation of "remote-dispatch" commands whose operands
+# target a remote host or a foreign (container/namespace) filesystem
+# rather than the local one this guard protects. Without this pass,
+# tokens that are part of a remote command string get walked by the
+# local-path detectors (cp, tee, rm, redirect, ...) and produce
+# false-positive boundary blocks.
+#
+# Three universal shapes are recognised, all rewritten so downstream
+# detectors only see the local-side surface (or nothing, when there
+# is no local surface):
+#
+#   1. Network-copy tools — operate on a remote target but may also
+#      take local operands and -flag values. The point of this class
+#      is that the remote `host:/path` / `host::module` / `rsync://`
+#      operands must NOT be walked as local filesystem paths;
+#      legitimate local operands (`scp ./key host:/dst` etc.) are
+#      reads from the plugin's perspective and the boundary doesn't
+#      police those.
+#        scp / rcp / sftp
+#      Rewrite: collapse CMD to the bare verb name.
+#
+#   2. Remote-command dispatch — `<verb> [opts] <target> <opaque-cmd>`,
+#      where the target is a host / container / pod and the trailing
+#      tokens form a command executed on a foreign filesystem (NOT
+#      the local one this guard protects):
+#        ssh
+#        docker exec | podman exec
+#        kubectl exec | oc exec | crictl exec | lxc exec
+#      Rewrite: collapse CMD to the verb prefix only.
+#
+#      `nsenter` and `chroot` are deliberately EXCLUDED — they
+#      execute on the local host (just under a different namespace
+#      or apparent root), so their command operands can still touch
+#      host paths outside the project and must remain subject to the
+#      destructive walkers (Copilot review on PR #22).
+#
+#      `docker run` / `podman run` / `buildah run` are also EXCLUDED
+#      because the `-v src:dst` / `--volume` / `--mount type=bind,…`
+#      flags can bind-mount host paths into the container, turning a
+#      container-side write into a host-fs write that bypasses the
+#      boundary. Until host-mount-source parsing is added, leaving
+#      them subject to the existing walkers errs on the safe side
+#      (Copilot review on PR #22).
+#
+#   3. Remote file copy with mixed local / remote operands —
+#      `<verb> <subverb> <a> <b>` where one operand has the form
+#      `<id>:<path>` and the other is local.
+#        docker cp | podman cp | kubectl cp | oc cp
+#      Rewrite: keep only the LOCAL DESTINATION operand (last
+#      positional, when not remote-shaped) so the cp walker still
+#      validates download targets like `… c:/x /etc/owned`. Source
+#      operands are dropped — local source = read (not policed),
+#      remote source = foreign filesystem.
+#
+# Depends on tokenize_args / strip_quotes from hooks/lib/tokenize.sh.
+# Pure (no caller-scope dependencies); returns the rewritten command
+# string on stdout.
+
+# --- Generic remote-target detector ---
+# Returns 0 iff the argument looks like a "remote address" of the
+# universal `<id>:<path>` form used by ssh, scp, rsync, docker cp,
+# kubectl cp, etc. The `:` must live in the FIRST path segment
+# (before any `/`) — a local path may legitimately contain `:` after a
+# slash (e.g. `../tmp/a:b`), and a URL like `http://...` keeps the
+# scheme separator inside the first segment but is excluded by an
+# explicit URL check first.
+_rd_is_remote_target_operand() {
+  local arg="$1"
+  case "$arg" in
+    *://*) return 1 ;;  # URL scheme
+  esac
+  local first="${arg%%/*}"
+  case "$first" in
+    *:*) return 0 ;;
+  esac
+  return 1
+}
+
+# --- Find command-name token index, skipping wrappers/flags/VAR=val ---
+# Mirrors the wrapper-skip rules used by strip_command_name_prefix and
+# command_name_is. Reads from the module-local _RD_TOKS array (set by
+# rewrite_remote_dispatch before calling). Returns -1 if no command-name
+# found. Uses a global rather than `local -n` because macOS ships
+# bash 3.2 which lacks nameref support.
+#
+# Also skips a per-wrapper option-with-value pair (e.g. `-u USER` for
+# sudo/env, `-k DUR` for timeout) when the value would otherwise be
+# mis-identified as the verb. Without this, `env -u FOO docker exec
+# ctr rm -rf /` mis-identified `FOO` as the verb (verb_pair="FOO
+# docker"), `rewrite_remote_dispatch` returned the cmd unchanged, and
+# the bare rm walker over-blocked the foreign-fs `rm -rf /` (which
+# actually runs inside the container, not on host). Same root cause
+# as section 40 (subcmd_flags.sh) and section 41 (command_name.sh);
+# Codex round-4 follow-up on PR #23.
+_rd_find_verb_idx() {
+  local i=0 n=${#_RD_TOKS[@]}
+  local prev_was_timeout=0 last_wrapper=""
+  while [ $i -lt $n ]; do
+    local raw="${_RD_TOKS[$i]}" t
+    t=$(strip_quotes "$raw")
+
+    if [ -n "$last_wrapper" ]; then
+      local opts; opts=$(_wrapper_opts_with_val "$last_wrapper")
+      if [ -n "$opts" ]; then
+        case " $opts " in
+          *" $t "*) i=$((i + 2)); continue ;;
+        esac
+      fi
+    fi
+
+    if [ $prev_was_timeout -eq 1 ]; then
+      prev_was_timeout=0
+      case "$t" in
+        [0-9]*|inf*) i=$((i + 1)); continue ;;
+      esac
+    fi
+    case "$t" in
+      timeout)
+        prev_was_timeout=1; last_wrapper="timeout"; i=$((i + 1)); continue ;;
+      sudo|env|/bin/env|/usr/bin/env|nice|nohup|time|stdbuf|ionice|chrt|taskset|command|builtin|exec)
+        last_wrapper=$(_rd_strip_path_prefix "$t")
+        i=$((i + 1)); continue ;;
+    esac
+    case "$t" in
+      [A-Za-z_]*=*) i=$((i + 1)); continue ;;
+      -*) i=$((i + 1)); continue ;;
+    esac
+    printf '%d' "$i"
+    return
+  done
+  printf -- '-1'
+}
+
+# --- Strip /bin/, /sbin/, /usr/bin/, /usr/sbin/, /usr/local/bin/, ---
+# /opt/homebrew/bin/ prefix. Mirrors _cn_strip_path_prefix in
+# command_name.sh — kept in sync so a Homebrew-installed ssh /
+# kubectl / etc. is recognised by the remote-dispatch walkers.
+_rd_strip_path_prefix() {
+  local n="$1"
+  case "$n" in
+    /bin/*|/sbin/*|/usr/bin/*|/usr/sbin/*|/usr/local/bin/*|/opt/homebrew/bin/*) printf '%s' "${n##*/}" ;;
+    *) printf '%s' "$n" ;;
+  esac
+}
+
+# --- Whitespace-list membership check ---
+# $1 = needle, $2 = space-separated haystack. Used to decide whether a
+# given short or long flag consumes the next token as its value.
+_rd_flag_takes_value() {
+  local needle="$1"
+  local short_list="$2"
+  local long_list="$3"
+  case " $short_list " in *" $needle "*) return 0 ;; esac
+  case " $long_list "  in *" $needle "*) return 0 ;; esac
+  return 1
+}
+
+# --- Main entry: rewrite remote-dispatch commands ---
+# In:  full CMD string
+# Out: CMD string with remote portions removed; unchanged for non-dispatch verbs.
+rewrite_remote_dispatch() {
+  local cmd="$1"
+  _RD_TOKS=()
+  local t
+  while IFS= read -r t; do
+    [[ -z "$t" ]] && continue
+    _RD_TOKS+=("$t")
+  done < <(tokenize_args "$cmd")
+
+  local verb_idx
+  verb_idx=$(_rd_find_verb_idx)
+  [ "$verb_idx" -lt 0 ] && { printf '%s' "$cmd"; return; }
+
+  local verb subverb=""
+  verb=$(strip_quotes "${_RD_TOKS[$verb_idx]}")
+  verb=$(_rd_strip_path_prefix "$verb")
+  if [ $((verb_idx + 1)) -lt ${#_RD_TOKS[@]} ]; then
+    subverb=$(strip_quotes "${_RD_TOKS[$((verb_idx + 1))]}")
+  fi
+
+  # Class 1: pure remote-fs tools.
+  case "$verb" in
+    scp|rcp|sftp)
+      printf '%s' "$verb"
+      return ;;
+  esac
+
+  # Class 3: two-word remote copy verbs.
+  case "$verb $subverb" in
+    "docker cp"|"podman cp"|"kubectl cp"|"oc cp")
+      _rd_rewrite_remote_copy "$verb_idx"
+      return ;;
+  esac
+
+  # Class 2: two-word remote-command dispatch verbs. `docker run` /
+  # `podman run` / `buildah run` are intentionally NOT in this list —
+  # see the header comment for the bind-mount rationale.
+  case "$verb $subverb" in
+    "docker exec"|"podman exec"|"kubectl exec"|"oc exec"|"crictl exec"|"lxc exec")
+      printf '%s %s' "$verb" "$subverb"
+      return ;;
+  esac
+
+  # Class 2: one-word remote-command dispatch verbs. `nsenter` and
+  # `chroot` are intentionally NOT in this list — see the header
+  # comment for why they remain subject to the local walkers.
+  case "$verb" in
+    ssh)
+      printf '%s' "$verb"
+      return ;;
+  esac
+
+  printf '%s' "$cmd"
+}
+
+# --- Rewrite a `<verb> <subverb> <operand-a> <operand-b>` copy invocation ---
+# Keep the verb pair plus operands that are NOT remote `<id>:<path>` form.
+# Flags are dropped (they cannot be local file targets in any of the
+# supported `cp` subcommands; -L, --follow-link, --archive etc. are
+# value-less or take non-path values).
+_rd_rewrite_remote_copy() {
+  local v_idx="$1"
+  local verb_pair="${_RD_TOKS[$v_idx]} ${_RD_TOKS[$((v_idx + 1))]}"
+  local k=$((v_idx + 2)) n=${#_RD_TOKS[@]}
+
+  # Per-verb flags-that-consume-the-next-token list. Necessary because
+  # Copilot review on PR #22 flagged a download-mode bypass shape:
+  #   `kubectl cp pod:/x /etc/owned --namespace default`
+  # without this table, `default` (the value of `--namespace`) gets
+  # added to the positionals list, becomes the LAST positional, and
+  # the rewrite emits `cp default` — relative path resolved inside
+  # the project → ALLOWED, missing the real download destination
+  # `/etc/owned`. cobra/pflag (used by kubectl/oc) lets flags appear
+  # before AND after positionals, so we can't just stop after the
+  # first non-flag token.
+  #
+  # docker cp / podman cp share a small flag set with no value-taking
+  # flags relevant to the path-walker bypass (`-a/--archive`,
+  # `-L/--follow-link`, `--quiet`, `--pause`, `--extract` are all
+  # value-less); their entries are deliberately empty. kubectl cp /
+  # oc cp inherit the entire kubectl global flag set — only the ones
+  # that take a value AND can credibly appear next to a path are
+  # listed here (kubeconfig/cluster paths can be local files but the
+  # plugin does not police reads, so we drop their values without
+  # validation).
+  local short_value_flags="" long_value_flags=""
+  case "$verb_pair" in
+    "kubectl cp"|"oc cp")
+      short_value_flags="-c -n -s"
+      long_value_flags="--container --namespace --kubeconfig --context --cluster --user --token --server --as --as-group --certificate-authority --client-certificate --client-key --cache-dir --request-timeout --tls-server-name --retries"
+      ;;
+  esac
+
+  # Walk positional operands. cp-family semantics: the LAST positional
+  # is the destination; every earlier positional is a source. The
+  # plugin protects writes, not reads — so a local SOURCE is dropped
+  # (uploading `docker cp /tmp/x container:/y` is read-only on /tmp/x
+  # and must not false-positive). A local DESTINATION is preserved
+  # below as the operand of a synthetic `cp <dst>` so the existing
+  # cp walker validates it. This is a deliberate divergence from the
+  # bare `cp` walker (which strict-checks both src and dst) — the
+  # remote-dispatch case has a remote operand on the OTHER side, so
+  # the boundary's "no copies from outside" semantics do not apply
+  # symmetrically here. Operands of the universal `<id>:<path>` form
+  # are dropped because they target a foreign filesystem.
+  local -a positionals=()
+  while [ $k -lt $n ]; do
+    local raw="${_RD_TOKS[$k]}" tok
+    tok=$(strip_quotes "$raw")
+    case "$tok" in
+      --)
+        # POSIX end-of-options: every later token is a positional,
+        # even if it begins with `-`. Used by kubectl exec but also
+        # valid for cp invocations.
+        k=$((k + 1))
+        while [ $k -lt $n ]; do
+          positionals+=("${_RD_TOKS[$k]}")
+          k=$((k + 1))
+        done
+        continue ;;
+      --*=*)
+        k=$((k + 1)); continue ;;
+      -*)
+        if _rd_flag_takes_value "$tok" "$short_value_flags" "$long_value_flags"; then
+          k=$((k + 2))
+        else
+          k=$((k + 1))
+        fi
+        continue ;;
+    esac
+    positionals+=("$raw")
+    k=$((k + 1))
+  done
+
+  local last_idx=$(( ${#positionals[@]} - 1 ))
+  if [ $last_idx -lt 0 ]; then
+    printf '%s' "$verb_pair"
+    return
+  fi
+  local last_raw="${positionals[$last_idx]}"
+  local last_tok
+  last_tok=$(strip_quotes "$last_raw")
+  if _rd_is_remote_target_operand "$last_tok"; then
+    # Destination is remote → no local write surface. Collapse to verb pair
+    # so no walker fires on the local source(s).
+    printf '%s %s' "${_RD_TOKS[$v_idx]}" "${_RD_TOKS[$((v_idx + 1))]}"
+    return
+  fi
+  # Destination is local. Emit a synthetic `cp <dst>` so the cp walker
+  # in destructive.sh validates that single path. Source operands are
+  # dropped: remote ones are foreign, local ones are reads (not policed).
+  printf 'cp %s' "$last_raw"
+}

--- a/plugins/project-boundary/hooks/lib/shell_exec_walkers.sh
+++ b/plugins/project-boundary/hooks/lib/shell_exec_walkers.sh
@@ -1,0 +1,435 @@
+# shellcheck shell=bash
+# project-boundary guard — shell / interpreter execution walkers
+# ===============================================================
+# Extracted from hooks/guard.sh check_single_command. All five
+# walkers fail-closed on un-inspectable code execution surfaces:
+#
+#   block_nested_shell_and_eval
+#       `bash -c CMD`, `sh -c CMD`, `zsh -c CMD`, ..., `eval CMD`.
+#
+#   block_interpreter_inline_code
+#       `python -c`, `perl -e`, `ruby -e`, `node -e`, `php -r`,
+#       `awk 'BEGIN{system(...)}'`, etc.
+#
+#   block_pipe_to_shell
+#       Bare `sh`/`bash`/... or shell with only flags (e.g. `bash -s`)
+#       — typical `echo "rm -rf /" | sh` shape.
+#
+#   block_shell_script_execution
+#       Path-form: `bash /tmp/x.sh`, `source ~/x.sh`, `. /tmp/x.sh`.
+#       STRICT project-root (allowlist must NOT grant execute).
+#       Uses tokenize-with-redirects + heredoc-blanked parallel
+#       stream + symlink dereference.
+#
+# All read CMD / CMD_BLANKED / EFFECTIVE_CWD / PROJECT_DIR from
+# caller's dynamic scope. Helpers (strip_quotes, expand_path,
+# resolve_path, tokenize_args, blank_quoted_heredoc_bodies,
+# is_shell_token, is_source_token) come from sibling modules.
+# Each calls `exit 2` on a boundary violation.
+
+block_nested_shell_and_eval() {
+  # Match: bash -c, sh -c, bash -lc, bash -ec, /bin/bash -c, /bin/sh -c, /usr/bin/env bash -c
+  # Also zsh / ksh / dash / fish / xonsh / tcsh / csh / nu / pwsh / osh
+  # (macOS ships zsh by default; all accept -c CMD with un-inspectable semantics).
+  #
+  # VERB-GATE: substring matching alone false-positives on text-as-arg
+  # cases (`echo "use bash -c here" > docs/fp.md`, `git commit -m
+  # "explain eval risk"`). Gate every check on CMD_VERB so the
+  # substring walker only fires when the verb itself is a shell
+  # opener, an interpreter wrapper that resolves to one (env / sudo /
+  # nice / ... already collapsed by _cn_find_verb_idx — CMD_VERB is
+  # the post-wrapper name), or a remote-dispatch verb where the
+  # asymmetry pin (294b64d / 7b65a45) intentionally over-blocks
+  # inline-shell payloads.
+  #
+  # INTENTIONAL ORDERING: this walker still runs BEFORE
+  # rewrite_remote_dispatch. That is what keeps `docker exec ctr sh
+  # -c '...'`, `kubectl exec pod -- bash -c '...'`, `ssh host bash -c
+  # '...'` blocked: CMD_VERB at this point is still `docker` /
+  # `kubectl` / `ssh`, not yet rewritten away. Deferring the check to
+  # AFTER remote-dispatch neutralisation would make the boundary
+  # easier to abuse via payloads hidden in pseudo-remote arguments
+  # (e.g. an alias that resolves `docker` to a local script but still
+  # parses as `docker exec ...`). Path-operand forms (`docker exec
+  # ctr rm /etc/x`) remain ALLOWED via rewrite_remote_dispatch —
+  # CMD_VERB falls in the `*` branch and the walker returns. See the
+  # asymmetry tests in test_true_negatives_b.sh near the docker exec
+  # block.
+  case "${CMD_VERB-}" in
+    bash|sh|zsh|ksh|dash|fish|xonsh|tcsh|csh|nu|pwsh|osh)
+      ;;  # real shell opener — fall through to the substring check
+    docker|podman|kubectl|oc|crictl|lxc|ssh)
+      ;;  # remote-dispatch verb — asymmetry pin: inline shell payload BLOCK
+    eval)
+      echo "BLOCKED: 'eval' cannot be safely inspected. Ask user for explicit permission." >&2
+      exit 2 ;;
+    *)
+      return ;;  # text-as-arg / unrelated verb — substring is content, not exec
+  esac
+  if echo "$CMD" | grep -qE '(^|[[:space:]])(/usr/bin/env[[:space:]]+)?(/bin/)?(bash|sh|zsh|ksh|dash|fish|xonsh|tcsh|csh|nu|pwsh|osh)[[:space:]]+-[a-zA-Z]*c[[:space:]]'; then
+    echo "BLOCKED: Nested shell execution ('bash -c' / 'sh -c' / 'zsh -c' / ...) cannot be safely inspected. Ask user for explicit permission." >&2
+    exit 2
+  fi
+  if echo "$CMD" | grep -qE '(^|[[:space:]])eval[[:space:]]'; then
+    echo "BLOCKED: 'eval' cannot be safely inspected. Ask user for explicit permission." >&2
+    exit 2
+  fi
+
+}
+
+# --- trap CMD SIG: deferred shell handler (round-4 pentest) ---
+# `trap CMD SIG` registers CMD as a shell handler that fires on the
+# named signal (EXIT, INT, TERM, ...). CMD is arbitrary shell code
+# stored on argv and executed later — same un-inspectable semantics
+# as `bash -c CMD` and `eval`. Read-only forms have no deferred CMD
+# and stay ALLOWED:
+#   trap            (list current traps)
+#   trap -l         (list signal names)
+#   trap -p         (print traps in re-input form)
+#   trap - SIG      (reset SIG to default — first positional `-`)
+#   trap '' SIG     (ignore SIG — first positional empty)
+# Lifted out of block_nested_shell_and_eval so the verb-gate on the
+# bash -c / eval substring checks does not also bypass this walker —
+# `trap` is its own verb and command_name_is gates correctly.
+block_trap_handler() {
+  if ! command_name_is "trap"; then
+    return
+  fi
+  local trap_i=1 trap_n=${#CMD_TOKENS_SCAN[@]}
+  local trap_seen_dashdash=0
+  local trap_readonly=0
+  local trap_first_pos=""
+  local trap_first_pos_set=0
+  while [ $trap_i -lt $trap_n ]; do
+    local trap_tok
+    trap_tok=$(strip_quotes "${CMD_TOKENS_SCAN[$trap_i]}")
+    if [ $trap_seen_dashdash -eq 0 ]; then
+      case "$trap_tok" in
+        --)
+          trap_seen_dashdash=1; trap_i=$((trap_i + 1)); continue ;;
+        -l|-p)
+          # `-l` / `-p` make the entire call read-only regardless
+          # of any signal-name args that may follow.
+          trap_readonly=1; break ;;
+      esac
+    fi
+    trap_first_pos="$trap_tok"
+    trap_first_pos_set=1
+    break
+  done
+  if [ "$trap_readonly" -eq 0 ] \
+     && [ "$trap_first_pos_set" -eq 1 ] \
+     && [ -n "$trap_first_pos" ] \
+     && [ "$trap_first_pos" != "-" ]; then
+    echo "BLOCKED: 'trap CMD SIG' deferred shell handler cannot be safely inspected. Ask user for explicit permission." >&2
+    exit 2
+  fi
+}
+
+block_interpreter_inline_code() {
+  # python/perl/ruby/node/php/osascript all accept code on argv. The inner
+  # string cannot be inspected, so the same fail-closed rule as `bash -c`
+  # applies. Flags covered: -c (python), -e (perl/ruby/node), --eval,
+  # --execute, -E (perl alias). A dedicated rule catches `awk 'BEGIN{system(
+  # "…")}'` and similar because awk programs are the first non-option arg,
+  # not behind a flag — so we detect the `system(` marker in the CMD_BLANKED
+  # view (heredoc bodies stripped) so a tee/cat heredoc whose body merely
+  # mentions `python -c`, `awk … system(…)`, etc. is not false-positively
+  # rejected.
+  #
+  # VERB-GATE: same reasoning as block_nested_shell_and_eval. Substring
+  # walkers without a verb gate false-positive on text-as-arg cases
+  # like `echo "avoid node -e examples" > docs/fp.md` and `git commit
+  # -m "docs: avoid python -c examples"`. Each branch below now gates
+  # on CMD_VERB so the substring check only fires when the verb itself
+  # is the matching interpreter (post-wrapper, post-path-prefix). For
+  # the awk family, `awk` / `gawk` / `mawk` / `nawk` all collapse to a
+  # bare verb name via _cn_strip_path_prefix.
+  case "${CMD_VERB-}" in
+    python|python2|python3|perl|ruby|node|nodejs|deno|bun|osascript|Rscript)
+      if echo "$CMD_BLANKED" | grep -qE '(^|[[:space:]])(python|python2|python3|perl|ruby|node|nodejs|deno|bun|osascript|Rscript)[[:space:]]+(-[a-zA-Z]*[ceE]|--eval|--execute)([[:space:]]|=|$)'; then
+        echo "BLOCKED: Non-shell interpreter with inline code flag cannot be safely inspected. Ask user for explicit permission." >&2
+        exit 2
+      fi ;;
+    php)
+      # Dedicated PHP rule — `-r`, `-R`, `--run` execute inline code.
+      # Cannot be folded into the python/etc. regex because `-r` is a
+      # module-preload flag in ruby/node (no code execution), so a
+      # generic `r` letter would false-positive on `ruby -r json` /
+      # `node -r dotenv`. The matcher accepts attached forms
+      # (`-rcode`, `-Rcode`), quoted-attached (`-r'code'`), clustered-
+      # ending (`-ar`, `-aR`), and the long alias `--run`.
+      if echo "$CMD_BLANKED" | grep -qE '(^|[[:space:]])php[[:space:]]+(-[rR][^[:space:]=]*|-[a-zA-Z]*[rR]|--run)([[:space:]]|=|$|'\''|")'; then
+        echo "BLOCKED: 'php -r/-R/--run' inline code cannot be safely inspected. Ask user for explicit permission." >&2
+        exit 2
+      fi
+      # php also accepts -c/--eval inline forms — same regex as the
+      # python branch covers them.
+      if echo "$CMD_BLANKED" | grep -qE '(^|[[:space:]])php[[:space:]]+(-[a-zA-Z]*[ceE]|--eval|--execute)([[:space:]]|=|$)'; then
+        echo "BLOCKED: Non-shell interpreter with inline code flag cannot be safely inspected. Ask user for explicit permission." >&2
+        exit 2
+      fi ;;
+    awk|gawk|mawk|nawk)
+      if echo "$CMD_BLANKED" | grep -qE 'system[[:space:]]*\(|\|[[:space:]]*&?[[:space:]]*"?(sh|bash)'; then
+        echo "BLOCKED: awk program with 'system()' / shell pipe cannot be safely inspected. Ask user for explicit permission." >&2
+        exit 2
+      fi ;;
+  esac
+}
+
+block_pipe_to_shell() {
+  # Match bare shell invocations: sh, bash, zsh, ksh, dash, fish,
+  # /bin/sh, /bin/bash, ..., and with flags: sh -s, bash --login, etc.
+  # But NOT: bash script.sh, bash -x script.sh (running a script file).
+  if echo "$CMD" | grep -qE '^(/bin/)?(sh|bash|zsh|ksh|dash|fish)$'; then
+    echo "BLOCKED: Piping to 'sh'/'bash'/'zsh'/'ksh'/'dash'/'fish' cannot be safely inspected. Ask user for explicit permission." >&2
+    exit 2
+  fi
+  # Match shell with only flags (no script file): sh -s, bash --login, sh -s -- args
+  if echo "$CMD" | grep -qE '^(/bin/)?(sh|bash|zsh|ksh|dash|fish)[[:space:]]+-'; then
+    local shell_args
+    shell_args=$(echo "$CMD" | sed -E 's/^(\/bin\/)?(sh|bash|zsh|ksh|dash|fish)[[:space:]]+//')
+    local has_script=0
+    local shell_token
+    for shell_token in $shell_args; do
+      case "$shell_token" in
+        --) break ;;  # everything after -- is args to the script/stdin
+        # Informational-only flags exit before reading stdin or
+        # executing user code — `bash --version` / `sh --help` are
+        # not pipe-to-shell targets even when they appear as a
+        # standalone subcommand (issue #33).
+        #
+        # Codex sweep 4: `-V` is NOT safe across all shells —
+        # zsh and dash treat `-V` as the version flag but still
+        # read and execute stdin, so `curl URL | zsh -V` was a
+        # real pipe-to-shell bypass. bash and ksh reject `-V`
+        # as an unknown option (no stdin read), but the walker
+        # can't distinguish per-shell here. Drop `-V` from the
+        # whitelist entirely — only the long forms `--version`
+        # and `--help` are safe across the guarded shell set.
+        --version|--help)
+          has_script=1; break ;;
+        -*) continue ;;
+        *) has_script=1; break ;;
+      esac
+    done
+    if [[ $has_script -eq 0 ]]; then
+      echo "BLOCKED: Piping to 'sh'/'bash' cannot be safely inspected. Ask user for explicit permission." >&2
+      exit 2
+    fi
+  fi
+}
+
+block_shell_script_execution() {
+  # Catches: `bash /tmp/x.sh`, `sh ~/x.sh`, `zsh|ksh|dash|fish /tmp/x.sh`,
+  # `source /tmp/x.sh`, `. /tmp/x.sh`. Inline-code forms (`bash -c ...`)
+  # are caught by block_nested_shell_and_eval; this covers the
+  # complementary case where the script is a path argument.
+  #
+  # STRICT project-root check (no allowlist). Allowlist grants WRITE to
+  # specific paths (e.g. memory/); if execute inherited that, a write-
+  # allowlisted dir would become an RCE escape hatch:
+  #   `echo 'rm -rf $HOME' > memory/x.sh && bash memory/x.sh`.
+  # Walk CMD_TOKENS to locate the shell/source invocation, possibly buried
+  # behind an `env [flags] [VAR=val]*` wrapper. Once found, scan for the
+  # script-path operand — honoring flags that consume the next token
+  # (-O / -o for bash set options). Finally, dereference symlinks on the
+  # script path so a `project/link.sh -> /tmp/evil.sh` bait is caught.
+  # Re-tokenize the command with redirect operators (< << <<< <<-) spaced
+  # out so that attached forms like `bash</tmp/x.sh`, `bash<<EOF`, and
+  # `bash<<<'rm -rf /'` don't slip past as single unsplit tokens.
+  local _exec_cmd
+  _exec_cmd=$(printf '%s' "$CMD" | sed -E 's/(<<-|<<<|<<|<)/ \1 /g')
+  local -a CMD_TOKENS_EXEC=()
+  local _etok
+  while IFS= read -r _etok; do
+    [[ -z "$_etok" ]] && continue
+    CMD_TOKENS_EXEC+=("$_etok")
+  done < <(tokenize_args "$_exec_cmd")
+
+  # A parallel token stream built from a heredoc-blanked copy of CMD.
+  # Used ONLY by the `_saw_redir`/`exec_kind` scans below, which otherwise
+  # would treat a quoted-heredoc body byte like "bash" or "source" as a
+  # shell token and false-positive with
+  #   "Stdin redirection feeding shell cannot be safely inspected"
+  # on perfectly innocuous text like a git-commit body mentioning `bash`.
+  # Real shell-stdin attacks (`bash << /tmp/x`, `< /tmp/x bash`,
+  # `bash <<'EOF' ... EOF`, `bash <<<'rm -rf /'`, attached `bash</tmp/x>`)
+  # still appear in this stream because their shell token sits OUTSIDE
+  # any heredoc body, so the fail-closed detectors keep firing.
+  local _exec_cmd_scan
+  _exec_cmd_scan=$(blank_quoted_heredoc_bodies "$CMD" \
+                   | sed -E 's/(<<-|<<<|<<|<)/ \1 /g')
+  local -a CMD_TOKENS_EXEC_SCAN=()
+  while IFS= read -r _etok; do
+    [[ -z "$_etok" ]] && continue
+    CMD_TOKENS_EXEC_SCAN+=("$_etok")
+  done < <(tokenize_args "$_exec_cmd_scan")
+
+  local exec_kind="" exec_shell_idx=-1
+  local _ti=0 _tn=${#CMD_TOKENS_EXEC[@]}
+
+  # Fail-closed on ANY stdin redirect (< << <<< <<-) that appears before
+  # a shell/source token — regardless of leading wrappers or VAR=val.
+  # Bash allows redirections to sit anywhere in the command-prefix, so
+  # `FOO=1 < /tmp/evil.sh bash`, `nice < /tmp/evil.sh bash`, and a bare
+  # `< /tmp/evil.sh bash` all feed the shell from an uninspectable source.
+  local _rk=0 _saw_redir=0
+  local _tn_scan=${#CMD_TOKENS_EXEC_SCAN[@]}
+  while [ $_rk -lt $_tn_scan ]; do
+    local _rtok_chk
+    _rtok_chk=$(strip_quotes "${CMD_TOKENS_EXEC_SCAN[$_rk]}")
+    case "$_rtok_chk" in
+      \<|\<\<|\<\<\<|\<\<-) _saw_redir=1 ;;
+      *)
+        if [ $_saw_redir -eq 1 ] && { is_shell_token "$_rtok_chk" || is_source_token "$_rtok_chk"; }; then
+          echo "BLOCKED: Stdin redirection feeding shell cannot be safely inspected. Ask user for explicit permission." >&2
+          exit 2
+        fi
+        ;;
+    esac
+    _rk=$((_rk + 1))
+  done
+
+  # Fail-closed on `env -S <str>`, `env --split-string=<str>`, `env -C <dir>`,
+  # `env --chdir=<dir>`: all of these either hide the real command inside a
+  # split string or change the cwd so relative script paths no longer match
+  # what Bash actually executes.
+  if [ $_tn -gt 0 ]; then
+    local _env_first
+    _env_first=$(strip_quotes "${CMD_TOKENS_EXEC[0]}")
+    if [[ "$_env_first" == "env" || "$_env_first" == "/usr/bin/env" ]]; then
+      local _envk=1
+      while [ $_envk -lt $_tn ]; do
+        local _envtok
+        _envtok=$(strip_quotes "${CMD_TOKENS_EXEC[$_envk]}")
+        case "$_envtok" in
+          -S|-S*|--split-string|--split-string=*|-C|-C*|--chdir|--chdir=*)
+            echo "BLOCKED: 'env -S/--split-string/-C/--chdir' cannot be safely inspected. Ask user for explicit permission." >&2
+            exit 2 ;;
+        esac
+        _envk=$((_envk + 1))
+      done
+    fi
+  fi
+
+  # Walk past common runtime wrappers (env, command, nice, nohup, timeout,
+  # time, stdbuf, ionice, chrt, taskset) and any leftover sudo flags
+  # (sudo itself is already stripped at the top of check_single_command,
+  # but its own short flags can remain in the token stream as `-E` etc.).
+  # We only advance past token 0 when it is a recognized wrapper or looks
+  # like a flag / VAR=val — this avoids false positives on invocations
+  # like `echo bash`, where `bash` is an argument, not the command.
+  # Greedy skip: walk past wrappers / flags / VAR=val / operands until
+  # a shell or source token appears. Known tradeoff — this over-blocks
+  # `time echo bash /tmp/x` (bash is an arg to echo, not a shell), but
+  # precise per-wrapper operand grammars would miss real bypasses like
+  # `timeout -s TERM 10 bash /tmp/x` and `stdbuf -o L bash /tmp/x` where
+  # flag operands are non-numeric. Security over precision for this case.
+  local _advance=0
+  if [ $_tn -gt 0 ]; then
+    local _t0
+    _t0=$(strip_quotes "${CMD_TOKENS_EXEC[0]}")
+    case "$_t0" in
+      env|/usr/bin/env|command|builtin|exec|nice|nohup|timeout|time|stdbuf|ionice|chrt|taskset)
+        _advance=1 ;;
+      -*|+*) _advance=1 ;;
+      *=*) _advance=1 ;;
+    esac
+  fi
+  if [ $_advance -eq 1 ]; then
+    _ti=1
+    while [ $_ti -lt $_tn ]; do
+      local _tok
+      _tok=$(strip_quotes "${CMD_TOKENS_EXEC[$_ti]}")
+      if is_shell_token "$_tok" || is_source_token "$_tok"; then
+        break
+      fi
+      _ti=$((_ti + 1))
+    done
+  fi
+  if [ $_ti -lt $_tn ]; then
+    local _cmd_tok
+    _cmd_tok=$(strip_quotes "${CMD_TOKENS_EXEC[$_ti]}")
+    if is_shell_token "$_cmd_tok"; then
+      exec_kind="shell"; exec_shell_idx=$_ti
+    elif is_source_token "$_cmd_tok"; then
+      exec_kind="source"; exec_shell_idx=$_ti
+    fi
+  fi
+  [ -z "$exec_kind" ] && return 0
+
+  local exec_target=""
+  local ei=$((exec_shell_idx + 1)) en=${#CMD_TOKENS_EXEC[@]}
+  local seen_ddash=0
+  while [ $ei -lt $en ]; do
+    local etok
+    etok=$(strip_quotes "${CMD_TOKENS_EXEC[$ei]}")
+    if [ $seen_ddash -eq 0 ]; then
+      case "$etok" in
+        --) seen_ddash=1; ei=$((ei + 1)); continue ;;
+        # bash/sh -O/+O and -o/+o take the next token as operand
+        -O|+O|-o|+o) ei=$((ei + 2)); continue ;;
+        # Bash accepts both `-x` (enable) and `+x` (disable) forms
+        -*|+*|'') ei=$((ei + 1)); continue ;;
+        # fd prefix for a redirect operator (e.g. `bash 0<file`, `bash 2>&1`).
+        # Skip — the operator itself is handled on the next iteration.
+        [0-9]|[0-9][0-9])
+          ei=$((ei + 1)); continue ;;
+        # Stdin redirection variants: bash executes whatever is piped in.
+        # `<< EOF` / `<<< "str"` content can't be inspected — fail closed.
+        # `< file` — validate `file` as exec target (treat next token as script).
+        \<\<|\<\<-|\<\<\<)
+          echo "BLOCKED: Shell invoked with heredoc/here-string (<<, <<-, <<<) cannot be safely inspected. Ask user for explicit permission." >&2
+          exit 2 ;;
+        \<)
+          ei=$((ei + 1))
+          if [ $ei -lt $en ]; then
+            local _next_tok
+            _next_tok=$(strip_quotes "${CMD_TOKENS_EXEC[$ei]}")
+            # `bash < <(cmd)` — process substitution on stdin is a hidden
+            # command source. Fail closed.
+            case "$_next_tok" in
+              \<|\<\(*|\(*|\&*)
+                echo "BLOCKED: Shell stdin from process substitution / fd duplicate cannot be safely inspected. Ask user for explicit permission." >&2
+                exit 2 ;;
+              *)
+                exec_target="$_next_tok" ;;
+            esac
+          fi
+          break ;;
+      esac
+    fi
+    exec_target="$etok"
+    break
+  done
+  [ -z "$exec_target" ] && return 0
+
+  exec_target=$(expand_path "$exec_target")
+  if [[ "$exec_target" != /* ]]; then
+    exec_target="$EFFECTIVE_CWD/$exec_target"
+  fi
+  local exec_resolved
+  exec_resolved=$(resolve_path "$exec_target")
+  # Dereference symlinks on the leaf — bash follows them at exec time,
+  # so a project-local symlink pointing outside must be caught.
+  local _exec_depth=20
+  while [[ -L "$exec_resolved" && $_exec_depth -gt 0 ]]; do
+    local _exec_link
+    _exec_link=$(readlink "$exec_resolved")
+    if [[ "$_exec_link" == /* ]]; then
+      exec_resolved=$(resolve_path "$_exec_link")
+    else
+      exec_resolved=$(resolve_path "$(dirname "$exec_resolved")/$_exec_link")
+    fi
+    _exec_depth=$((_exec_depth - 1))
+  done
+  if [[ -L "$exec_resolved" ]]; then
+    echo "BLOCKED: Script symlink chain too deep or circular at '$exec_resolved'. Ask user for explicit permission." >&2
+    exit 2
+  fi
+  if [[ "$exec_resolved/" != "$PROJECT_DIR/"* ]]; then
+    echo "BLOCKED: Executing script '$exec_resolved' is OUTSIDE project directory '$PROJECT_DIR'. Allowlist does not cover execute. Ask user for explicit permission." >&2
+    exit 2
+  fi
+}

--- a/plugins/project-boundary/hooks/lib/subcmd_flags.sh
+++ b/plugins/project-boundary/hooks/lib/subcmd_flags.sh
@@ -1,0 +1,338 @@
+#!/bin/bash
+# project-boundary guard — subcmd_flags module
+# =============================================
+# Some tools take a SHELL COMMAND as the value of a specific flag and
+# execute it locally at runtime. The guard's path / destructive walkers
+# only see flag NAMES — not flag VALUES — so a destructive command
+# hidden in such a value slips past every detector. Same side-channel
+# class as `find -exec <cmd>` (already covered) and the remote-dispatch
+# verbs from issue #21 (ssh / docker exec / kubectl exec): an opaque
+# command argument that the surface walker never opens.
+#
+# Affected sinks (added incrementally per the §Security-bypass TDD flow
+# in CLAUDE.md):
+#
+#   tar -xf … --to-command=<cmd>          [section 29]
+#   rsync -e / --rsh=<cmd>                [section 30]
+#   git -c core.sshCommand=<cmd>          [section 31]
+#   git -c <other-exec-key>=<cmd>         [section 32]
+#       core.editor / core.pager / pager.<cmd> / sequence.editor /
+#       gpg.program / gpg.ssh.program / credential.helper /
+#       diff.external / mergetool.<tool>.cmd
+#   git -c <additional-exec-keys>         [section 35]
+#       core.askPass / core.fsmonitor / uploadpack.packObjectsHook /
+#       filter.<n>.clean / filter.<n>.smudge / filter.<n>.process /
+#       diff.<n>.command / diff.<n>.textconv / merge.<n>.driver
+#   git -c <bang-prefixed-exec-keys>      [section 36]
+#       gpg.openpgp.program / gpg.x509.program /
+#       submodule.<n>.update (with leading `!`)
+#
+# The mechanism is intentionally simple: extract each sub-command
+# value from a single (post-split) command and emit one payload per
+# line on stdout. The caller — check_single_command in guard.sh —
+# recursively dispatches each payload through itself, so every
+# existing destructive / write-target walker validates the payload
+# without any per-tool duplication of detection logic.
+#
+#   tar -xf foo.tar --to-command='<destructive-payload>'
+#     → check_single_command "<destructive-payload>"
+#
+# Must run PER SUBCOMMAND (i.e. inside check_single_command, AFTER
+# split_and_check has split the chained command line on `;` / `&&`
+# / `||` / `|` / newline). Routing the extraction earlier — before
+# the splitter — would only catch the FIRST verb of a chained
+# command, leaving any sink in a later subcommand undetected
+# (Copilot review on PR #23, options.sh:92).
+#
+# Pure (no caller-scope dependencies). Depends on
+# hooks/lib/tokenize.sh (tokenize_args, strip_quotes).
+
+# --- Sink table ---
+# Format: "<verb>|<short_flag>|<long_flag_no_eq>|<kind>|<key_regex>"
+#
+#   verb         - command-name token after wrapper-skip
+#   short_flag   - short option that consumes the next token (e.g. "-e");
+#                  empty if none. Attached form `-eVALUE` also recognised.
+#   long_flag    - long option without trailing `=` (e.g. "--to-command");
+#                  empty if none. Both `--flag=VALUE` and `--flag VALUE`
+#                  shapes are recognised.
+#   kind         - "value":     value IS the shell command directly.
+#                  "git-config": value is `key=cmd`; only the rows whose
+#                                key matches <key_regex> are exec sinks.
+#   key_regex    - bash extended regex; used only when kind=git-config.
+declare -a SUBCMD_FLAG_SINKS=(
+  "tar||--to-command|value|"
+  "rsync|-e|--rsh|value|"
+  "git|-c||git-config|^(core\\.(sshCommand|editor|pager|askPass|fsmonitor)|pager\\..+|sequence\\.editor|gpg\\.(program|ssh\\.program|openpgp\\.program|x509\\.program)|credential\\.helper|diff\\.(external|.+\\.(command|textconv))|mergetool\\..+\\.cmd|merge\\..+\\.driver|filter\\..+\\.(clean|smudge|process)|uploadpack\\.packObjectsHook|submodule\\..+\\.update|alias\\..+)$"
+)
+
+# --- Find verb token index, skipping wrappers / VAR=val / flags ---
+# Mirrors _rd_find_verb_idx in remote_dispatch.sh. Reads from the
+# module-local _SF_TOKS array. Uses a global rather than `local -n`
+# because macOS ships bash 3.2 which lacks nameref support.
+_sf_find_verb_idx() {
+  local i=0 n=${#_SF_TOKS[@]}
+  local prev_was_timeout=0 last_wrapper=""
+  while [ $i -lt $n ]; do
+    local raw="${_SF_TOKS[$i]}" t
+    t=$(strip_quotes "$raw")
+
+    # Wrapper opt-with-value: if the previous wrapper had options
+    # that consume the next token, advance past both the flag and
+    # its value (Copilot review on PR #23, guard.sh:897).
+    if [ -n "$last_wrapper" ]; then
+      local opts; opts=$(_wrapper_opts_with_val "$last_wrapper")
+      if [ -n "$opts" ]; then
+        case " $opts " in
+          *" $t "*) i=$((i + 2)); continue ;;
+        esac
+      fi
+    fi
+
+    # `timeout` takes a duration operand (e.g. `timeout 5 cmd`,
+    # `timeout 1.5s cmd`, `timeout infinity cmd`); skip one extra
+    # token after it. Digit-prefixed forms cover `5`, `5s`, `2m`,
+    # `1.5h`; `inf*` covers `inf` / `infinity`.
+    if [ $prev_was_timeout -eq 1 ]; then
+      prev_was_timeout=0
+      case "$t" in
+        [0-9]*|inf*) i=$((i + 1)); continue ;;
+      esac
+    fi
+    case "$t" in
+      timeout)
+        prev_was_timeout=1; last_wrapper="timeout"; i=$((i + 1)); continue ;;
+      sudo|env|/bin/env|/usr/bin/env|nice|nohup|time|stdbuf|ionice|chrt|taskset|command|builtin|exec)
+        last_wrapper=$(_sf_strip_path_prefix "$t")
+        i=$((i + 1)); continue ;;
+    esac
+    case "$t" in
+      [A-Za-z_]*=*) i=$((i + 1)); continue ;;
+      -*) i=$((i + 1)); continue ;;
+    esac
+    printf '%d' "$i"
+    return
+  done
+  printf -- '-1'
+}
+
+# --- Strip /bin/, /sbin/, /usr/bin/, /usr/sbin/, /usr/local/bin/, ---
+# /opt/homebrew/bin/ prefix from a command-name token. Mirrors
+# _cn_strip_path_prefix in command_name.sh — kept in sync so a
+# Homebrew-installed tar / git / etc. is recognised by the
+# subcommand sink walkers in this module too.
+_sf_strip_path_prefix() {
+  local n="$1"
+  case "$n" in
+    /bin/*|/sbin/*|/usr/bin/*|/usr/sbin/*|/usr/local/bin/*|/opt/homebrew/bin/*) printf '%s' "${n##*/}" ;;
+    *) printf '%s' "$n" ;;
+  esac
+}
+
+# --- Bang-prefix keys list (case-insensitive match) ---
+# Keys whose value is an exec sink ONLY when prefixed with `!`.
+# Centralised so the `-c` and `git config` branches use the same
+# rule. Reads $key from the caller's scope.
+_sf_key_requires_bang() {
+  local k="$1"
+  local was=0
+  shopt -q nocasematch && was=1
+  shopt -s nocasematch
+  local hit=0
+  { [[ "$k" =~ ^submodule\..+\.update$ ]] || [[ "$k" =~ ^alias\..+$ ]]; } && hit=1
+  [ $was -eq 1 ] || shopt -u nocasematch
+  return $((1 - hit))
+}
+
+# --- Helper: emit payload from a (key, value) pair, honouring bang rules ---
+_sf_emit_git_config_payload() {
+  local key="$1" subcmd_val="$2"
+  if _sf_key_requires_bang "$key"; then
+    case "$subcmd_val" in
+      '!'*) printf '%s\n' "${subcmd_val#!}" ;;
+    esac
+  else
+    printf '%s\n' "$subcmd_val"
+  fi
+}
+
+# --- `git config [opts] <key> <value>` form ---
+# Long-form alternative to `git -c <key>=<value>`. Setting an exec-
+# sink config persistently runs the same shell command at the next
+# git operation, so the value still needs validation. Reads tokens
+# from the module-local _SF_TOKS array.
+_sf_try_git_config_form() {
+  local v_idx="$1" key_regex="$2"
+  local n=${#_SF_TOKS[@]}
+
+  # Find the first non-flag, non-VAR=val token after the verb;
+  # that is the subverb (`config` for this form).
+  local subverb_idx=$((v_idx + 1))
+  while [ $subverb_idx -lt $n ]; do
+    local raw="${_SF_TOKS[$subverb_idx]}" t
+    t=$(strip_quotes "$raw")
+    case "$t" in
+      [A-Za-z_]*=*|-*) subverb_idx=$((subverb_idx + 1)); continue ;;
+    esac
+    break
+  done
+  [ $subverb_idx -ge $n ] && return
+  local subverb
+  subverb=$(strip_quotes "${_SF_TOKS[$subverb_idx]}")
+  [ "$subverb" = "config" ] || return
+
+  # Walk past `config`, collect at most two positionals (key, value).
+  # Two-token flags (`--file PATH`, `--blob OBJ`) consume their value;
+  # read-only flags (`--get*`, `--list`, `-l`) bail entirely.
+  local i=$((subverb_idx + 1))
+  local -a positionals=()
+  while [ $i -lt $n ] && [ ${#positionals[@]} -lt 2 ]; do
+    local raw="${_SF_TOKS[$i]}" t
+    t=$(strip_quotes "$raw")
+    case "$t" in
+      --file|--blob) i=$((i + 2)); continue ;;
+      --get|--get-all|--get-regexp|--get-urlmatch|--list|-l|--show-origin|--show-scope|--name-only|-e|--edit)
+        return ;;
+      --file=*|--blob=*|--unset|--unset-all|--add|--replace-all|--type=*|--null|-z|--global|--system|--local|--worktree|--includes|--no-includes|--default=*|--int|--bool|--bool-or-int|--path|--expiry-date|--*|-*)
+        i=$((i + 1)); continue ;;
+    esac
+    positionals+=("$raw")
+    i=$((i + 1))
+  done
+
+  [ ${#positionals[@]} -lt 2 ] && return
+
+  local key val
+  key=$(strip_quotes "${positionals[0]}")
+  val=$(strip_quotes "${positionals[1]}")
+
+  local _was=0
+  shopt -q nocasematch && _was=1
+  shopt -s nocasematch
+  local _match=0
+  [[ "$key" =~ $key_regex ]] && _match=1
+  [ $_was -eq 1 ] || shopt -u nocasematch
+  [ $_match -eq 0 ] && return
+
+  _sf_emit_git_config_payload "$key" "$val"
+}
+
+# --- Main entry: extract sub-command flag values from one subcommand ---
+# In:  single (post-split) command string
+# Out: zero or more payload strings on stdout, one per line. Empty
+#      output when no sink row matches the verb or no recognised flag
+#      carries a value. Caller dispatches each payload through
+#      check_single_command recursively.
+extract_subcmd_flag_payloads() {
+  local cmd="$1"
+  _SF_TOKS=()
+  local t
+  while IFS= read -r t; do
+    [[ -z "$t" ]] && continue
+    _SF_TOKS+=("$t")
+  done < <(tokenize_args "$cmd")
+
+  local verb_idx
+  verb_idx=$(_sf_find_verb_idx)
+  [ "$verb_idx" -lt 0 ] && return
+
+  local verb
+  verb=$(strip_quotes "${_SF_TOKS[$verb_idx]}")
+  verb=$(_sf_strip_path_prefix "$verb")
+
+  # Match a sink row by verb. First match wins; the table currently
+  # has at most one row per verb.
+  local row sink_short="" sink_long="" sink_kind="" sink_key_regex=""
+  local matched=0
+  for row in "${SUBCMD_FLAG_SINKS[@]}"; do
+    local r_verb="${row%%|*}"
+    if [ "$r_verb" = "$verb" ]; then
+      local rest="${row#*|}"
+      sink_short="${rest%%|*}"; rest="${rest#*|}"
+      sink_long="${rest%%|*}"; rest="${rest#*|}"
+      sink_kind="${rest%%|*}"; rest="${rest#*|}"
+      sink_key_regex="$rest"
+      matched=1
+      break
+    fi
+  done
+  [ $matched -eq 0 ] && return
+
+  # Walk tokens after the verb, emit every flag-value that the sink
+  # row recognises (one payload per line on stdout).
+  local i=$((verb_idx + 1)) n=${#_SF_TOKS[@]}
+  while [ $i -lt $n ]; do
+    local raw="${_SF_TOKS[$i]}" tok val="" hit=0
+    tok=$(strip_quotes "$raw")
+
+    if [ -n "$sink_long" ] && [[ "$tok" == "${sink_long}="* ]]; then
+      val="${tok#${sink_long}=}"
+      val=$(strip_quotes "$val")
+      hit=1; i=$((i + 1))
+    elif [ -n "$sink_long" ] && [ "$tok" = "$sink_long" ] && [ $((i + 1)) -lt $n ]; then
+      val=$(strip_quotes "${_SF_TOKS[$((i + 1))]}")
+      hit=1; i=$((i + 2))
+    elif [ -n "$sink_short" ] && [ "$tok" = "$sink_short" ] && [ $((i + 1)) -lt $n ]; then
+      val=$(strip_quotes "${_SF_TOKS[$((i + 1))]}")
+      hit=1; i=$((i + 2))
+    elif [ -n "$sink_short" ] && [[ "$tok" == "${sink_short}"* ]] && [ "$tok" != "$sink_short" ]; then
+      val="${tok#${sink_short}}"
+      val=$(strip_quotes "$val")
+      hit=1; i=$((i + 1))
+    elif [ -n "$sink_short" ] \
+        && [ "$tok" != "$sink_short" ] \
+        && [[ "$tok" == -[!-]*"${sink_short#-}" ]] \
+        && [ $((i + 1)) -lt $n ]; then
+      # Clustered short-flag form: `-avze <val>` where the cluster's
+      # last char matches the sink's short-flag letter and consumes
+      # the next token as its value (Copilot review on PR #23,
+      # subcmd_flags.sh:167). Excludes long flags (`--rsh`) via
+      # `-[!-]*` and the bare short flag via the inequality test.
+      val=$(strip_quotes "${_SF_TOKS[$((i + 1))]}")
+      hit=1; i=$((i + 2))
+    else
+      i=$((i + 1)); continue
+    fi
+
+    [ $hit -eq 0 ] && continue
+    # Skip empty / whitespace-only values; they cannot be exec sinks
+    # (Codex review on PR #23, Q4).
+    [[ -z "${val//[[:space:]]/}" ]] && continue
+
+    if [ "$sink_kind" = "git-config" ]; then
+      # Value shape is `key=subcmd`. Without an `=` it is not a config
+      # assignment and cannot be an exec sink.
+      case "$val" in *=*) ;; *) continue ;; esac
+      local key="${val%%=*}"
+      local subcmd_val="${val#*=}"
+      # The token tokenizer keeps surrounding quotes around an
+      # attached value (e.g. `--c-flag-token` looks like
+      # `key='!cmd ...'` with the quotes intact). Strip them here so
+      # the bang-prefix check below sees the real first character.
+      subcmd_val=$(strip_quotes "$subcmd_val")
+      # git config keys are case-insensitive (`Core.SshCommand` ==
+      # `core.sshCommand`); enable nocasematch around the regex test
+      # so case-folded variants are not a bypass route. Save / restore
+      # the previous state to avoid leaking the option to callers.
+      local _sf_nocase_was_on=0
+      shopt -q nocasematch && _sf_nocase_was_on=1
+      shopt -s nocasematch
+      local _sf_key_match=0
+      [[ "$key" =~ $sink_key_regex ]] && _sf_key_match=1
+      [ $_sf_nocase_was_on -eq 1 ] || shopt -u nocasematch
+      if [ $_sf_key_match -eq 1 ]; then
+        _sf_emit_git_config_payload "$key" "$subcmd_val"
+      fi
+    else
+      printf '%s\n' "$val"
+    fi
+  done
+
+  # `git config [opts] <key> <value>` — alternative assignment form
+  # of git's exec-sink config keys (same key regex, different shape
+  # than the `-c` flag). Run after the main walk so the `-c` flow
+  # is unaffected.
+  if [ "$verb" = "git" ] && [ "$sink_kind" = "git-config" ]; then
+    _sf_try_git_config_form "$verb_idx" "$sink_key_regex"
+  fi
+}

--- a/plugins/project-boundary/hooks/lib/tokenize.sh
+++ b/plugins/project-boundary/hooks/lib/tokenize.sh
@@ -99,3 +99,22 @@ tokenize_args() {
     printf '%s\n' "$t"
   done
 }
+
+# --- Fill a named array with tokenize_args output ---
+# Usage: fill_tokens_from <array_name> <cmd_string>
+# Replaces the open-coded `arr=(); while read tok; arr+=(...); done <
+# <(tokenize_args "$cmd")` boilerplate. guard.sh uses this twice for
+# CMD_TOKENS and twice for CMD_TOKENS_SCAN (once at initial build, once
+# after remote-dispatch rewrite); centralising removes a 4× repeat.
+# Uses eval (not `local -n`) for bash 3.2 compatibility — macOS ships
+# /bin/bash 3.2 and the whole project targets that.
+fill_tokens_from() {
+  local _arr_name="$1"
+  local _src="$2"
+  eval "$_arr_name=()"
+  local _tok
+  while IFS= read -r _tok; do
+    [[ -z "$_tok" ]] && continue
+    eval "$_arr_name+=(\"\$_tok\")"
+  done < <(tokenize_args "$_src")
+}

--- a/plugins/project-boundary/hooks/lib/wrapper_opts.sh
+++ b/plugins/project-boundary/hooks/lib/wrapper_opts.sh
@@ -1,0 +1,35 @@
+# shellcheck shell=bash
+# Per-wrapper list of options that consume the NEXT token.
+#
+# Some wrappers take option-with-value flags before the real verb
+# (`sudo -u root cmd`, `env -u VAR cmd`, `timeout -k 5 10 cmd`).
+# Without skipping the value too, the verb-finder mis-identifies the
+# value as the verb (e.g. `root` instead of `cmd`), so downstream
+# walkers (sink table / install detector / remote-dispatch
+# neutraliser) never match. Reported by Copilot review on PR #23
+# (guard.sh:897); propagated to command_name.sh / remote_dispatch.sh
+# in PR #24 sec 41 / 42.
+#
+# Returns a space-separated list on stdout; empty for unknown
+# wrappers. Callers wrap the result in ` ` so a `case` glob like
+# `*" $t "*` matches whole tokens only.
+#
+# IMPORTANT: only flags that actually take a value go here. Value-
+# less flags (sudo `-A`, `-k`, `-K`, `-E`, `-H`, `-i`, `-l`, `-n`,
+# `-P`, `-S`, `-s`, `-V`, `-v`, `-b`, `-e`; long forms `--askpass`,
+# `--background`, `--preserve-env`, `--login`, `--shell`, ...) MUST
+# fall through to the caller's generic `-*` / `-[A-Za-z]*` branch
+# (consume one token). Mis-listing a value-less flag skips the real
+# verb and reopens the section-40 bypass — Codex round-1 P1 on PR
+# #24.
+_wrapper_opts_with_val() {
+  case "$1" in
+    sudo) printf -- '-a -c -C -D -g -h -p -R -r -t -T -U -u --auth-type --chdir --chroot --close-from --command-timeout --group --host --login-class --other-user --prompt --role --type --user' ;;
+    env)  printf -- '-u -C -P --unset --chdir' ;;
+    timeout) printf -- '-k -s --kill-after --signal' ;;
+    nice) printf -- '-n --adjustment' ;;
+    ionice) printf -- '-c -n -p --class --classdata --pid' ;;
+    chrt) printf -- '-p --pid' ;;
+    *) ;;
+  esac
+}

--- a/plugins/project-boundary/hooks/project-boundary.md
+++ b/plugins/project-boundary/hooks/project-boundary.md
@@ -5,7 +5,7 @@ category: security
 event: PreToolUse
 matcher: Bash
 language: bash
-version: 1.8.0
+version: 1.10.0
 ---
 
 # project-boundary


### PR DESCRIPTION
## Summary
Syncs `plugins/project-boundary/` from upstream [justi/claude-code-project-boundary v1.10.0](https://github.com/justi/claude-code-project-boundary/releases/tag/v1.10.0).

## Releases included since v1.8.0
- **v1.9.0** — issue #21 remote-dispatch fix
- **v1.10.0** — Windows-smoke CI, jq canary, per-token cygpath, sec 108–114 cluster

## Notable additions
- New `hooks/lib/` modular detectors (`db_dump`, `destructive`, `download`, `filesystem_create`, `inplace`, `permissions`, `redirects`, `write_targets`)
- `guard.sh` refactored to dispatch through `lib/`
- `jq` hard-dependency check at hook entry
- Windows MSYS2 smoke job (upstream CI)

## Test plan
- [ ] Manual smoke: install plugin in fresh marketplace and trigger blocked / allowed cases
