### PR TITLE
feat: update archcore v0.4.4

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -126,6 +126,42 @@
       "source": "./plugins/slopmop"
     },
     {
+      "name": "archcore",
+      "description": "Make your AI agent code with your project's architecture, rules, and decisions. Git-native context (folder conventions, ADRs, team standards) so new code lands in the right place and decisions persist across sessions and agents.",
+      "version": "0.4.4",
+      "author": {
+        "name": "Archcore",
+        "url": "https://github.com/archcore-ai"
+      },
+      "repository": "https://github.com/archcore-ai/plugin",
+      "license": "Apache-2.0",
+      "keywords": [
+        "claude-code",
+        "cursor",
+        "claude-code-plugin",
+        "mcp",
+        "ai-agents",
+        "ai-coding",
+        "context-engineering",
+        "architecture",
+        "adr",
+        "knowledge-management",
+        "rules",
+        "decisions",
+        "conventions",
+        "git-native",
+        "skills",
+        "subagents",
+        "spec-driven",
+        "documentation"
+      ],
+      "category": "productivity",
+      "source": {
+        "source": "github",
+        "repo": "archcore-ai/plugin"
+      }
+    },
+    {
       "name": "agents-blockchain-web3",
       "description": "Specialized agents for blockchain development, smart contracts, and Web3 applications",
       "version": "1.0.0",

--- a/plugins/archcore/.claude-plugin/plugin.json
+++ b/plugins/archcore/.claude-plugin/plugin.json
@@ -1,15 +1,16 @@
 {
   "name": "archcore",
-  "version": "0.3.5",
+  "version": "0.4.4",
   "description": "Make your AI agent code with your project's architecture, rules, and decisions. Git-native context (folder conventions, ADRs, team standards) so new code lands in the right place and decisions persist across sessions and agents.",
   "author": {
     "name": "Archcore",
     "url": "https://github.com/archcore-ai"
   },
-  "repository": "https://github.com/archcore-ai/archcore-plugin",
+  "repository": "https://github.com/archcore-ai/plugin",
   "license": "Apache-2.0",
   "keywords": [
     "claude-code",
+    "cursor",
     "claude-code-plugin",
     "mcp",
     "ai-agents",

--- a/plugins/archcore/README.md
+++ b/plugins/archcore/README.md
@@ -1,6 +1,10 @@
 # Archcore
 
-Make your AI agent code with your project's architecture, rules, and decisions. Git-native context (folder conventions, ADRs, team standards) lives in `.archcore/` next to your code, so every agent and every contributor reads from the same source of truth.
+**Make your AI code like it already knows your repo.**
+
+Archcore gives coding agents the architecture, rules, and prior decisions of *this* repo — so new changes land where your project says they belong and follow the team's conventions, automatically. Git-native context (folder conventions, ADRs, team standards) lives in `.archcore/` next to your code, so every agent and every contributor reads from the same source of truth.
+
+Works in **Claude Code**, **Cursor**, and **Codex CLI**. One source of truth, in Git.
 
 ## Why
 
@@ -9,15 +13,27 @@ Make your AI agent code with your project's architecture, rules, and decisions. 
 - **Decisions persist** — ADRs captured once stay enforced across sessions and agents.
 - **Team-wide** — Context is in Git, shared by humans and agents alike.
 
+## Commands
+
+| Command              | Outcome                                                | When to use                                                                 |
+| -------------------- | ------------------------------------------------------ | --------------------------------------------------------------------------- |
+| `/archcore:init`     | Make your repo legible to AI agents                    | First-time setup — seeds a stack rule, a run-the-app guide, and imports existing `CLAUDE.md` / `AGENTS.md` / `.cursorrules` |
+| `/archcore:context`  | Load what's already decided before you change code     | Daily, before editing — pulls relevant rules, decisions, specs, and patterns |
+| `/archcore:capture`  | Document what already lives in code                    | A module, API, pipeline, or integration has tribal knowledge but no doc yet |
+| `/archcore:plan`     | Turn an idea into a scoped implementation plan         | New feature, refactor, or initiative                                        |
+| `/archcore:decide`   | Record a decision and (optionally) make it a team rule | Capture rationale, consequences, and turn into an enforced standard         |
+| `/archcore:audit`    | Find stale, missing, or drifting docs                  | Health check — `--deep` for full audit, `--drift` for code/doc staleness    |
+| `/archcore:help`     | Navigate the skill catalog                             | When you forget which command fits                                          |
+
 ## What's included
 
-| Component   | Details                                                                                                                                                                                         |
-| ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| MCP server  | `archcore` (init project, create/get/list/search/update/remove documents, manage relations)                                                                                                     |
-| Agents      | `archcore-assistant`, `archcore-auditor`                                                                                                                                                        |
-| Skills (18) | architecture-track, bootstrap, capture, context, decide, plan, review, verify, status, graph, help, actualize, feature-track, iso-track, product-track, sources-track, standard, standard-track |
-| Hooks       | session-start, cursor sync                                                                                                                                                                      |
-| Rules       | Cursor `.mdc` files (architecture-context, file ownership)                                                                                                                                      |
+| Component  | Details                                                                                       |
+| ---------- | --------------------------------------------------------------------------------------------- |
+| MCP server | `archcore` (init project, create/get/list/search/update/remove documents, manage relations)   |
+| Agents     | `archcore-assistant`, `archcore-auditor`                                                      |
+| Skills     | `init`, `context`, `capture`, `plan`, `decide`, `audit`, `help`                                |
+| Hooks      | `SessionStart`, write/code-alignment guards, post-document validation, cascade & precision    |
+| Rules      | Cursor `.mdc` files (architecture-context, file ownership)                                    |
 
 ## Document types
 
@@ -31,14 +47,29 @@ Documents can be linked with directed relations stored in the sync manifest.
 
 ## Install
 
+Archcore plugins require the **Archcore CLI** on `PATH` — it serves the MCP server the plugin talks to. The CLI is **not bundled** with the plugin; install it separately:
+
 ```bash
-/plugin marketplace add archcore-ai/archcore-plugin
-/plugin install archcore@archcore-plugin
+# macOS / Linux / WSL
+curl -fsSL https://archcore.ai/install.sh | bash
+
+# Windows (PowerShell 5.1+)
+irm https://archcore.ai/install.ps1 | iex
 ```
 
-The plugin ships a launcher in `bin/` that backs the MCP server, so install from the upstream marketplace above — this buildwithclaude listing is for discovery only.
+Verify: `archcore --version` · Update: `archcore update`
+
+Then add the plugin from the upstream marketplace:
+
+```bash
+/plugin marketplace add archcore-ai/plugin
+/plugin install archcore@archcore-plugins
+```
+
+This buildwithclaude listing is for discovery only — install from the upstream marketplace above so the plugin and CLI stay in sync.
 
 ## Links
 
-- [GitHub](https://github.com/archcore-ai/archcore-plugin)
+- [GitHub](https://github.com/archcore-ai/plugin)
+- [Docs](https://docs.archcore.ai)
 - License: Apache-2.0


### PR DESCRIPTION
hello @davepoon!

Update plugin to v0.4.4 (https://github.com/archcore-ai/plugin/releases/tag/v0.4.4)

 - **`plugins/archcore/.claude-plugin/plugin.json`**
    - Bump `version` 0.3.5 → 0.4.4
    - Fix `repository` URL (`archcore-ai/archcore-plugin` → `archcore-ai/plugin` — repo was renamed upstream)
    - Add `cursor` keyword (v0.4.x adds Cursor host support)

  - **`plugins/archcore/README.md`** — rewritten to match v0.4.4 reality
    - Drop "ships a launcher in `bin/`" — the Archcore CLI is no longer bundled; it installs separately via `curl -fsSL https://archcore.ai/install.sh | bash`
    - Update marketplace install commands to current names (`archcore-ai/plugin` + `archcore@archcore-plugins`)
    - Document the actual 7 slash commands (`init`, `context`, `capture`, `plan`, `decide`, `audit`, `help`)
    - Note multi-host support (Claude Code, Cursor, Codex CLI)

  - **`.claude-plugin/marketplace.json`** — add `archcore` entry (it was missing, so `/plugin/archcore` returned 404 on the site)
    - `source` uses the GitHub remote form (`{ "source": "github", "repo": "archcore-ai/plugin" }`) so `/plugin install archcore@buildwithclaude` resolves to the upstream repo — no need to vendor the plugin
  source into this monorepo
    - Category `productivity` (the plugin is a context/knowledge layer, not a bundle of MCP servers — picking `mcp-servers` caused the plugin detail page to render every keyword as a fake "Included MCP Server")

  ## Out of scope

  - The `archcore` MCP server itself isn't surfaced on buildwithclaude — the site only ingests from the Official MCP Registry and Docker Hub MCP. The plugin's README and upstream repo document the MCP
  capabilities. I'll register with the Official MCP Registry separately.
  - Per-plugin agents/commands/skills don't get individual detail pages because the site only sources from the central `plugins/all-*/` directories. Following the discovery-only pattern used by
  `claude-snapshot`, I didn't mirror files into the central dirs to avoid duplication and sync drift on every archcore release.
