### PR TITLE
fix(indexer): paginate topic search to mirror code-search pagination

### DIFF
--- a/web-ui/lib/indexer/marketplace-indexer.ts
+++ b/web-ui/lib/indexer/marketplace-indexer.ts
@@ -120,10 +120,14 @@ export async function indexMarketplaces(): Promise<IndexResult> {
 
   for (const topic of topicQueries) {
     try {
-      const { repos } = await github.searchRepositories(`topic:${topic}`)
-      console.log(`Found ${repos.length} repos for topic: ${topic}`)
-      for (const repo of repos) {
-        repoSet.add(repo.full_name)
+      const first = await github.searchRepositories(`topic:${topic}`)
+      console.log(`Found ${first.totalCount} repos for topic: ${topic}`)
+      const maxPages = Math.min(Math.ceil(first.totalCount / 100), 10)
+      for (let page = 1; page <= maxPages; page++) {
+        const pageResult = page === 1 ? first : await github.searchRepositories(`topic:${topic}`, page)
+        for (const repo of pageResult.repos) {
+          repoSet.add(repo.full_name)
+        }
       }
     } catch (error) {
       console.error(`Topic search failed for "${topic}":`, error)


### PR DESCRIPTION
Fixes #157.

## Summary

The topic-search loop in `indexMarketplaces` (`web-ui/lib/indexer/marketplace-indexer.ts`) calls `github.searchRepositories(topic)` exactly once and never paginates — silently dropping any repo ranked past position #100 in `searchRepositories`'s `stars,desc` ordering. The helper exposes a `page` parameter and returns `totalCount`; both were unused at the call site.

This PR mirrors the pagination pattern from the code-search block immediately above it in the same function:

```ts
const maxPages = Math.min(Math.ceil(searchResult.total_count / 100), 10)
for (let page = 1; page <= maxPages; page++) {
  const pageResult = page === 1 ? searchResult : await github.searchCode(searchQuery, page)
  ...
}
```

## The diff

```diff
 for (const topic of topicQueries) {
   try {
-    const { repos } = await github.searchRepositories(`topic:${topic}`)
-    console.log(`Found ${repos.length} repos for topic: ${topic}`)
-    for (const repo of repos) {
-      repoSet.add(repo.full_name)
+    const first = await github.searchRepositories(`topic:${topic}`)
+    console.log(`Found ${first.totalCount} repos for topic: ${topic}`)
+    const maxPages = Math.min(Math.ceil(first.totalCount / 100), 10)
+    for (let page = 1; page <= maxPages; page++) {
+      const pageResult = page === 1 ? first : await github.searchRepositories(`topic:${topic}`, page)
+      for (const repo of pageResult.repos) {
+        repoSet.add(repo.full_name)
+      }
     }
   } catch (error) {
     console.error(`Topic search failed for "${topic}":`, error)
```

## Why `Math.min(..., 10)`

Same ceiling as the existing code-search loop, and matches GitHub's hard 1000-result cap on Search queries (page 11 returns HTTP 422). Not policy — just the API limit.

## API-call cost

Today this means +2 calls per cron run (`claude-code-plugins` has 266 results → 3 pages). The other four topics (`claude-code-skill`, `claude-skill`, `agent-skill`, `claude-agent-skill`) likely fit in one page each, so they're unchanged. The throttle/backoff/circuit-breaker in `GitHubClient` already covers the additional load.

## Test plan

- [ ] Trigger the indexer manually (cron route or admin endpoint) and confirm `Found N repos for topic: ...` now logs the full totalCount for `claude-code-plugins`
- [ ] After the run, query `/api/marketplaces/list?search=glitchwerks` (or any small marketplace previously past rank #100 in `claude-code-plugins`) and confirm it appears

I was unable to test against your Postgres/Neon DB locally, so the runtime verification is gated on the cron trigger in your environment. Happy to iterate on the shape if you'd prefer a different pagination idiom or want telemetry around the new pages.

---

🤖 Generated by Claude Code on behalf of @cbeaulieu-gt