### PR TITLE
Add RunAPI MCP plugin for AI media generation and LLM chat

### DIFF
--- a/plugins/runapi-mcp/.claude-plugin/plugin.json
+++ b/plugins/runapi-mcp/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "runapi-mcp",
+  "description": "AI image, video, music, audio generation and LLM chat — 130+ models from 18 providers via RunAPI MCP server.",
+  "version": "0.1.7",
+  "author": {
+    "name": "RunAPI",
+    "url": "https://runapi.ai"
+  }
+}

--- a/plugins/runapi-mcp/README.md
+++ b/plugins/runapi-mcp/README.md
@@ -1,0 +1,8 @@
+# RunAPI MCP
+
+130+ AI models for image, video, music, audio, and LLM generation from 18 providers.
+
+Install: `npx @runapi.ai/mcp init claude`
+
+- [GitHub](https://github.com/runapi-ai/mcp)
+- [npm](https://www.npmjs.com/package/@runapi.ai/mcp)


### PR DESCRIPTION
Adds RunAPI MCP plugin — 130+ AI models from 18 providers. Image, video, music, audio, and LLM. Free catalog tools. GitHub: https://github.com/runapi-ai/mcp