### PR TITLE
Add kegg-mcp-server plugin

### DIFF
--- a/plugins/kegg-mcp-server/.claude-plugin/plugin.json
+++ b/plugins/kegg-mcp-server/.claude-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "kegg-mcp-server",
+  "version": "0.3.0",
+  "description": "Query the KEGG bioinformatics database — pathways, genes, compounds, drugs, enzymes, diseases, reactions, and more via 34 MCP tools. No API key required.",
+  "author": {
+    "name": "Lucas Servi",
+    "url": "https://github.com/Lucas-Servi"
+  },
+  "repository": "https://github.com/Lucas-Servi/kegg-mcp-server-python",
+  "license": "MIT",
+  "keywords": [
+    "mcp",
+    "kegg",
+    "bioinformatics",
+    "pathways",
+    "genomics",
+    "metabolomics",
+    "systems-biology",
+    "science"
+  ]
+}

--- a/plugins/kegg-mcp-server/.mcp.json
+++ b/plugins/kegg-mcp-server/.mcp.json
@@ -1,0 +1,6 @@
+{
+  "kegg": {
+    "command": "uvx",
+    "args": ["kegg-mcp-server"]
+  }
+}

--- a/plugins/kegg-mcp-server/agents/kegg-bioinformatics.md
+++ b/plugins/kegg-mcp-server/agents/kegg-bioinformatics.md
@@ -1,0 +1,26 @@
+---
+name: kegg-bioinformatics
+description: Use when the user asks about biological pathways, gene functions, metabolic networks, drug targets, enzyme reactions, disease mechanisms, or any KEGG database query. Specializes in pathway enrichment, cross-species comparison, and drug-target investigation.
+category: data-ai
+---
+
+You are a bioinformatics research assistant specialized in querying the KEGG database via MCP tools.
+
+When invoked:
+1. Identify the biological question (pathway analysis, gene lookup, drug investigation, etc.)
+2. Select the appropriate KEGG tools (search, get_info, find_related_entries, convert_identifiers)
+3. Retrieve and cross-reference data across KEGG databases
+4. Synthesize findings into clear biological context
+
+Process:
+- Start broad (search) then drill down (get_info, get_pathway_genes, etc.)
+- Cross-reference between databases (genes to pathways to compounds to reactions)
+- Use batch_entry_lookup for efficient multi-entry retrieval (max 50)
+- Use render_pathway_ascii for visual pathway representation
+- Use convert_identifiers to bridge KEGG IDs with external databases (UniProt, NCBI, PDB)
+
+Provide:
+- Biological context for all results, not just raw IDs
+- Pathway enrichment summaries with statistical relevance
+- Cross-species conservation analysis when comparing organisms
+- Actionable follow-up suggestions (related pathways, drug interactions, ortholog groups)

--- a/plugins/kegg-mcp-server/commands/kegg-drug.md
+++ b/plugins/kegg-mcp-server/commands/kegg-drug.md
@@ -1,0 +1,22 @@
+---
+description: Investigate a drug — targets, pathways, classification, and interactions
+category: miscellaneous
+argument-hint: <drug_name>
+---
+
+# Drug Investigation
+
+Investigate a drug's mechanism of action, targets, and interactions.
+
+1. Call `search_drugs` with: `$ARGUMENTS`
+2. Call `get_drug_info` for the top match to retrieve targets, classification, and metabolism.
+3. For each target gene listed, call `search_genes` in human (hsa) to get the KEGG gene ID.
+4. Call `find_related_entries` to identify pathways each target participates in.
+5. Call `get_drug_interactions` to screen for drug-drug interactions.
+6. Present a structured report:
+   - Drug name, formula, and classification
+   - Mechanism of action (from target + pathway data)
+   - Target genes and their biological roles
+   - Key pathways affected
+   - Drug-drug interactions (if any)
+   - Suggested follow-ups: "Try `/kegg-pathway` to explore a target pathway in detail."

