### PR TITLE
Add Origin plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1396,6 +1396,29 @@
       "source": "./plugins/obsidian-skills"
     },
     {
+      "name": "origin",
+      "description": "AI work memory for Claude Code: brief, capture, recall, handoff, and distill, backed by a local daemon and MCP so decisions, lessons, project context, and wiki pages carry across sessions.",
+      "version": "0.6.1",
+      "author": {
+        "name": "Qi-Xuan Lu",
+        "url": "https://github.com/7xuanlu"
+      },
+      "repository": "https://github.com/7xuanlu/origin",
+      "homepage": "https://github.com/7xuanlu/origin/tree/main/plugin",
+      "license": "Apache-2.0",
+      "keywords": [
+        "memory",
+        "claude-code",
+        "mcp",
+        "local-first",
+        "context",
+        "handoff",
+        "wiki"
+      ],
+      "category": "productivity",
+      "source": "./plugins/origin"
+    },
+    {
       "name": "project-boundary",
       "description": "Security hook that blocks destructive commands and file operations outside the project directory",
       "version": "1.8.0",

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Curated collections maintained in this repository:
 | **Commands** | 175 | Slash commands for automation (`/commit`, `/docs`, `/tdd`) |
 | **Hooks** | 28 | Event-driven automation (notifications, git, formatting) |
 | **Skills** | 26 | Reusable capabilities from plugins |
-| **Plugins** | 50 | Bundled plugin packages by category |
+| **Plugins** | 51 | Bundled plugin packages by category |
 
 ### Community Discovery
 

--- a/plugins/origin/.claude-plugin/README.md
+++ b/plugins/origin/.claude-plugin/README.md
@@ -1,0 +1,119 @@
+# Origin
+
+AI work memory for Claude Code. Origin carries sessions, decisions, lessons, and project context forward, then turns them into searchable memory and wiki pages.
+
+## 30-Second Setup
+
+```text
+0s   /plugin marketplace add davepoon/buildwithclaude
+     /plugin install origin@buildwithclaude
+5s   restart Claude Code
+10s  /init   auto-installs daemon if missing, configures local memory,
+            verifies daemon + MCP + round-trip, prints "Origin ready"
+30s  /brief  (or /capture <something to remember>)
+```
+
+`/init` is self-healing — if the daemon isn't running and the `origin`
+CLI isn't on PATH, it runs the install one-liner for you. No copy/paste,
+no restart loop. The `SessionStart` hook only nudges you toward `/init`
+if the daemon ever stops.
+
+## Install
+
+```text
+/plugin marketplace add davepoon/buildwithclaude
+/plugin install origin@buildwithclaude
+```
+
+Origin's upstream marketplace is also available from `7xuanlu/origin`.
+
+The plugin metadata is defined in [`plugin.json`](plugin.json). MCP configuration is in [`../.mcp.json`](../.mcp.json), which delegates to [`../bin/origin-mcp-runner.sh`](../bin/origin-mcp-runner.sh).
+
+The runner picks the MCP server binary in three paths, in order:
+
+1. **Filesystem override** — if `plugin/bin/origin-mcp.local` exists (typically a symlink to a locally-built binary, gitignored), the runner exec's it. Most reliable: survives plugin reloads that don't re-read env.
+2. **Env var override** — `ORIGIN_MCP_DEV_BIN=/abs/path/to/origin-mcp`. Convenient if you already export it; requires Claude Code to inherit the var at startup.
+3. **Default** — `npx -y origin-mcp@^X.Y.Z`. What end users get after installing the plugin.
+
+To set up the filesystem override during dev:
+
+```
+cargo build -p origin-mcp --release
+ln -s $(pwd)/target/release/origin-mcp plugin/bin/origin-mcp.local
+```
+
+Reload the plugin (`/reload-plugins`) and the wrapper picks the local binary on the next MCP spawn.
+
+## Daily Commands
+
+```text
+/init       set up + verify Origin works (run once, or to diagnose)
+/help       one-screen reference
+/brief      load identity + topic context (start of session)
+/capture    save one durable memory in flow
+/recall     search local memory
+/distill    synthesize pages from clusters (scoped to current repo)
+/read       preview a distilled page inline
+/review     audit pending memories
+/forget     delete a memory by ID
+/handoff    end-of-session debrief
+/debrief    alias for /handoff (brief/debrief symmetry)
+```
+
+A `SessionStart` hook (`hooks/check-daemon.sh`) probes the local daemon at `127.0.0.1:7878`. If down, it prints a single line: `daemon not running. Run /origin:init to set up.` The skill owns the install logic — the hook is just a nudge. Hook never blocks the session.
+
+## Where your data lives
+
+```text
+~/.origin/pages/               wiki pages distilled from memories (md)
+~/.origin/sessions/            session logs by date (md)
+~/.origin/sessions/_status/    current per-project goals + last-handoff timestamp
+~/.origin/db/                  symlink to the libSQL store
+~/.origin/bin/                 installed binaries
+```
+
+Browse with `open ~/.origin/` (Finder), `code ~/.origin/` (VS Code), or symlink `~/.origin/pages/` into an Obsidian vault for the graph view. No Tauri app required.
+
+## Local memory and agent-side model phases
+
+By default `/init` configures **local memory**: no model download, no API
+key, no prompts. The daemon stores, embeds, dedupes, and serves hybrid
+search. Model-backed work like classification, entity extraction, page
+synthesis, and reranking stays opt-in.
+
+The skills compensate. Where the daemon would normally call a model, the
+skill asks Claude itself to do the equivalent step and posts the result
+back via HTTP:
+
+| Phase | Model-equipped daemon | Local memory + skill |
+|---|---|---|
+| Pick `memory_type` | daemon classifier | `/capture` picks one of 6 types from content |
+| Extract entities/relations | daemon `extract.rs` | `/capture` POSTs to `/api/memory/entities` and `/api/memory/relations` |
+| Synthesize a page | daemon distill cycles + `/distill` | `/distill` reads the cluster, writes the page, POSTs to `/api/pages` |
+| Expand a query / rerank hits | daemon expansion + rerank | `/recall` rewrites the query before search and reorders hits after |
+
+The daemon stays the single writer and storage owner. Claude does the
+thinking. This is why local memory works without an API key or
+on-device model — and why the same skills also work when you later add
+one. The skills detect the daemon's capabilities and fall through to
+the agent path when needed.
+
+## Skill Files
+
+The actual skill instructions live in [`../skills`](../skills):
+
+- `init`: end-to-end setup verifier (daemon + MCP + round-trip)
+- `help`: one-screen quick reference
+- `brief`: load session context
+- `capture`: save one durable memory
+- `recall`: targeted lookup
+- `distill`: refresh wiki pages
+- `read`: preview a distilled page inline
+- `review`: audit pending memories
+- `forget`: delete a memory by ID
+- `handoff`: capture end-of-session decisions, lessons, gotchas, and open threads
+- `debrief`: alias for `handoff` (brief/debrief symmetry)
+
+## License
+
+Apache-2.0.

--- a/plugins/origin/.claude-plugin/plugin.json
+++ b/plugins/origin/.claude-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "origin",
+  "description": "AI work memory for Claude Code. Carries sessions, decisions, lessons, and project context forward, then turns them into searchable memory and wiki pages.",
+  "version": "0.6.1",
+  "author": {
+    "name": "Qi-Xuan Lu",
+    "url": "https://github.com/7xuanlu"
+  },
+  "homepage": "https://github.com/7xuanlu/origin",
+  "repository": "https://github.com/7xuanlu/origin",
+  "license": "Apache-2.0",
+  "category": "memory",
+  "keywords": [
+    "memory",
+    "knowledge",
+    "context",
+    "recall",
+    "mcp"
+  ]
+}

--- a/plugins/origin/bin/origin-mcp-runner.sh
+++ b/plugins/origin/bin/origin-mcp-runner.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Dispatch the origin MCP server.
+#
+# Default path: pull the published origin-mcp from npm via npx. This is what
+# end users get after installing the plugin.
+#
+# Dev paths (checked in order):
+#   1. Sibling file `bin/origin-mcp.local` next to this script — typically a
+#      symlink to a locally-built origin-mcp binary. Filesystem-based so it
+#      survives plugin reloads that don't re-read settings.json env.
+#   2. ORIGIN_MCP_DEV_BIN env var — secondary, kept for shells that already
+#      export it. Requires Claude Code to inherit the var at startup.
+#
+# Either path means plugin changes to the MCP tool shape can be tested
+# without publishing to npm first.
+
+# Don't enable `set -u` here: if Claude Code (or any MCP host) invokes the
+# script through a shell that doesn't populate BASH_SOURCE, `set -u` halts
+# before we even get to the npx fallback. Fall back to $0 instead.
+here="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd -P)"
+local_bin="${here}/origin-mcp.local"
+
+if [ -x "${local_bin}" ]; then
+  exec "${local_bin}" "$@"
+fi
+
+if [ -n "${ORIGIN_MCP_DEV_BIN:-}" ] && [ -x "${ORIGIN_MCP_DEV_BIN}" ]; then
+  exec "${ORIGIN_MCP_DEV_BIN}" "$@"
+fi
+
+exec npx -y origin-mcp@^0.6.1 "$@"

