### PR TITLE
Add kegg-mcp-server to marketplace.json registry

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1591,6 +1591,30 @@
         "source": "github",
         "repo": "nicolai-bernsen/backlogd"
       }
+    },
+    {
+      "name": "kegg-mcp-server",
+      "description": "Query the KEGG bioinformatics database — pathways, genes, compounds, drugs, enzymes, diseases, reactions, and more via 34 read-only MCP tools. No API key required.",
+      "version": "0.3.0",
+      "author": {
+        "name": "Lucas Servi",
+        "url": "https://github.com/Lucas-Servi"
+      },
+      "homepage": "https://github.com/Lucas-Servi/kegg-mcp-server-python",
+      "repository": "https://github.com/Lucas-Servi/kegg-mcp-server-python",
+      "license": "MIT",
+      "keywords": [
+        "mcp",
+        "kegg",
+        "bioinformatics",
+        "pathways",
+        "genomics",
+        "metabolomics",
+        "systems-biology",
+        "science"
+      ],
+      "category": "mcp-servers",
+      "source": "./plugins/kegg-mcp-server"
     }
   ]
 }


### PR DESCRIPTION
PR #168 merged the `kegg-mcp-server` plugin files into `plugins/kegg-mcp-server/`, but the entry was never added to `.claude-plugin/marketplace.json`, so the plugin doesn't show on the /plugins or MCP Servers pages (searching "kegg" returns 0 results).

This small follow-up adds the missing registry entry, with `source` pointing at the in-repo `./plugins/kegg-mcp-server` directory — consistent with the other vendored plugins. Values are taken directly from the plugin's `plugin.json` (name, version 0.3.0, description, author, repository, license, keywords); category is `mcp-servers` to match `mcp-servers-docker`.

Note: `marketplace.json` is a generated file — if you'd rather regenerate it via `npm run generate:registry`, this PR still documents exactly what's missing and is trivially closeable. You mentioned in the #168 merge comment that you're happy to take small follow-up tweaks, so here it is. Thanks!

Diff is purely additive (24 insertions, 0 deletions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)