--- a/plugins/kegg-mcp-server/commands/kegg-pathway.md
+++ b/plugins/kegg-mcp-server/commands/kegg-pathway.md
@@ -1,0 +1,23 @@
+---
+description: Deep-dive into a KEGG pathway — genes, compounds, reactions, and ASCII visualization
+category: miscellaneous
+argument-hint: <pathway_id_or_name>
+---
+
+# Pathway Deep-Dive
+
+Provide a comprehensive overview of a KEGG pathway.
+
+1. If `$ARGUMENTS` looks like a pathway ID (e.g., hsa00010, map00010), use it directly. Otherwise call `search_pathways` with the argument as a keyword and pick the top result.
+2. Call `get_pathway_info` with full detail.
+3. Call `get_pathway_genes` to list key enzymes.
+4. Call `get_pathway_compounds` to list metabolites.
+5. Call `render_pathway_ascii` in chain mode for an overview diagram.
+6. Present a structured summary:
+   - Pathway name and organism
+   - Biological function (1-2 sentences)
+   - Key enzymes (with EC numbers)
+   - Key metabolites
+   - ASCII diagram
+   - Related diseases or drugs (if any in the pathway data)
+   - Suggested follow-ups: "Try `/kegg-drug` for drugs targeting this pathway, or ask for a cross-species comparison."

--- a/plugins/kegg-mcp-server/commands/kegg.md
+++ b/plugins/kegg-mcp-server/commands/kegg.md
@@ -1,0 +1,26 @@
+---
+description: Search the KEGG bioinformatics database for pathways, genes, compounds, drugs, enzymes, or diseases
+category: miscellaneous
+argument-hint: <query>
+---
+
+# KEGG Search
+
+Search the KEGG database for the user's query.
+
+1. Determine the most relevant KEGG category from the query:
+   - Biological processes/signaling → search_pathways
+   - Gene names/symbols/organisms → search_genes
+   - Chemical names/formulas → search_compounds
+   - Enzyme names/EC numbers → search_enzymes
+   - Reaction descriptions → search_reactions
+   - Disease names/symptoms → search_diseases
+   - Drug names/trade names → search_drugs
+   - Functional modules → search_modules
+   - Ortholog groups → search_ko_entries
+   - Sugar structures → search_glycans
+2. Call the appropriate search tool with: `$ARGUMENTS`
+3. Display results as a compact numbered list with IDs and descriptions
+4. End with: "Say a number or ID to get full details, or refine your search."
+
+If the user picks a number, call the corresponding get_*_info tool for that entry.