--- a/plugins/origin/hooks/check-daemon.sh
+++ b/plugins/origin/hooks/check-daemon.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# SessionStart hook: probe the local Origin daemon and surface two issues:
+#   1. Daemon not running → point user at /origin:init (it auto-installs).
+#   2. Daemon version mismatches the plugin manifest → print the upgrade
+#      one-liner directly so the user can copy-paste.
+# Hook never blocks (always exit 0) and never prints command soup.
+set -u
+
+URL="http://127.0.0.1:7878/api/health"
+PLUGIN_JSON="${CLAUDE_PLUGIN_ROOT:-}/.claude-plugin/plugin.json"
+
+RESP=$(curl -fsS -m 1 "$URL" 2>/dev/null) || {
+  cat <<MSG
+[origin] daemon not running. Run /origin:init to set up.
+MSG
+  exit 0
+}
+
+# Compare daemon version vs plugin manifest version. Silent unless mismatch.
+[ -r "$PLUGIN_JSON" ] || exit 0
+command -v python3 >/dev/null 2>&1 || exit 0  # fail closed without python3
+
+extract_version() {
+  python3 -c 'import json,sys; print(json.load(sys.stdin).get("version",""))' 2>/dev/null
+}
+
+DAEMON_VER=$(printf '%s' "$RESP" | extract_version)
+EXPECTED_VER=$(extract_version <"$PLUGIN_JSON")
+
+if [ -n "$DAEMON_VER" ] && [ -n "$EXPECTED_VER" ] && [ "$DAEMON_VER" != "$EXPECTED_VER" ]; then
+  cat <<MSG
+[origin] daemon v${DAEMON_VER}, plugin expects v${EXPECTED_VER}. Upgrade:
+  curl -fsSL https://raw.githubusercontent.com/7xuanlu/origin/v${EXPECTED_VER}/install.sh | bash
+MSG
+fi
+
+exit 0

--- a/plugins/origin/hooks/hooks.json
+++ b/plugins/origin/hooks/hooks.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/check-daemon.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/origin/skills/README.md
+++ b/plugins/origin/skills/README.md
@@ -1,0 +1,37 @@
+# Origin Skills
+
+Claude Code workflow skills installed by the Origin plugin.
+
+These skills keep the daily interface short:
+
+```text
+/init        verify setup end-to-end
+/help        one-screen reference
+/brief       load session context
+/capture     save one durable memory
+/recall      search local memory
+/distill     refresh wiki pages
+/review captures|revisions   power-user deep audit; daily flow is /brief
+/forget      delete a memory by ID
+/handoff     end-of-session debrief
+/debrief     alias for /handoff
+```
+
+The skills do not store data themselves. They guide Claude Code to use the local `origin-mcp` tools, which talk to the Origin daemon on `127.0.0.1:7878`.
+
+## Files
+
+| Skill | Purpose |
+| --- | --- |
+| `init` | End-to-end setup verifier (daemon + MCP + round-trip). |
+| `help` | One-screen quick reference of the 10 verbs and the daily flow. |
+| `brief` | Load working context at session start or topic shifts. |
+| `capture` | Save one durable memory: decision, lesson, gotcha, preference, fact, or correction. |
+| `recall` | Query Origin for focused context. |
+| `distill` | Refresh wiki pages from accumulated memories. |
+| `review` | Power-user deep audit of pending surfaces (captures, revisions). Daily flow handled by `/brief`. |
+| `forget` | Delete a memory by ID. |
+| `handoff` | End-session capture for decisions, lessons, gotchas, and open threads. |
+| `debrief` | Alias for `handoff` — symmetric with `brief`. |
+
+Plugin metadata lives in [`.claude-plugin`](../.claude-plugin/README.md).

