### PR TITLE
Add RunAPI MCP media generation plugin

### DIFF
--- a/plugins/runapi-mcp/.claude-plugin/plugin.json
+++ b/plugins/runapi-mcp/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "runapi-mcp",
+  "description": "AI image, video, music, audio generation and LLM chat — 130+ models from 18 providers via RunAPI MCP server.",
+  "version": "0.1.7",
+  "author": {
+    "name": "RunAPI",
+    "url": "https://runapi.ai"
+  }
+}

--- a/plugins/runapi-mcp/README.md
+++ b/plugins/runapi-mcp/README.md
@@ -1,0 +1,8 @@
+# RunAPI MCP
+
+130+ AI models for image, video, music, audio, and LLM generation from 18 providers.
+
+Install: `npx @runapi.ai/mcp init claude`
+
+- [GitHub](https://github.com/runapi-ai/mcp)
+- [npm](https://www.npmjs.com/package/@runapi.ai/mcp)


### PR DESCRIPTION
## Summary

Adds **RunAPI MCP**, a media generation plugin with MCP server config, 2 agents, and 2 commands.

### MCP Server
- 8 tools (5 free, 3 require API key): list_models, get_model_info, list_actions, check_pricing, search_prompts, check_balance, create_task, get_task
- 130+ AI models across image, video, music, audio from 18 providers
- 1,600+ curated prompt library with search
- npm: `@runapi.ai/mcp` (via `npx -y @runapi.ai/mcp`)

### Agents
- `task-executor` — executes create_task in isolated context for parallel generation
- `model-advisor` — searches models and pricing to recommend the best option

### Commands
- `/runapi:gen <prompt>` — quick generation, skips intent assessment
- `/runapi:models` — list models by modality

### Links
- GitHub: https://github.com/runapi-ai/mcp
- npm: https://www.npmjs.com/package/@runapi.ai/mcp