--- a/plugins/kegg-mcp-server/skills/kegg-analysis/SKILL.md
+++ b/plugins/kegg-mcp-server/skills/kegg-analysis/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: kegg-analysis
+category: data-ai
+description: Multi-step KEGG bioinformatics workflows — pathway enrichment from gene lists, drug-target investigation, cross-species metabolic comparison, and compound-reaction network exploration. Guides Claude through the full analytical pipeline using KEGG MCP tools.
+---
+
+# KEGG Bioinformatics Analysis
+
+This skill orchestrates multi-step biological analyses using the KEGG MCP server tools. It transforms raw gene lists, drug names, or pathway IDs into structured biological insights.
+
+## When to Use This Skill
+
+- Performing pathway enrichment analysis on a gene list
+- Investigating a drug's mechanism of action, targets, and interactions
+- Comparing metabolic pathways across species
+- Tracing compound-reaction networks
+- Mapping genes to functional modules and ortholog groups
+
+## What This Skill Does
+
+1. **Identifies the analysis type** from the user's input (enrichment, drug, comparison, network)
+2. **Resolves identifiers** — maps gene symbols, drug names, or pathway IDs to KEGG entries
+3. **Retrieves cross-linked data** — follows relationships across KEGG databases
+4. **Aggregates and ranks results** — counts pathway hits, scores conservation, groups by function
+5. **Synthesizes biological context** — explains significance, not just IDs
+
+## How to Use
+
+### Pathway Enrichment
+
+```
+Analyze these genes for pathway enrichment in human: BRCA1, TP53, EGFR, KRAS, PIK3CA
+```
+
+Workflow:
+1. `search_genes` for each gene in the target organism (e.g., hsa)
+2. `get_gene_info` to confirm identity and get KEGG gene IDs
+3. `find_related_entries` to get pathway associations per gene
+4. Aggregate: count how many input genes map to each pathway
+5. `get_pathway_info` for top pathways
+6. `render_pathway_ascii` for visual context
+7. Report ranked pathways with p-value proxy (gene count / pathway size)
+
+### Drug Target Investigation
+
+```
+Investigate metformin: targets, pathways, and interactions
+```
+
+Workflow:
+1. `search_drugs` to find the KEGG drug entry
+2. `get_drug_info` for targets, classification, and metabolism
+3. `search_genes` for each target gene
+4. `find_related_entries` to get target pathways
+5. `get_drug_interactions` for DDI screening
+6. Synthesize mechanism-of-action summary
+
+### Cross-Species Comparison
+
+```
+Compare glycolysis (map00010) between human, E. coli, and yeast
+```
+
+Workflow:
+1. `get_pathway_info` for organism-specific variants (hsa00010, eco00010, sce00010)
+2. `get_pathway_genes` for each organism
+3. `get_gene_orthologs` to identify conserved vs. species-specific enzymes
+4. `get_pathway_compounds` to compare metabolite pools
+5. `render_pathway_ascii` for each organism
+6. Report conservation matrix and unique adaptations
+
+## Example
+
+**User**: "What pathways are enriched in this gene set: SOD1, SOD2, CAT, GPX1, PRDX1?"
+
+**Output**:
+```
+Pathway Enrichment Results (Homo sapiens)
+
+Top Pathways:
+1. hsa04146 Peroxisome (4/5 genes) — organelle for fatty acid oxidation and ROS detox
+2. hsa04216 Ferroptosis (3/5 genes) — iron-dependent cell death regulated by GPX
+3. hsa05022 Pathways of neurodegeneration (3/5 genes) — oxidative damage in ALS, AD, PD
+4. hsa00480 Glutathione metabolism (2/5 genes) — GSH-dependent antioxidant system
+
+Biological Context:
+All 5 genes encode antioxidant enzymes. The enrichment in Peroxisome
+and Ferroptosis pathways reflects their central role in reactive oxygen
+species (ROS) detoxification. The neurodegeneration hit is consistent
+with oxidative stress as a driver of SOD1-linked ALS.
+```
+
+## Tips
+
+- Provide organism context (human, mouse, E. coli) for faster resolution
+- Use standard gene symbols — KEGG resolves HGNC symbols for human
+- For large gene lists (>20), batch with `batch_entry_lookup` (max 50 per call)
+- Cross-reference with `convert_identifiers` to bridge UniProt, NCBI Gene, or PDB IDs
+- Use `find_related_entries` to discover unexpected connections between databases


### PR DESCRIPTION
## Summary

Adds a KEGG bioinformatics MCP server plugin that provides 34 read-only tools for querying the KEGG REST API — pathways, genes, compounds, reactions, enzymes, diseases, drugs, modules, orthology, glycans, and BRITE hierarchies. No API key required.

## Component Details

- **Name**: kegg-mcp-server
- **Type**: Plugin (MCP Server + Agent + Command)
- **Category**: data-ai / science

## Testing

- [x] Ran validation (`npm test`) — all passed
- [x] Tested functionality (server starts, tools respond correctly)
- [x] No overlap with existing components

## Examples

1. **Pathway enrichment:** "I have upregulated genes (BRCA1, TP53, EGFR). What KEGG pathways are they enriched in?"
2. **Drug investigation:** "What are the targets and drug-drug interactions for metformin?"
3. **Cross-species comparison:** "Compare glycolysis between human and E. coli — which enzymes are conserved?"

## Links

- Repository: https://github.com/Lucas-Servi/kegg-mcp-server-python
- Install: `uvx kegg-mcp-server` (Python 3.11+, on PyPI)