--- a/plugins/origin/skills/brief/SKILL.md
+++ b/plugins/origin/skills/brief/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: brief
+description: >
+  Session-start briefing from Origin. Reads the project status file (the
+  /handoff-maintained ledger of Active/Backlog work), then loads identity,
+  preferences, and topic-relevant memories so the agent walks in with context.
+  Surfaces any memories the daemon has flagged for human revision before the
+  session uses them. Invoked as `/brief [topic]`. Call FIRST at session start,
+  before any other Origin verb.
+argument-hint: "[topic]"
+allowed-tools: ["Bash", "mcp__plugin_origin_origin__context", "mcp__plugin_origin_origin__recall", "mcp__plugin_origin_origin__list_pending_revisions", "mcp__plugin_origin_origin__accept_revision", "mcp__plugin_origin_origin__dismiss_revision"]
+---
+
+# /brief
+
+Pull a curated session brief from Origin. Three sources, in order:
+
+1. **Project status file** — what `/handoff` last wrote. Authoritative for
+   "what's left to do" right now.
+2. **`context` MCP** — identity, preferences, topic-relevant memories.
+   Background, not ledger.
+3. **`list_pending_revisions`** — daemon-flagged memories awaiting review.
+
+Status file wins on "what's next" because memories rank by topic similarity
+and surface stale items alongside fresh ones; the status file is the live
+ledger maintained per session.
+
+## 1. Read project status file first
+
+Detect project root:
+
+```
+Bash: cd_repo=$(git -C "$PWD" rev-parse --show-toplevel 2>/dev/null); echo "${cd_repo:-no-git}"
+```
+
+- If output is a path → `<project>` = basename (e.g. `origin`).
+- If `no-git` → `<project>` = cwd basename.
+
+Read `~/.origin/sessions/_status/<project>.md`:
+
+```
+Bash: cat ~/.origin/sessions/_status/<project>.md
+```
+
+If the file exists, render its `## Last session`, `## Active`, and `## Backlog`
+sections verbatim at the top of the brief output, under a heading like
+`Status (last session <date>)`. This is the authoritative "what's left" frame.
+
+If the file is missing, say nothing about it. First-time projects haven't
+been handed off yet.
+
+## 2. Call context
+
+Call the `origin` MCP server's `context` tool. If the user passed a topic
+argument, pass it through. Otherwise infer scope from the working directory and
+the conversation so far — don't ask the user.
+
+```
+context(topic="<args or inferred>", space=<inferred from cwd or recent turns>)
+```
+
+**Scope inference rules:**
+
+- `topic`: if user omitted args, pass the most recent topic from the
+  conversation (file or feature being discussed), or omit for a fresh
+  general brief at session start.
+- `space`: from cwd. `~/Repos/origin/...` → `"origin"`. Other repos → repo
+  name. Outside any repo → omit. Always pass when scope is known; if
+  uncertain, run `list_spaces` later (post-PR-C) or omit.
+
+## When to use
+
+- Session start — call BEFORE any other Origin tool.
+- Major topic shift mid-session.
+- User says "catch me up", "what's the background on X", "remind me about Y".
+- Mid-session check-in to confirm assumptions.
+
+## When NOT to use
+
+- Specific factual lookup → use `/recall` (more targeted).
+- Storing a new memory → use `/capture`.
+- End of session → use `/handoff`.
+
+## How to use the result
+
+Treat the status file as the live ledger (what's next), and the `context`
+memories as background (how the user thinks). When the status file says an
+item is done but a memory still says it's pending, trust the status file —
+memories don't auto-supersede. If you see drift, flag it inline rather than
+parrot the stale memory.
+
+Model how the user thinks. Their preferences, corrections, and past decisions
+tell you how they want to be helped, not just what they already know. Don't
+just look things up: adjust your behavior.
+
+## 3. Pending revisions check
+
+After loading context, call:
+
+```
+list_pending_revisions(limit=10)
+```
+
+If the result is empty, **say nothing**. Do not print "0 pending revisions" or any "all clear" line. The brief is already noisy enough.
+
+If the MCP call errors, log a one-line warning and continue. Do not error out the brief.
+
+If the result is non-empty, render a block at the end of the brief (after the context summary, before handing back to the user). The daemon returns rows already sorted by `last_modified DESC`; just slice the first three.
+
+Each `PendingRevisionItem` carries `target_source_id`, `revision_source_id`, `revision_content`, `source_agent`, and `last_modified`. The original memory's content is **not** on this response. The block displays the proposed revision text and the target memory id; if the user wants to see the original before deciding, they can run `/recall <target_source_id>` first.
+
+```
+Pending revisions (<N> total, top 3 shown):
+
+1. target: mem_abc123  (proposed by <source_agent or "daemon">)
+   revision: "Origin uses Turso libSQL fork (libSQL-server) for vectors..."
+   Action: accept (replace original) | dismiss (drop revision) | skip
+
+2. ...
+```
+
+Inline accept/dismiss verbs map to:
+
+- accept: `accept_revision(target_source_id="<id>")`
+- dismiss: `dismiss_revision(target_source_id="<id>")`
+- skip: no call; the revision stays pending for the next /brief
+
+If `<N> > 3`, end the block with one line:
+
+```
+Run `/review revisions` to walk the rest.
+```
+
+Do not auto-action anything. The user picks per item.
+
+Note: this block surfaces *all* pending revisions, not just this session's, because revisions are about memories you may still be using right now, regardless of when the contradiction was flagged.

--- a/plugins/origin/skills/capture/SKILL.md
+++ b/plugins/origin/skills/capture/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: capture
+description: >
+  Save a memory to Origin in flow. Active capture verb — use proactively
+  when the user states a preference, makes a decision, corrects you, or
+  shares a durable fact. Invoked as `/capture <content>`.
+argument-hint: "<content>"
+allowed-tools: ["mcp__plugin_origin_origin__capture", "mcp__plugin_origin_origin__recall", "mcp__plugin_origin_origin__create_entity", "mcp__plugin_origin_origin__create_relation", "mcp__plugin_origin_origin__accept_revision", "mcp__plugin_origin_origin__dismiss_revision", "Bash"]
+---
+
+# /capture
+
+Capture a single memory in the moment. Active verb: agent captures the
+moment of insight, like a photograph.
+
+## How to invoke
+
+Call the `origin` MCP server's `capture` tool with the user's content as a
+complete, self-contained statement. Attach `topic` from cwd or the
+conversation — don't make the user type it.
+
+```
+capture(content="<args, written as a full sentence with WHY>",
+        memory_type="<picked from the 6 types>",
+        entity="<primary entity name, if any>",
+        space=<inferred>)
+```
+
+### `memory_type` — agent picks one of 6
+
+The daemon classifies when a local model or API key is configured. In
+local memory mode it does not, so the agent picks the type from the content itself. Use this
+mapping:
+
+| Type | Use for |
+|---|---|
+| `identity` | Durable facts about the user (role, company, language preference) |
+| `preference` | "I prefer X because Y" — a habit, a correction, a stylistic choice |
+| `decision` | "Going with A over B because C" — a specific choice with rationale |
+| `lesson` | Root cause found, workaround discovered, technical insight earned |
+| `gotcha` | Sharp edge, surprising behavior, a thing to watch out for |
+| `fact` | Durable info about people, projects, tools — anchor to `entity` when possible |
+
+If two types fit, pick the one closest to *why the memory matters*. A
+decision *also* implies a preference, but `decision` is more specific.
+
+### `entity` — extract the anchor
+
+Pick the single most important named thing in the content: a person,
+project, tool, place. Use the exact name. Example: "Alice prefers TDD
+because…" → `entity="Alice"`. If the content has no named anchor,
+omit `entity`.
+
+### `topic` / `space` inference
+
+- cwd inside a repo → repo name (e.g. `~/Repos/origin/...` → `"origin"`).
+- Outside any repo → most recent topic from the conversation, or omit.
+- Always pass `space` when scope is known; if uncertain, run `list_spaces`
+  later (post-PR-C) or omit.
+
+### Multiple entities or relations
+
+The MCP `capture` tool takes a single primary `entity`. For additional
+entities or relations, use the dedicated MCP tools. If the content
+names more than one entity, capture the memory first, then for each
+additional entity:
+
+```
+create_entity(name="<entity>", entity_type="<person|project|tool|place>")
+```
+
+For a relation between two entities:
+
+```
+create_relation(from_entity="<a>", to_entity="<b>", relation_type="<verb>")
+```
+
+Skip these calls when the daemon has an LLM — its post-ingest enrichment
+covers extraction.
+
+## What to capture
+
+- Decisions: "Going with approach A because B"
+- Preferences: "Prefers TDD because catches regressions early"
+- Corrections: "Actually it's C, not D"
+- Identity / project facts: "Works on Origin, a local memory daemon for AI tools"
+
+## What NOT to capture
+
+- System prompts, boot logs, heartbeats
+- Transient task state ("currently working on...")
+- Tool output, command results, architecture dumps
+- Single-word acknowledgments
+- Things the user can trivially re-derive (file paths, recent git history)
+
+## Atomic ideas
+
+One capture = one idea. "Prefers TDD" and "Uses pytest" are two captures, not
+one.
+
+## When to use
+
+- User explicitly says "remember this", "save that", "capture this".
+- User states a durable preference / decision / correction proactively (no
+  ask required — that's the floor, not the trigger).
+
+## When NOT to use
+
+- End of session bulk store → use `/handoff` (multi-item batch).
+- Pulling memories back out → use `/recall`.
+
+## Post-capture contradiction signal
+
+After `capture` returns, check `response.triggered_revisions` and `response.auto_superseded`.
+
+### auto_superseded (no action needed)
+
+If `auto_superseded` is non-empty, the daemon already resolved the contradiction. Surface it as informational:
+
+```
+Note: auto-superseded mem_X. Origin replaced a prior protected memory because
+trust=high and similarity > 0.9. No action needed.
+```
+
+No accept/dismiss call required. The revision was applied automatically.
+
+### triggered_revisions (human review needed)
+
+If `triggered_revisions` is non-empty (and `auto_superseded` is empty), render an inline block to the user:
+
+```
+Stored mem_new.
+
+This capture topic-matches a protected memory now flagged for revision:
+  - mem_target_abc
+
+Action: accept (replace original content) | dismiss (drop the revision) | leave (decide later)
+```
+
+Inline verb map:
+
+- accept: `accept_revision(target_source_id="mem_target_abc")`
+- dismiss: `dismiss_revision(target_source_id="mem_target_abc")`
+- leave: no call; surfaces again in next `/brief`
+
+Both fields can technically be non-empty in a single response (multiple protected matches), but in practice only one fires per capture: `auto_superseded` fires when trust=full and similarity > 0.9, `triggered_revisions` fires otherwise.
+
+If neither field is non-empty, the capture stored cleanly with no conflicts.

--- a/plugins/origin/skills/debrief/SKILL.md
+++ b/plugins/origin/skills/debrief/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: debrief
+description: >
+  Alias for `/origin:handoff` — symmetric brief/debrief naming. Same
+  behavior: end-of-session ritual that writes session log + project
+  status + granular MCP captures. Invoked as `/debrief`. Use when the
+  user prefers the brief/debrief pair over brief/handoff.
+allowed-tools: ["Bash", "mcp__plugin_origin_origin__capture"]
+---
+
+# /debrief
+
+Alias for `/handoff`. Identical behavior — full end-of-session ritual:
+git context grab (if repo), narrative session log at
+`~/.origin/sessions/`, project status update, granular MCP captures.
+
+Run the steps in `/origin:handoff` exactly. Same artifacts, same
+guardrails. The only reason this skill exists is the symmetric naming —
+`/brief` (session start) ↔ `/debrief` (session end). Pick whichever
+verb feels natural; both invoke the same flow.
+
+## When to use
+
+- User says "wrapping up", "let's call it", "we're done", "debrief".
+- Session about to close and useful state would otherwise be lost.
+
+## When NOT to use
+
+- Mid-flow capture during work → use `/capture` (single memory).
+- Search / lookup → use `/recall`.

--- a/plugins/origin/skills/distill/SKILL.md
+++ b/plugins/origin/skills/distill/SKILL.md
@@ -1,0 +1,364 @@
+---
+name: distill
+description: >
+  Synthesize wiki pages from related memories. One endpoint, one flow:
+  daemon clusters and synthesizes what it can; agent finishes whatever
+  the daemon couldn't (no LLM or cluster too big). Invoked as
+  `/distill [target]`.
+argument-hint: "[target | rebuild <page-id> | deep]"
+allowed-tools: ["mcp__plugin_origin_origin__recall", "mcp__plugin_origin_origin__distill", "mcp__plugin_origin_origin__create_page", "mcp__plugin_origin_origin__update_page", "mcp__plugin_origin_origin__delete_page", "mcp__plugin_origin_origin__get_page_sources", "Bash"]
+---
+
+# /distill
+
+Force a distillation pass now. The daemon's background distill cycles run
+on its own clock; `/distill` is the explicit user-triggered pass.
+
+## Mental model
+
+Distillation is four operations bundled into one flow:
+
+- **emerge** — cluster new memories into new pages
+- **absorb** — assign orphan memories to existing pages, propose new pages
+  from topics that 2+ existing pages link to but no page is named for
+- **refresh** — regenerate stale pages from their source memories (only when
+  the user has not edited the page; pages you have touched stay locked)
+- **merge** — combine duplicate pages flagged by the daemon's global review
+
+The default flow runs all four. The `rebuild` verb is a destructive opt-in
+that overrides the lock on a single page.
+
+## Single flow
+
+One POST to the daemon. Response splits into:
+
+- `pages_created` / `created_ids`: pages the daemon synthesized itself
+  (only when daemon has an LLM).
+- `pending`: clusters the daemon couldn't finish. The agent
+  synthesizes each in this session and POSTs them back to `/api/pages`.
+
+Trigger timing is the only thing that differs between background distill
+cycles and this skill. Code path is the same; daemon hands back
+clusters when it can't synthesize; whoever called fills in the rest.
+
+## Flow
+
+### 1. Pick the scope
+
+For bare `/distill`, infer a target from cwd:
+
+```
+Bash: top=$(git -C "$PWD" rev-parse --show-toplevel 2>/dev/null); \
+      common=$(git -C "$PWD" rev-parse --git-common-dir 2>/dev/null); \
+      if [ -n "$common" ]; then \
+        case "$common" in /*) root=$(dirname "$common");; *) root=$(cd "$top" && cd "$(dirname "$common")" && pwd);; esac; \
+        basename "$root"; \
+      fi
+```
+
+- Output → use it (e.g. `origin`).
+- Not a git repo → fall back to `basename "$PWD"`.
+- Reserved keyword `deep` → no scope (global pass).
+- Reserved keyword sequence `rebuild <page-id>` → call
+  `distill(target=<page-id>, force=true)`. Confirms "Rebuild page <id>?
+  Your edits will be wiped, page regenerates from sources." before
+  proceeding. Skip the rest of this skill — single-page rebuild does
+  not produce `pending` clusters; the daemon's response shape is
+  `{"status": "ok", "force": true, "page_id": ..., "updated": true}`.
+  Report verbatim.
+
+For `/distill <arg>` → forward `<arg>` to `target`.
+
+### 2. Call the MCP tool
+
+```
+distill(target="<scope>")
+```
+
+The tool returns the daemon's full JSON payload as text. Parse it as
+JSON. Possible shapes:
+
+```
+{
+  "pages_created": 0,
+  "scoped": true,
+  "created_ids": [],
+  "pending": [
+    { "source_ids": [...], "contents": [...], "entity_id": ...,
+      "entity_name": ..., "space": ..., "estimated_tokens": ... },
+    ...
+  ],
+  "stale_pages": [
+    { "page_id": ..., "title": ..., "summary": ...,
+      "source_memory_ids": [...], "stale_reason": "source_updated",
+      "user_edited": false, "sources_updated_count": 3 },
+    ...
+  ],
+  "stale_truncated": false,
+  "orphan_topics": [
+    { "label": "Topic Z", "count": 3 },
+    ...
+  ]
+}
+```
+
+The route never invokes the daemon LLM. `created_ids` is always empty
+when called from this skill; `pending` carries every cluster the
+daemon found. The agent synthesizes them in this session — that's why
+the LLM choice is consistent with how the user invoked the skill.
+
+`unresolved` + `hint`: relay to user verbatim and stop.
+
+### 3. Synthesize each `pending` cluster
+
+The daemon route filters out clusters fully covered by an existing
+page (subset or Jaccard ≥ 0.8). What remains is either:
+
+- A **brand-new cluster** (no existing page) → create a new page.
+- A **refresh candidate** (`existing_page_id` is set) → the cluster
+  has new memories beyond what's in the matched page. The agent has
+  LLM access, so the right move is to refresh the existing page in
+  the same pass.
+
+Cluster shape:
+
+```
+pending: [
+  {
+    source_ids, contents, entity_id, entity_name, space,
+    estimated_tokens,
+    existing_page_id?, existing_page_title?, new_memory_count?
+  },
+  ...
+]
+```
+
+For each cluster, first run a **coherence check** before synthesizing:
+
+- Skim every memory in `cluster.contents`.
+- If the cluster has ≥ ~4 memories and the topics scatter (entity
+  shared but the memories cover unrelated sub-topics — e.g. all tagged
+  `Origin` but spanning RwLock bugs, schema choices, onboarding UI,
+  migrations, and CSS), the cluster is **incoherent**. Skip
+  synthesizing it. Record it for the report under "Skipped (low
+  coherence)" with the existing page title (if refresh) or a short
+  topic hint (if new).
+- Coherent cluster (memories share an actual topic, not just an entity
+  tag) → proceed to synthesis.
+
+The coherence judgement is something only the agent can do — it needs
+to read the prose. Daemon clustering is heuristic; agent is the
+final filter against producing a grab-bag page.
+
+For each coherent cluster:
+
+- Title: short noun phrase. Use `existing_page_title` when refreshing
+  unless the new memories materially change the topic. For new
+  clusters: `cluster.entity_name` if specific, otherwise derive from
+  the first memory's content.
+- Summary: one sentence — the durable claim.
+- Body: 3-7 paragraphs of wiki prose. Use `[[wikilinks]]`. Cite source
+  ids inline with `(source: mem_XXX)`.
+
+**New cluster** (no `existing_page_id`) — call the MCP tool:
+
+```
+create_page(title="...", summary="...", content="...",
+            entity_id="<cluster.entity_id or omit>",
+            space="<cluster.space>",
+            source_memory_ids=[...])
+```
+
+**Refresh candidate** (`existing_page_id` is set) — replace the body
+in place via the `update_page` MCP tool. This is a single atomic
+call: replaces content + source list + optional summary, clears the
+daemon's `stale_reason`, bumps version, preserves page_id +
+created_at so external `[[wikilinks]]` keep working.
+
+```
+update_page(page_id=cluster.existing_page_id,
+            content="...",
+            source_memory_ids=cluster.source_ids,
+            summary="...")
+```
+
+### 3.5 Refresh stale pages
+
+The `stale_pages` block in the response lists pages whose sources
+changed since last compile. Shape:
+
+```
+stale_pages: [
+  { page_id, title, summary, source_memory_ids,
+    sources_updated_count, stale_reason, user_edited },
+  ...
+]
+stale_truncated: <bool>   # true when 10+ stale pages exist
+```
+
+For each stale page:
+
+- **`user_edited == true`** → never auto-rewrite. The user touched
+  the page; the upstream memories also changed. Surface in the
+  "Conflict" report block and stop. The user resolves by hand, OR
+  runs `/distill rebuild <page-id>` to wipe their edits and
+  regenerate from sources.
+- **`user_edited == false`** → fetch source memories via
+  `get_page_sources(page_id="<id>")`, run the same coherence check
+  used for clusters, then call `update_page` with the existing
+  `source_memory_ids` and freshly synthesized prose.
+
+```
+update_page(page_id=stale.page_id,
+            content="<refreshed prose>",
+            source_memory_ids=stale.source_memory_ids,
+            summary="<optional refreshed claim>")
+```
+
+When `stale_truncated == true`, tell the user "more stale pages
+remain — re-run `/distill` after this pass to continue."
+
+### 3.6 Surface orphan-topic suggestions
+
+`orphan_topics` lists wikilink labels that 2+ existing pages reach
+for but no page is named for. Each entry is a topic-discovery
+signal — other pages are asking for this page.
+
+Do **not** auto-create pages from this list — the agent doesn't have
+the source memories at hand, and an empty-stub page is worse than no
+page. Surface them in the report so the user can choose to run
+`/distill <label>` intentionally:
+
+```
+Topic suggestions (other pages link here, no page yet):
+  - "Topic Z"  (3 pages reference it)
+  - "Other"    (2 pages reference it)
+```
+
+Skip the section when `orphan_topics` is empty.
+
+### 4. Report terse
+
+Three output shapes. Pick the one that matches what happened.
+
+**If `pending` is empty (every cluster already fully covered):**
+
+```
+Scope `<scope>` is up to date — no new memories to distill.
+```
+
+**If at least one cluster was synthesized:**
+
+```
+Distilled N page(s) from <total> memories in scope `<scope>`:
+  - <Title>  v1, synthesized from <K> sources
+  - <Title>  v3 → v4: +mem_xyz, +250 chars
+  ...
+```
+
+For each page, `create_page` and `update_page` return a `WriteResult`
+whose `warnings` array carries a pre-formatted delta line from the
+daemon (e.g. `"v3 → v4: +mem_xyz, +250 chars"`). Render it verbatim
+after the title. When `warnings` is empty or the call returned no
+`WriteResult`, fall back to:
+
+- New page: `v1, synthesized from <K> sources` (K = source_ids length)
+- Refreshed page: `refreshed` (bare, as before)
+
+This lets the user see exactly what changed per page without opening
+each file.
+
+**If at least one cluster was skipped on the coherence check:**
+
+```
+Skipped M cluster(s) — low coherence (memories share entity but
+topics scatter; would produce a grab-bag page):
+  - "<existing_page_title or topic hint>"  (<N> memories)
+  ...
+```
+
+**If at least one stale page was refreshed:**
+
+```
+Refreshed K stale page(s):
+  - <Title>  v2 → v3: +mem_abc, +180 chars
+  - <Title>  refreshed
+  ...
+```
+
+Same delta-line rule as new/refresh clusters: render `warnings[0]`
+from the `update_page` WriteResult verbatim; fall back to `refreshed`
+when absent.
+
+**If at least one stale page was skipped because `user_edited`:**
+
+```
+Conflict on L stale page(s) — page has user edits, sources also
+changed. Open and reconcile manually:
+  - <Title>  (~/.origin/pages/<slug>.md)
+```
+
+Distinct wording from the coherence-skip block so the user can tell
+the two reasons apart at a glance.
+
+Emit the blocks back-to-back when more than one outcome happened in
+the same pass.
+
+When the only outcome is skipped clusters (and `pending` was
+non-empty), still emit the Skipped block. Do **not** report "up to
+date" in that case — the scope isn't up to date, the candidates were
+just too low quality.
+
+Rules:
+- **Titles, not page ids.** Ids visually truncate; titles read clean.
+- One line per synthesized page. No body in chat — `/read "<title>"`
+  for that.
+- `<total>` = sum of `source_ids.len()` across the clusters that were
+  actually synthesized.
+- If the pass produced fewer pages than expected, it's the clustering
+  thresholds. Most memories sit alone without enough peers to form a
+  cluster of 3+. Capture more on the same topic to grow them.
+
+## Auto-commit ~/.origin/
+
+After writing the pages above, snapshot the change so the user can `git
+log` their memory's life timeline. Defensive — silent skip if `git` is
+missing or `~/.origin/` is not a repo yet.
+
+```
+Bash: git -C ~/.origin add -A && \
+      git -C ~/.origin -c user.name=Origin -c user.email=daemon@origin.local \
+          commit --quiet -m "distill: <N> pages" 2>/dev/null || \
+      (sleep 1 && git -C ~/.origin add -A && \
+       git -C ~/.origin -c user.name=Origin -c user.email=daemon@origin.local \
+           commit --quiet -m "distill: <N> pages" 2>/dev/null) || true
+```
+
+The retry handles index.lock races — the daemon may be writing to
+`~/.origin/` at the same moment (auto-commit from captures). One-second
+wait is enough for the daemon to release the lock.
+
+## When to use
+
+- User says "distill", "synthesize", "rebuild the page on X".
+- After a bulk import — daemon distill cycles handle this in the background;
+  user can force a pass for immediate visibility.
+- `/distill rebuild <page-id>` when you want to wipe a page you
+  previously edited and have the daemon regenerate from current
+  sources. Destructive: your prose goes away. Use after you are
+  done curating a page and want it back on the auto-refresh path.
+
+## When NOT to use
+
+- Trivial / one-off interactions. The background scheduler covers
+  periodic refresh.
+- Single memory write → daemon's post-ingest enrichment already
+  covers it.
+
+## Cost
+
+Each cluster the agent synthesizes counts against this session's
+tokens. Daemon-side clusters (when an LLM is present) cost daemon LLM
+tokens instead (cents on API, seconds on-device). Either way, keep
+cluster sizes reasonable — the daemon already enforces a per-cluster
+token budget via its tuning config.

--- a/plugins/origin/skills/forget/SKILL.md
+++ b/plugins/origin/skills/forget/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: forget
+description: >
+  Delete a memory from Origin by ID. Destructive and cannot be undone —
+  prefer `/capture` with `supersedes` for corrections. Invoked as
+  `/forget <source_id>`.
+argument-hint: "<source_id>"
+allowed-tools: ["Bash", "mcp__plugin_origin_origin__forget", "mcp__plugin_origin_origin__recall"]
+---
+
+# /forget
+
+Permanently delete a memory by its `source_id`.
+
+## How to invoke
+
+You need the `source_id`. If the user did not provide it, call
+`/recall` first to find the matching memory and confirm with the
+user before deleting.
+
+```
+forget(memory_id="<source_id>")
+```
+
+## When to use
+
+- User says "forget this", "delete that", "that's wrong, remove it".
+- User explicitly identifies a memory by ID.
+
+## When NOT to use
+
+- For corrections, prefer storing a new memory with `supersedes` pointing
+  at the old one. That preserves history. Use `/capture` with the
+  `supersedes` arg instead.
+- Bulk deletions — call `/review` first, confirm with the user,
+  then delete one at a time.
+
+## Safety
+
+Deletion is destructive. Always confirm with the user before calling forget,
+unless the user has already given an explicit, unambiguous instruction in
+the same turn (e.g. they pasted the ID and said "delete this").
+
+## Auto-commit ~/.origin/
+
+If the deletion removed a page md (daemon archives the page and
+KnowledgeWriter unlinks the file), snapshot the change. Defensive —
+silent skip if `git` missing, `~/.origin/` not a repo, or no diff.
+
+```
+Bash: git -C ~/.origin add -A && \
+      git -C ~/.origin -c user.name=Origin -c user.email=daemon@origin.local \
+          commit --quiet -m "forget: <source_id>" 2>/dev/null || \
+      (sleep 1 && git -C ~/.origin add -A && \
+       git -C ~/.origin -c user.name=Origin -c user.email=daemon@origin.local \
+           commit --quiet -m "forget: <source_id>" 2>/dev/null) || true
+```
+
+The retry handles index.lock races — the daemon may be writing to
+`~/.origin/` at the same moment (auto-commit from captures). One-second
+wait is enough for the daemon to release the lock.

--- a/plugins/origin/skills/handoff/SKILL.md
+++ b/plugins/origin/skills/handoff/SKILL.md
@@ -1,0 +1,276 @@
+---
+name: handoff
+description: >
+  End-of-session ritual. Captures decisions, lessons, gotchas, and open
+  threads. Writes a narrative session log to ~/.origin/sessions/ and stores
+  granular memories via Origin MCP. Previews any unconfirmed captures from
+  the current session before closing. Invoked as `/handoff`.
+allowed-tools: ["Bash", "mcp__plugin_origin_origin__capture", "mcp__plugin_origin_origin__list_pending"]
+---
+
+# /handoff
+
+End-of-session debrief. Three artifacts each pass:
+
+1. **Granular MCP captures** — one per decision/lesson/gotcha (DB authoritative).
+2. **Session log md** — narrative thread at `~/.origin/sessions/<YYYY-MM-DD-HHmm>-<slug>.md`.
+3. **Project status md + json** — current goals + last-handoff timestamp at `~/.origin/sessions/_status/`.
+
+These are orthogonal: captures are queryable atoms, session log is the
+narrative thread, status file lets the next session see where we left off.
+
+## Steps
+
+### 1. Detect project + last handoff time
+
+```
+Bash: cd_repo=$(git -C "$PWD" rev-parse --show-toplevel 2>/dev/null); echo "${cd_repo:-no-git}"
+```
+
+- If output is a path → use the basename as `<project>` (e.g. `origin`).
+- If `no-git` → use the cwd basename. Skip git steps below; rely entirely
+  on conversation context.
+
+Read `~/.origin/sessions/_status/handoff-<project>.json` for `lastHandoff`
+timestamp (ISO-8601). If file missing, default to "12 hours ago".
+
+### 1.5 Pending-captures preview
+
+After establishing `<lastHandoff>`, call:
+
+```
+list_pending(limit=50)
+```
+
+The MCP returns memory rows with `source_id`, `content`, `created_at`, and
+other metadata. Convert `lastHandoff` (ISO-8601 string, e.g.
+`2026-05-13T22:50:00Z`) to a Unix epoch seconds integer before filtering:
+
+```
+Bash: date -j -f %Y-%m-%dT%H:%M:%SZ "$lastHandoff" +%s
+```
+
+Or in your scripting language of choice (Python's `datetime.fromisoformat`,
+JavaScript's `Date.parse`, etc.). Save the result as `lastHandoffEpoch`.
+
+Then filter the response rows: keep where `row.created_at >= lastHandoffEpoch`.
+These are captures this session produced that the quality gate left unconfirmed
+(untrusted-source captures).
+
+If the filtered list is empty, say nothing. Proceed to Step 2.
+
+If non-empty, render a preview block once, before the existing capture flow:
+
+```
+Pending captures this session (<N> total, top 3 shown):
+
+1. mem_xyz789  "..."  (untrusted source: <agent>)
+2. ...
+
+Default: proceed (captures stay pending). Opt in by running
+`/review captures` before re-invoking /handoff if you want to walk them.
+```
+
+Do NOT prompt for per-item action inline. The user proceeds with /handoff
+regardless; the preview is informational only.
+
+### 2. Gather session context (parallel, only if git repo)
+
+```
+Bash: git -C <repo> log --oneline --since=<lastHandoff>
+Bash: git -C <repo> status --short
+Bash: git -C <repo> diff --stat HEAD~5..HEAD 2>/dev/null
+Bash: git -C <repo> worktree list
+```
+
+Capture output. Use it alongside conversation history to infer what
+happened. If not a git repo, skip — conversation context is the source.
+
+### 3. Infer, do not ask
+
+Synthesize silently from git output + conversation. Categorize each item
+into user-facing groups. Each maps to a daemon `memory_type` for the
+capture call:
+
+| Display label | daemon memory_type | What belongs here |
+|---|---|---|
+| Decisions | `decision` | architectural choice, tool/pattern selection (with WHY) |
+| Lessons | `lesson` | root cause discovered, workaround found, technical insight |
+| Insights | `gotcha` | unexpected behavior, debugging discovery, sharp edge |
+| Corrections | `preference` | user pushed back, corrected approach or assumption |
+| Facts | `fact` | durable project/people/tool fact worth persisting |
+
+Non-memory items (not stored, session-log only):
+- **Open threads** — started but not finished, blockers.
+
+Skip purely mechanical facts already in git (file paths, function names,
+config values). The commit log preserves those.
+
+### 4. MCP captures (one per item)
+
+For each non-trivial item, call with the mapped `memory_type`:
+
+```
+capture(content="<one self-contained sentence with WHY>", memory_type="<decision|lesson|gotcha|preference|fact>")
+```
+
+Atomic: one decision per call. Don't merge multiple items into one
+memory. The daemon dedups against existing knowledge, so re-storing
+known facts is a no-op.
+
+Only surface items to the user BEFORE storing if they meet one of these
+bars:
+
+- Contradicts an existing memory (recall returned a conflicting fact).
+- Marks a critical incident, irreversible action, or production change.
+- You are uncertain whether the item is durable vs transient.
+
+Otherwise just store and report counts at the end.
+
+### 5. Write session log
+
+Bash heredoc to `~/.origin/sessions/<YYYY-MM-DD-HHmm>-<slug>.md`:
+
+```markdown
+# Session <YYYY-MM-DD HH:MM> — <slug>
+
+**Project:** <project>
+**Range:** <lastHandoff> → <now>
+
+## Accomplished
+- <item>
+
+## Decisions
+- <decision and rationale>
+
+## Lessons & Gotchas
+- <root cause / workaround>
+
+## Open Threads
+- <what's unfinished>
+
+## Captures stored
+- <source_id_or_brief_summary>
+
+## Git summary
+<git log --oneline output>
+```
+
+`<slug>` = kebab-case 2-4 word summary (`session-handoff-md-writer`).
+
+### 6. Update project status
+
+Overwrite `~/.origin/sessions/_status/<project>.md`:
+
+```markdown
+# <Project> — Current Status
+
+## Last session (<date>)
+- <accomplished bullet>
+
+## Active
+<!-- Items touched/spawned in the last 1-2 sessions. Real next-move candidates. -->
+- <item> (added <YYYY-MM-DD>)
+- <blocked item> (added <YYYY-MM-DD>) (gated: <trigger>)
+
+## Backlog
+<!-- Older accretion. Not gated, not picked. Promote back to Active when re-engaged. -->
+- <item> (added <YYYY-MM-DD>)
+```
+
+Single file per project. New session overwrites — this is the *current*
+state, not a log.
+
+**Two sections, not one flat list:** `## Active` and `## Backlog` separate
+the two types of tasks that get mixed otherwise. Active = fresh signal
+worth picking next. Backlog = older parked items, kept for reference but
+not in the "what next?" frame.
+
+**Date stamp every bullet** with `(added <YYYY-MM-DD>)`. Use today's date
+when adding a new item; preserve the original date when carrying an item
+forward. Dates make age visible at a glance and avoid relative-time drift.
+
+**Gated items stay inline-tagged** with `(gated: <trigger>)` — no separate
+section. The tag tells the reader why it can't move yet; the bullet stays
+in whichever section reflects its recency.
+
+**Promotion / demotion rules:**
+- New item this session → `## Active` with today's date
+- Item in `## Active` that wasn't touched this session AND wasn't touched
+  the prior session → demote to `## Backlog` (keep original date)
+- Item in `## Backlog` that work resumed on → promote back to `## Active`
+  (keep original date — staleness is a property of the work, not the
+  bullet text)
+
+### 7. Write timestamp
+
+Overwrite `~/.origin/sessions/_status/handoff-<project>.json`:
+
+```json
+{
+  "lastHandoff": "<ISO-8601 now>",
+  "project": "<project>",
+  "summary": "<one-line>"
+}
+```
+
+Per-project file prevents parallel sessions from clobbering each other.
+
+### 8. Auto-commit ~/.origin/
+
+After writing the files above, snapshot the change so the user can `git
+log` their memory's life timeline. Defensive — silent skip if `git` is
+missing or `~/.origin/` is not a repo yet.
+
+```
+Bash: git -C ~/.origin add -A && \
+      git -C ~/.origin -c user.name=Origin -c user.email=daemon@origin.local \
+          commit --quiet -m "session: <slug>" 2>/dev/null || \
+      (sleep 1 && git -C ~/.origin add -A && \
+       git -C ~/.origin -c user.name=Origin -c user.email=daemon@origin.local \
+           commit --quiet -m "session: <slug>" 2>/dev/null) || true
+```
+
+The retry handles index.lock races — the daemon may be writing to
+`~/.origin/` at the same moment (auto-commit from captures). One-second
+wait is enough for the daemon to release the lock.
+
+### 9. Confirm
+
+Print one summary block with captures grouped by display label:
+
+```
+Handoff stored.
+  Decisions:   <N> (brief list)
+  Lessons:     <N> (brief list)
+  Insights:    <N> (brief list)
+  Corrections: <N> (brief list)
+  Facts:       <N> (brief list)
+  Session:     ~/.origin/sessions/<filename>
+  Status:      ~/.origin/sessions/_status/<project>.md
+  Git:         <commit hash> session: <slug>
+```
+
+Show each label only if non-empty. List items as short phrases, not
+full sentences — the session log has the details.
+
+## When to use
+
+- "Wrapping up", "let's call it", "we're done".
+- Session about to close and useful state would otherwise be lost.
+
+## When NOT to use
+
+- Mid-flow capture during work → use `/capture` (single memory).
+- Search / lookup → use `/recall`.
+- One-off chat with no decisions or lessons — captures alone are enough.
+
+## Notes on the three artifact classes
+
+- **Memories** (MCP captures) live in the daemon DB only. Confirmation flips
+  a `stability` flag — they never get exported to md.
+- **Pages** are wiki-style syntheses written to `~/.origin/pages/` by the
+  daemon when `/distill` runs. Citations link back to source memory ids.
+- **Sessions** (this skill) live only at `~/.origin/sessions/`. They are
+  the narrative axis: chronological, not topical. Browse them as a
+  changelog of your work.

--- a/plugins/origin/skills/help/SKILL.md
+++ b/plugins/origin/skills/help/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: help
+description: >
+  One-screen quick reference for the Origin plugin. Lists the daily
+  verbs, the daily flow, where data lives, and how to view it without a
+  GUI. Use when the user says "help", "what can I do", "list origin
+  commands", "how do I use origin", or invokes `/help`.
+allowed-tools: []
+---
+
+# /help
+
+Print the Origin plugin reference card. Read-only — never calls a tool.
+
+## How to invoke
+
+When triggered, output the block below verbatim. No editing, no
+abbreviating, no embellishing. The user is asking for the menu.
+
+```
+Origin plugin — daily verbs
+
+  /init         set up Origin (auto-installs daemon + local memory)
+  /brief        load identity + topic context (start of session)
+  /capture <x>  save one durable memory in flow
+  /recall <q>   search local memory
+  /distill [t]  synthesize pages from clusters (scoped to current repo)
+  /read <p>     preview a distilled page inline
+  /review <surface>   deep audit (surface = captures|revisions); /brief handles daily
+  /forget <id>  delete a memory by ID
+  /handoff      end-of-session ritual (session log + captures)
+  /debrief      alias for /handoff (brief/debrief symmetry)
+  /help         this card
+
+Daily flow (~1 min overhead per session):
+
+  1. start session  →  hook auto-checks daemon, silent if up
+  2. /brief         →  ~5 s, load context
+  3. work normally  →  Claude proactively /captures durable facts
+  4. /recall X      →  as needed for lookups
+  5. /handoff       →  ~30 s, narrative session log + captures
+
+Where your data lives (everything under ~/.origin/):
+
+  ~/.origin/pages/      wiki pages distilled from your memories (md)
+  ~/.origin/sessions/   session logs by date (md)
+  ~/.origin/sessions/_status/  current per-project goals + last-handoff
+  ~/.origin/db/         memories + knowledge graph (symlink to libSQL)
+  ~/.origin/bin/        installed binaries
+
+View it without a GUI:
+
+  open ~/.origin/                  browse in Finder
+  code ~/.origin/                  open in VS Code
+  git -C ~/.origin log --oneline   timeline of every memory + distill pass
+  ln -s ~/.origin/pages ~/Vault/origin   # symlink into Obsidian for graph view
+
+~/.origin/ is a git repo. Skills auto-commit per logical batch (one per
+session, distill pass, or forget). Use git log / git diff / git revert
+as a free audit trail. No remote — purely local history.
+
+Three classes of artifact:
+  - memories: granular, queryable, live in DB only (confirmed = stays in DB)
+  - pages:    synthesized wikis, DB + ~/.origin/pages/*.md projection
+  - sessions: chronological narrative, ~/.origin/sessions/*.md only
+
+Daemon must run at 127.0.0.1:7878. Hook prints "/origin:init" if down.
+
+Optional upgrades for richer distill cycles:
+  origin model install            local Qwen, no API cost
+  origin key set anthropic        Anthropic API, higher quality
+```
+
+## When to use
+
+- User explicitly types `/help`.
+- User asks "what can I do with origin", "list origin commands", "how
+  does this plugin work", "remind me what verbs are available".
+- First session after install — print this once on `/init` success too.
+
+## When NOT to use
+
+- Specific factual lookup → use `/recall`.
+- Setup troubleshooting → use `/init` (it diagnoses + auto-installs).

--- a/plugins/origin/skills/init/SKILL.md
+++ b/plugins/origin/skills/init/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: init
+description: >
+  Frictionless setup. Detects missing daemon, installs it, configures local
+  memory, and verifies the full plugin → MCP → daemon round-trip. Run
+  after `/plugin install origin@7xuanlu`, or any time the user says "set up
+  origin", "is origin working", "fix origin".
+allowed-tools: ["Bash", "mcp__plugin_origin_origin__doctor", "mcp__plugin_origin_origin__context"]
+---
+
+# /init
+
+Self-healing setup. Goal: 30 seconds, two user actions max (install plugin,
+type /init). Default backend is local memory — no local model, no API key, no
+prompts. Local model and Anthropic key are opt-in upgrades documented in
+`/help`.
+
+## Steps
+
+Run in order. Stop and report at the first failure that needs human
+attention. Otherwise, push through automatically.
+
+### 1. Daemon health probe
+
+```
+Bash: curl -fsS -m 1 http://127.0.0.1:7878/api/health
+```
+
+- 200 OK → skip to step 4.
+- Anything else → step 2.
+
+### 2. Bootstrap (auto-install if missing)
+
+Detect whether the `origin` CLI is on PATH:
+
+```
+Bash: command -v origin >/dev/null 2>&1 && echo present || echo absent
+```
+
+If `absent`, run the installer (no human prompts):
+
+```
+Bash: curl -fsSL https://raw.githubusercontent.com/7xuanlu/origin/v0.6.1/install.sh | bash
+```
+
+Then add it to PATH for the current session and configure local memory
+non-interactively:
+
+```
+Bash: export PATH="$HOME/.origin/bin:$PATH" && origin setup --basic && origin install
+```
+
+If `present` (CLI exists, daemon down), just install + start:
+
+```
+Bash: origin setup --basic 2>/dev/null || true; origin install
+```
+
+`origin setup --basic` is idempotent — safe to re-run. `origin install`
+writes the launchd plist and starts the daemon.
+
+### 3. Re-probe daemon health
+
+```
+Bash: for i in 1 2 3 4 5; do curl -fsS -m 1 http://127.0.0.1:7878/api/health && break; sleep 1; done
+```
+
+If the daemon still isn't reachable after ~5s, surface the error and stop.
+Likely cause: launchd plist load failure, port 7878 occupied by another
+process, or macOS Tahoe Metal init issue (daemon degrades but still binds —
+check `lsof -ti :7878`).
+
+### 4. Doctor (verify backend)
+
+Call the `origin` MCP server's `doctor` tool:
+
+```
+doctor()
+```
+
+Expected: local memory configured (no model, no key). Capture the mode
+string for the final report.
+
+### 5. MCP round-trip
+
+```
+context()
+```
+
+Pass → continue. Fail → MCP not wired. Tell user:
+"origin-mcp didn't respond. Restart Claude Code so the plugin's
+`.mcp.json` re-spawns the server."
+
+### 6. Ready report
+
+Print:
+
+```
+Origin ready.
+  Daemon:   up on 127.0.0.1:7878
+  Mode:     <mode from doctor()>
+  MCP:      connected
+  Data:     ~/.origin/  (pages, sessions, db symlink)
+  Try:      /brief, /capture <thing>, /recall <query>, /help
+```
+
+If this was the first /init invocation in the session, dispatch `/help`
+once so the user sees the verb cheat-sheet without asking.
+
+## Optional upgrades (don't auto-run)
+
+Mention these in the ready report only if the user explicitly asks for
+"richer features" or asks about model-backed extraction:
+
+- `origin model install` — local Qwen for distill cycles.
+- `origin key set anthropic` — Anthropic for stronger synthesis.
+
+Default flow ignores both. Storage, search, recall, and MCP memory all
+work in local memory mode.
+
+## When to use
+
+- Right after `/plugin install origin@7xuanlu`.
+- Hook printed "daemon down — run /origin:init".
+- User says "set up origin", "is it working", "reinstall origin".
+
+## When NOT to use
+
+- Daemon already verified this session → `/brief` instead.
+- Editing one config field → `origin doctor` or settings file directly.

--- a/plugins/origin/skills/read/SKILL.md
+++ b/plugins/origin/skills/read/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: read
+description: >
+  Preview a distilled wiki page from inside Claude Code. Prints title,
+  summary, source count, and the local md path. Full body lives on disk —
+  open with the user's editor. Invoked as `/read <title_or_id>`.
+argument-hint: "<title_or_id>"
+allowed-tools: ["mcp__plugin_origin_origin__get_page", "mcp__plugin_origin_origin__search_pages", "mcp__plugin_origin_origin__get_page_links", "Bash"]
+---
+
+# /read
+
+Surface a page's identity so the user can decide whether to open it.
+`/read` is **preview, not full text**. The body is on disk; preview
+keeps chat scannable, dodges Bash output truncation, and respects the
+"md is canonical, viewer is the user's editor" model.
+
+## How to invoke
+
+Two shapes accepted:
+
+1. **Page id** (starts with `page_`; legacy `concept_` ids still work) → direct fetch.
+2. **Title or freeform word** → search, pick best match, fetch.
+
+Both end with the same preview block.
+
+### 1. Direct id
+
+Call the MCP tool to fetch the page:
+
+```
+get_page(page_id="<id>")
+```
+
+The response is a JSON object wrapping `{ "page": {...} }`. Read
+`title`, `summary`, `space`, and `source_memory_ids` off the page,
+then look up the md filename in `~/.origin/pages/.origin/state.json`:
+
+```
+Bash: python3 -c '
+import json, os, sys
+state_path = os.path.expanduser("~/.origin/pages/.origin/state.json")
+pid = "<id>"
+filename = None
+try:
+    with open(state_path) as f:
+        filename = json.load(f).get("pages", {}).get(pid, {}).get("file")
+except FileNotFoundError:
+    pass
+print(f"~/.origin/pages/{filename}" if filename else "(no md projection on disk)")
+'
+```
+
+Combine the page fields with the resolved md path and emit the preview
+block.
+
+### 2. Title or freeform word
+
+Search first, then fetch the top hit by id and run the same preview
+block. Always resolve through the `search_pages` MCP tool — never
+derive a slug client-side (skill heuristics drift from the canonical
+`slugify()` on apostrophes and punctuation).
+
+```
+search_pages(query="<arg>", limit=1)
+```
+
+Parse the returned JSON — the response shape is `{ "pages": [...] }`.
+Read the first hit's `id`. If `pages` is empty, tell the user "no page
+found matching `<arg>` — try `/distill <arg>` to create one" and stop.
+Otherwise call `get_page(page_id=<id>)` and emit the same preview
+block from section 1.
+
+## Output shape
+
+Always print exactly these lines (no body):
+
+```
+Title:    <title>
+Version:  v<N> — <last_edited_by> <relative_time> (<last_delta_summary>)
+Summary:  <one sentence>
+Sources:  <N> memories
+Space:    <space or (none)>
+Links:    <N inbound, M outbound (<K> broken)>
+Open:     ~/.origin/pages/<slug>.md
+⚠ Stale: <stale_reason> — run /distill to refresh
+```
+
+**Lock banner rule:**
+
+When the page payload returned by `get_page` has `user_edited == true`,
+prepend this line as the very first line of the rendered output, before
+the title:
+
+```
+🔒 You've edited this page. Auto-refresh paused. `/distill rebuild <page-id>` to unlock.
+```
+
+Substitute `<page-id>` with the actual `page.id` value. When
+`user_edited` is false or absent, omit this line entirely.
+
+The lock means daemon distill cycles will not auto-rewrite this page's
+prose from sources — edits stay until the user explicitly runs
+`/distill rebuild` to wipe and regenerate.
+
+**Version line rules:**
+
+- Always show `v<N>`. When `version` is null or missing, omit the line.
+- Append ` — <last_edited_by>` when populated (e.g. `re_distill`, `user`, `agent`).
+- Append relative time when `last_edited_at` is set (e.g. `2h ago`, `3d ago`).
+- Append `(<last_delta_summary>)` when the field is non-empty.
+- Examples:
+  - `v1 — synthesized 4h ago`
+  - `v4 — re_distill 2h ago (+mem_xyz, +250 chars)`
+  - `v3 — user 1d ago`
+
+**Stale warning rule:**
+
+- Emit the `⚠ Stale:` line only when `stale_reason` is non-null/non-empty.
+- Render `stale_reason` verbatim (daemon sets it; values like
+  `source_updated`, `new_memories` are human-readable enough).
+
+**Links line rules** (unchanged): Call `get_page_links(page_id="<id>")` right after
+`get_page` and count:
+
+- inbound = `len(inbound)`
+- outbound = `len(outbound)`
+- broken = outbound entries where `target_page_id` is null
+
+Omit the parenthetical when broken is zero. Drop the line entirely if
+inbound + outbound is zero.
+
+Don't paraphrase the title, don't trim the summary, don't decorate the
+preview. The block is one screen, predictable, easy to skim.
+
+If the user wants the full body, they open the md file in their editor
+(Obsidian, VS Code, glow, bat, …). The plugin doesn't render markdown
+better than their tools do.
+
+## When to use
+
+- User asks "show me the page on X", "what's in <title>", "preview that".
+- After `/distill` finishes, follow up with `/read "<title>"` (titles
+  survive any rendering surface; ids may visually truncate).
+
+## When NOT to use
+
+- Raw memory lookups → use `/recall`.
+- Listing all pages → `list_pages_recent` MCP tool or
+  `ls ~/.origin/pages/`.
+- Reading the full body → open the md file in the user's editor.

--- a/plugins/origin/skills/recall/SKILL.md
+++ b/plugins/origin/skills/recall/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: recall
+description: >
+  Search Origin's local memory by query. Targeted lookup, not orientation.
+  Invoked as `/recall <query>`. Use when the user asks "do you
+  remember", "what do you know about", "look up".
+argument-hint: "<query>"
+allowed-tools: ["mcp__plugin_origin_origin__recall"]
+---
+
+# /recall
+
+Search Origin's memory by natural-language query. Returns matching memories
+ranked by hybrid vector + FTS search, then re-ordered by the agent if it
+helps.
+
+## Two phases
+
+When a local model or API key is configured, the daemon can rerank and
+expand server-side. In local memory mode it cannot. The skill always does
+**agent-side expansion and rerank** itself — cheap, makes results good in
+both modes.
+
+### Phase 1 — expand the query (agent-side)
+
+Before calling `recall`, rewrite the user's query into a more
+search-friendly form:
+
+- Replace pronouns with the referent ("it" → the actual thing).
+- Expand abbreviations the embedder is unlikely to know.
+- Add the obvious synonym when the original term is too narrow (e.g.
+  "auth" → "auth OR authentication").
+
+Don't over-expand. If the query is already specific, leave it alone.
+One recall call per `/recall` invocation — duplicate calls double
+embedding load and the merge step is rarely worth it. The daemon's
+own `search_memory_expanded` exists for the multi-query case; if it
+matters, use that endpoint instead of issuing parallel calls here.
+
+### Phase 2 — call the MCP tool
+
+```
+recall(query="<expanded query>", space=<inferred>, memory_type=<inferred>)
+```
+
+Inferences (do not ask the user):
+
+- `space`: current working directory (e.g. `~/Repos/origin/...` → `"origin"`),
+  the topic being discussed, or whatever space was mentioned in recent turns.
+  Always pass when scope is known; if uncertain, run `list_spaces` later
+  (post-PR-C) or omit.
+- `memory_type`: only when the query itself names a type ("decision on X",
+  "lesson about Y", "preference for Z"). Otherwise omit and let hybrid
+  search rank.
+- `limit`: default 10. Use 3-5 for quick lookups, 10-20 for exploration.
+
+### Phase 3 — rerank (agent-side)
+
+The daemon returns hits ranked by hybrid search. That ranking is good but
+not perfect — it doesn't know the user's exact intent.
+
+Re-read the returned memories against the *original* query. Promote the
+ones that directly answer the question; demote ones that just share
+keywords.
+
+Show the user the top 3-5 reranked hits. Surface the rest only if asked.
+
+### Phase 4 — render revision context (per result)
+
+Each memory may carry revision fields: `version`, `pending_revision`,
+`merged_from`, `last_delta_summary`. Most memories are fresh (v1, none
+set) — render nothing extra for those. Only add a tag line when
+something meaningful is present.
+
+**Condition:** emit the tag line when any of these holds:
+- `version > 1`
+- `merged_from` is non-empty
+- `pending_revision == true`
+
+**Format** — one compact line above the memory body:
+
+```
+<id>  v<N> (merged <K> memories)         ← merged_from has K entries
+<id>  v<N>, pending revision against <id> ← pending_revision true
+<id>  v<N> — <last_delta_summary>         ← version > 1, delta populated
+<id>  v<N>                                ← version > 1, no delta
+```
+
+Rules:
+- Merged takes precedence over pending_revision in the label.
+- Omit `— <delta>` when `last_delta_summary` is empty or null.
+- Skip the tag line entirely when version == 1 (or null) and no other
+  flag is set. Preserves current output for fresh memories.
+
+## When to use
+
+- "What did I say about X?"
+- "Do you remember the decision on Y?"
+- Need a specific fact before continuing.
+
+## When NOT to use
+
+- Broad session orientation → use `/brief` instead.
+- Storing a new memory → use `/capture`.
+
+## Hint: write specific queries
+
+"Alice database preference" finds more than "database stuff". The semantic
+matcher rewards specificity. If too many results return, add filters rather
+than making the query longer.

--- a/plugins/origin/skills/review/SKILL.md
+++ b/plugins/origin/skills/review/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: review
+description: >
+  Power-user audit of Origin's pending surfaces. Most users want
+  `/brief` for revisions. That handles the daily flow. Use `/review` only
+  for explicit deep-walk audits after bulk imports, or when you want to walk
+  the full queue rather than the top 3 shown in /brief.
+  Invoked as `/review captures` or `/review revisions`.
+argument-hint: "captures | revisions"
+allowed-tools: ["mcp__plugin_origin_origin__list_pending", "mcp__plugin_origin_origin__list_pending_revisions", "mcp__plugin_origin_origin__confirm_memory", "mcp__plugin_origin_origin__forget", "mcp__plugin_origin_origin__capture", "mcp__plugin_origin_origin__accept_revision", "mcp__plugin_origin_origin__dismiss_revision"]
+---
+
+# /review
+
+Power-user audit lever. Most users do not need /review in daily flow:
+
+- **Pending revisions** surface in `/brief` automatically (top 3 with inline accept/dismiss).
+- **Pending captures from this session** surface in `/handoff`'s preview
+  block (top 3, informational). Use `/review captures` for the deep walk.
+- **Orphan wikilinks** surface in `/distill`'s topic-suggestion block.
+
+Use /review only when you want the deep walk those skills intentionally do not force.
+
+## Scoped invocation
+
+- `/review captures`: walk every unconfirmed memory (`list_pending`,
+  unfiltered by session). Per item: accept (`confirm_memory`), edit
+  (`capture` with `supersedes=<old_id>` then `forget(old_id)`), or
+  reject (`forget`).
+
+- `/review revisions`: walk every pending revision (`list_pending_revisions`,
+  no cap). Per item: accept (`accept_revision`), dismiss (`dismiss_revision`),
+  or skip.
+
+Bare `/review` (no arg) prints this help block and exits. Does not auto-walk.
+
+## When to use
+
+- After a bulk import (ChatGPT, Obsidian dump) when you want to audit
+  every auto-classification before sealing.
+- When `/brief` shows ">3 pending revisions" and you want to clear the
+  full queue, not just the top 3.
+
+## When NOT to use
+
+- Daily session work. `/brief` handles the surface that matters today.
+- Specific factual lookup: use `/recall`.
+- Searching for facts: use `/recall`.
+
+## Cost
+
+Read-only until the user confirms or rejects. No LLM calls. Cheap.


### PR DESCRIPTION
## Summary

Adds Origin as a Claude Code plugin.

Origin gives Claude Code a local memory loop: start with `/brief`, capture durable decisions with `/capture`, search with `/recall`, end with `/handoff`, and use `/distill` to turn memory clusters into readable wiki pages.

## Component Details

- **Name**: origin
- **Type**: Plugin
- **Category**: productivity
- **Repository**: https://github.com/7xuanlu/origin

## Testing

- [x] Ran validation (`npm test`)
- [x] Checked that the marketplace JSON parses
- [x] Checked that `origin` is registered once in `.claude-plugin/marketplace.json`
- [x] No overlap with existing components found

## Examples

```text
/init
```

Set up the local daemon, MCP wiring, and first round-trip check.

```text
/brief
```

Load relevant project context, recent handoffs, decisions, and distilled pages at the start of a session.

```text
/capture This release uses the local daemon as the single writer.
```

Save one durable decision, lesson, preference, or project fact during work.
