### PR TITLE
fix(indexer): handle object-form author in trigger/index-plugins

### DIFF
--- a/web-ui/trigger/index-plugins.ts
+++ b/web-ui/trigger/index-plugins.ts
@@ -84,7 +84,9 @@ async function fetchGitHubMarketplacePlugins(
             category: plugin.category,
             keywords: plugin.keywords || plugin.tags,
             skills: plugin.skills,
-            author: plugin.author || repoFullName.split("/")[0],
+            author: typeof plugin.author === 'object'
+              ? plugin.author?.name || repoFullName.split("/")[0]
+              : plugin.author || repoFullName.split("/")[0],
             gitUrl: plugin.repository || `https://github.com/${repoFullName}`,
             stars: 0,
             downloads: 0,


### PR DESCRIPTION
## Summary

When a plugin manifest uses the documented object form for `author` (e.g. `{ name: "...", email: "..." }`), `trigger/index-plugins.ts` was writing the field directly to a varchar column, producing `"[object Object]"` in the database.

This applies the same `typeof === 'object'` guard already present at `web-ui/lib/indexer/plugin-indexer.ts:192`, extracting `author.name` when the value is an object and falling back to the repo namespace when the name is absent.

**Diff:**
```
- author: plugin.author || repoFullName.split("/")[0],
+ author: typeof plugin.author === 'object'
+   ? plugin.author?.name || repoFullName.split("/")[0]
+   : plugin.author || repoFullName.split("/")[0],
```

Fixes #166

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_