### PR TITLE
Add backlogd plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1567,6 +1567,30 @@
       ],
       "category": "sales-marketing",
       "source": "./plugins/vibe-prospecting"
+    },
+    {
+      "name": "backlogd",
+      "description": "Turn Claude Code into a problem-driven scrum team. You file problems as Linear issues; an agent team runs the empirical Scrum loop (scope, solve, review, adapt) and owns the solutions. An independent reviewer gates every increment against its acceptance criteria, the Definition of Done, and a standards corpus. Runs on your Claude subscription via the official Linear MCP over OAuth — no API keys.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Nicolai Bernsen",
+        "url": "https://github.com/nicolai-bernsen"
+      },
+      "repository": "https://github.com/nicolai-bernsen/backlogd",
+      "license": "MIT",
+      "keywords": [
+        "claude-code",
+        "linear",
+        "scrum",
+        "agents",
+        "product-management",
+        "orchestration"
+      ],
+      "category": "orchestration",
+      "source": {
+        "source": "github",
+        "repo": "nicolai-bernsen/backlogd"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary
Adds backlogd to the marketplace listing — an agent *team* that runs real Scrum on any problem type, on your Claude subscription (no API tokens).

## Component Details
- **Name**: backlogd
- **Type**: Plugin (marketplace)
- **Category**: orchestration
- **Repository**: https://github.com/nicolai-bernsen/backlogd
- **Version**: 1.0.0 (released 2026-06-03)
- **License**: MIT

## What it is
You act as Product Owner and file *problems* (Linear issues), not specs. The slash commands are the Scrum Master; subagents are the Developers. The loop is scope -> solve -> review -> adapt, and an **independent reviewer** verifies every increment against its acceptance criteria, the Definition of Done, and a standards corpus — blocking on a missing load-bearing standard instead of guessing. It runs on your existing Claude subscription via the **official Linear MCP over OAuth — no API keys**.

Install:
```
/plugin marketplace add nicolai-bernsen/backlogd
/plugin install backlogd
```

## Testing
- [x] Entry references a remote `github` source (no vendored source), mirroring the existing `archcore-ai/plugin` entry
- [x] `marketplace.json` parses as valid JSON and the new entry matches the existing entries' schema/shape
- [x] No overlap with existing components (backlogd is a Scrum-team orchestrator, not a single agent/command/hook); categorised `orchestration` alongside the existing multi-agent orchestrator entry
- [ ] `npm test` — the validator currently reports pre-existing markdown warnings ("Code blocks should specify a language after the backticks") in ~104 `plugins/all-commands/commands/*.md` files. These are present on a pristine `main` checkout and are **unrelated to this change**; this PR touches only `.claude-plugin/marketplace.json` and adds no command/agent/hook/skill files.

## Links
- README: https://github.com/nicolai-bernsen/backlogd#readme
- Release v1.0.0: https://github.com/nicolai-bernsen/backlogd/releases
