### PR TITLE
claude-pager plugin

### DIFF
--- a/plugins/claude-pager/.claude-plugin/plugin.json
+++ b/plugins/claude-pager/.claude-plugin/plugin.json
@@ -1,0 +1,44 @@
+{
+  "name": "claude-pager",
+  "description": "Native desktop notifications when Claude Code needs your attention",
+  "version": "1.0.0",
+  "author": {
+    "name": "Bharat Gupta",
+    "url": "https://github.com/bharat7gupta"
+  },
+  "repository": "https://github.com/bharat7gupta/claude-pager",
+  "license": "MIT",
+  "keywords": ["notifications", "alerts", "desktop", "sound", "pager", "idle", "permission", "task-completion", "productivity"],
+  "userConfig": {
+    "idle_enabled": {
+      "type": "string",
+      "title": "Idle notifications",
+      "description": "Enable notifications when Claude waits for input (on/off)"
+    },
+    "permission_enabled": {
+      "type": "string",
+      "title": "Permission notifications",
+      "description": "Enable notifications when Claude needs permission (on/off)"
+    },
+    "completion_enabled": {
+      "type": "string",
+      "title": "Completion notifications",
+      "description": "Enable notifications when a task completes (on/off)"
+    },
+    "idle_sound": {
+      "type": "string",
+      "title": "Idle sound preset",
+      "description": "Sound for idle events: default, ping, glass, pop, hero, none"
+    },
+    "permission_sound": {
+      "type": "string",
+      "title": "Permission sound preset",
+      "description": "Sound for permission events: default, ping, glass, pop, hero, none"
+    },
+    "completion_sound": {
+      "type": "string",
+      "title": "Completion sound preset",
+      "description": "Sound for completion events: default, ping, glass, pop, hero, none"
+    }
+  }
+}

--- a/plugins/claude-pager/README.md
+++ b/plugins/claude-pager/README.md
@@ -1,0 +1,88 @@
+<h1 align="center"><img src="https://i.ibb.co/jPRMBm30/icon.jpg" alt="claude-pager icon" width="36" height="36" align="center"> Claude Pager</h1>
+
+<p align="center">Native desktop notifications for Claude Code. Get alerted when a session needs your attention — permission prompts, idle waits, or task completion.</p>
+
+## Install
+
+```bash
+git clone https://github.com/bharat7gupta/claude-pager.git
+claude --plugin-dir ./claude-pager
+```
+
+## What It Does
+
+Each notification shows your **project name** in the title so you know which session to switch to.
+
+### Permission — Claude needs tool approval
+
+<img src="https://i.ibb.co/QFRXF8w8/permission.webp" alt="Permission notification" width="500">
+
+### Idle — Claude is waiting for your input
+
+<img src="https://i.ibb.co/nNxn5GzD/idle.png" alt="Idle notification" width="500">
+
+### Task Completion — Claude finished working
+
+<img src="https://i.ibb.co/WNTYt00M/task-completion.webp" alt="Task completion notification" width="500">
+
+<img src="https://i.ibb.co/Jw5xWwCX/task-completion-2.jpg" alt="Task completion notification with summary" width="500">
+
+## Configuration
+
+After install, configure via `pluginConfigs` in `~/.claude/settings.json`:
+
+```json
+{
+  "pluginConfigs": {
+    "claude-pager": {
+      "options": {
+        "idle_enabled": "on",
+        "permission_enabled": "on",
+        "completion_enabled": "on",
+        "idle_sound": "default",
+        "permission_sound": "default",
+        "completion_sound": "default"
+      }
+    }
+  }
+}
+```
+
+### Toggle Events
+
+Set any `*_enabled` to `"off"` to disable that notification type.
+
+### Sound Presets
+
+| Preset | Description |
+|---|---|
+| `default` | Per-event default (idle=blow, permission=funk, completion=glass) |
+| `blow` | Warm, noticeable |
+| `funk` | Short, attention-grabbing |
+| `glass` | Satisfying ding |
+| `ping` | Subtle ping |
+| `pop` | Quick pop |
+| `hero` | Bold alert |
+| `none` | Silent — visual notification only |
+
+## Platform Support
+
+| Platform | Notification | Sound | Notes |
+|---|---|---|---|
+| **macOS** | `terminal-notifier` or `osascript` | `afplay` | Works out of the box. `brew install terminal-notifier` for clickable notifications |
+| **Linux** | `notify-send` | `paplay` / `aplay` | Requires `libnotify` package |
+| **Windows** | PowerShell NotifyIcon balloon | PowerShell SystemSounds | Optional: install `BurntToast` module for modern toasts |
+
+### Headless / SSH
+
+When no desktop is available, falls back to a stdout line + terminal bell. No errors.
+
+## Requirements
+
+- Claude Code v2.1.0+
+- Node.js (ships with Claude Code)
+- Linux: `libnotify` / `notify-send` for desktop notifications
+
+## License
+
+MIT

--- a/plugins/claude-pager/hooks/hooks.json
+++ b/plugins/claude-pager/hooks/hooks.json
@@ -1,0 +1,52 @@
+{
+  "hooks": {
+    "Notification": [
+      {
+        "matcher": "idle_prompt",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/notify.mjs",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PermissionRequest": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/notify.mjs",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/notify.mjs",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "TaskCompleted": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/notify.mjs",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/claude-pager/scripts/config.mjs
+++ b/plugins/claude-pager/scripts/config.mjs
@@ -1,0 +1,25 @@
+// scripts/config.mjs
+
+const DEFAULTS = {
+  idle: { enabled: true, sound: 'default' },
+  permission: { enabled: true, sound: 'default' },
+  completion: { enabled: true, sound: 'default' },
+};
+
+const EVENT_TYPES = ['idle', 'permission', 'completion'];
+
+export function loadConfig() {
+  const config = {};
+
+  for (const type of EVENT_TYPES) {
+    const enabledRaw = process.env[`CLAUDE_PLUGIN_OPTION_${type}_enabled`];
+    const soundRaw = process.env[`CLAUDE_PLUGIN_OPTION_${type}_sound`];
+
+    config[type] = {
+      enabled: enabledRaw === 'off' ? false : DEFAULTS[type].enabled,
+      sound: soundRaw || DEFAULTS[type].sound,
+    };
+  }
+
+  return config;
+}

--- a/plugins/claude-pager/scripts/notify.mjs
+++ b/plugins/claude-pager/scripts/notify.mjs
@@ -1,0 +1,98 @@
+// scripts/notify.mjs
+import { readFileSync } from 'node:fs';
+import { basename } from 'node:path';
+import { loadConfig } from './config.mjs';
+import { detectPlatform, sendNotification } from './platforms.mjs';
+import { resolveSound, playSound } from './sounds.mjs';
+
+export function classifyEvent(payload) {
+  const { hook_event_name, notification_type } = payload;
+
+  if (hook_event_name === 'Notification') {
+    if (notification_type === 'idle_prompt') return 'idle';
+    return null;
+  }
+
+  if (hook_event_name === 'PermissionRequest') return 'permission';
+
+  if (hook_event_name === 'Stop' || hook_event_name === 'TaskCompleted') {
+    return 'completion';
+  }
+
+  return null;
+}
+
+export function buildTitle(payload) {
+  if (payload.cwd) return `Claude Pager - ${basename(payload.cwd)}`;
+  return 'Claude Pager';
+}
+
+function extractToolSummary(payload) {
+  const { tool_name, tool_input } = payload;
+  if (!tool_name) return null;
+
+  let detail = '';
+  if (tool_input) {
+    if (tool_input.command) detail = tool_input.command;
+    else if (tool_input.file_path) detail = tool_input.file_path;
+  }
+
+  return detail ? `Allow ${tool_name}: ${detail}?` : `Allow ${tool_name}?`;
+}
+
+export function buildBody(eventType, payload) {
+  if (eventType === 'idle') {
+    return payload.message || 'Waiting for your input';
+  }
+
+  if (eventType === 'permission') {
+    return extractToolSummary(payload) || payload.message || 'Needs permission';
+  }
+
+  // completion
+  if (payload.last_assistant_message) {
+    const firstLine = payload.last_assistant_message.split('\n')[0].trim();
+    if (firstLine) return firstLine.length > 120 ? firstLine.slice(0, 120) + '...' : firstLine;
+  }
+  return 'Task complete';
+}
+
+async function main() {
+  let raw;
+  try {
+    raw = readFileSync(0, 'utf8').trim();
+  } catch {
+    process.exit(0);
+  }
+
+  if (!raw) process.exit(0);
+
+  let payload;
+  try {
+    payload = JSON.parse(raw);
+  } catch {
+    process.stderr.write('[claude-pager] failed to parse stdin JSON\n');
+    process.exit(0);
+  }
+
+  const eventType = classifyEvent(payload);
+  if (!eventType) process.exit(0);
+
+  const config = loadConfig();
+  if (!config[eventType].enabled) process.exit(0);
+
+  const plat = detectPlatform();
+  const title = buildTitle(payload);
+  const body = buildBody(eventType, payload);
+
+  sendNotification(plat, title, body, process.env);
+
+  const soundPreset = resolveSound(config[eventType].sound, eventType);
+  playSound(soundPreset, plat);
+}
+
+// Only run main when executed directly, not when imported for testing
+import { fileURLToPath } from 'node:url';
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/plugins/claude-pager/scripts/platforms.mjs
+++ b/plugins/claude-pager/scripts/platforms.mjs
@@ -1,0 +1,105 @@
+// scripts/platforms.mjs
+import { spawn, execFileSync } from 'node:child_process';
+import { platform } from 'node:os';
+
+let _hasTerminalNotifier;
+function hasTerminalNotifier() {
+  if (_hasTerminalNotifier === undefined) {
+    try {
+      execFileSync('which', ['terminal-notifier'], { stdio: 'ignore' });
+      _hasTerminalNotifier = true;
+    } catch {
+      _hasTerminalNotifier = false;
+    }
+  }
+  return _hasTerminalNotifier;
+}
+
+export function detectPlatform() {
+  return platform();
+}
+
+export function isHeadless(plat, env) {
+  if (plat === 'darwin') {
+    return !!env.SSH_TTY;
+  }
+  if (plat === 'linux') {
+    return !env.DISPLAY && !env.WAYLAND_DISPLAY;
+  }
+  // Windows: assume GUI available
+  return false;
+}
+
+function escapeAppleScript(str) {
+  return str.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+export function buildNotificationCommand(plat, title, body) {
+  if (plat === 'darwin') {
+    if (hasTerminalNotifier()) {
+      return { command: 'terminal-notifier', args: ['-title', title, '-message', body, '-group', 'claude-pager'] };
+    }
+    const escaped = `display notification "${escapeAppleScript(body)}" with title "${escapeAppleScript(title)}"`;
+    return { command: 'osascript', args: ['-e', escaped] };
+  }
+
+  if (plat === 'linux') {
+    return { command: 'notify-send', args: [title, body] };
+  }
+
+  if (plat === 'win32') {
+    const ps = `
+      Add-Type -AssemblyName System.Windows.Forms;
+      $n = New-Object System.Windows.Forms.NotifyIcon;
+      $n.Icon = [System.Drawing.SystemIcons]::Information;
+      $n.Visible = $true;
+      $n.ShowBalloonTip(5000, '${title.replace(/'/g, "''")}', '${body.replace(/'/g, "''")}', 'Info');
+      Start-Sleep -Seconds 6;
+      $n.Dispose();
+    `.trim();
+    return { command: 'powershell', args: ['-NoProfile', '-Command', ps] };
+  }
+
+  return null;
+}
+
+export function formatHeadless(title, body) {
+  return `[claude-pager] ${title}: ${body}`;
+}
+
+export function sendNotification(plat, title, body, env) {
+  if (isHeadless(plat, env)) {
+    const line = formatHeadless(title, body);
+    process.stdout.write(line + '\n');
+    process.stdout.write('\x07'); // terminal bell
+    return;
+  }
+
+  const cmd = buildNotificationCommand(plat, title, body);
+  if (!cmd) {
+    // Unknown platform — headless fallback
+    const line = formatHeadless(title, body);
+    process.stdout.write(line + '\n');
+    process.stdout.write('\x07');
+    return;
+  }
+
+  try {
+    const child = spawn(cmd.command, cmd.args, {
+      detached: true,
+      stdio: 'ignore',
+    });
+    child.unref();
+    child.on('error', () => {
+      // Notifier binary missing — headless fallback
+      const line = formatHeadless(title, body);
+      process.stderr.write(`[claude-pager] notification command failed, falling back to stdout\n`);
+      process.stdout.write(line + '\n');
+      process.stdout.write('\x07');
+    });
+  } catch {
+    const line = formatHeadless(title, body);
+    process.stdout.write(line + '\n');
+    process.stdout.write('\x07');
+  }
+}

--- a/plugins/claude-pager/scripts/sounds.mjs
+++ b/plugins/claude-pager/scripts/sounds.mjs
@@ -1,0 +1,97 @@
+// scripts/sounds.mjs
+import { spawn } from 'node:child_process';
+
+const EVENT_DEFAULTS = {
+  idle: 'blow',
+  permission: 'funk',
+  completion: 'glass',
+};
+
+const MACOS_SOUNDS = {
+  blow: 'Blow.aiff',
+  funk: 'Funk.aiff',
+  glass: 'Glass.aiff',
+  ping: 'Ping.aiff',
+  pop: 'Pop.aiff',
+  hero: 'Hero.aiff',
+};
+
+const LINUX_SOUNDS = {
+  blow: 'dialog-warning.oga',
+  funk: 'bell.oga',
+  glass: 'dialog-information.oga',
+  ping: 'bell.oga',
+  pop: 'message-new-instant.oga',
+  hero: 'complete.oga',
+};
+
+const WINDOWS_SOUNDS = {
+  blow: 'Question',
+  funk: 'Exclamation',
+  glass: 'Asterisk',
+  ping: 'Beep',
+  pop: 'Exclamation',
+  hero: 'Hand',
+};
+
+export function resolveSound(preset, eventType) {
+  if (preset === 'default') return EVENT_DEFAULTS[eventType];
+  return preset;
+}
+
+export function buildSoundCommand(preset, platform) {
+  if (preset === 'none') return null;
+
+  if (platform === 'darwin') {
+    const file = MACOS_SOUNDS[preset];
+    if (!file) return null;
+    return { command: 'afplay', args: [`/System/Library/Sounds/${file}`] };
+  }
+
+  if (platform === 'linux') {
+    const file = LINUX_SOUNDS[preset];
+    if (!file) return null;
+    const path = `/usr/share/sounds/freedesktop/stereo/${file}`;
+    return {
+      command: 'paplay',
+      args: [path],
+      fallback: { command: 'aplay', args: [path] },
+    };
+  }
+
+  if (platform === 'win32') {
+    const name = WINDOWS_SOUNDS[preset];
+    if (!name) return null;
+    return {
+      command: 'powershell',
+      args: ['-NoProfile', '-Command', `[System.Media.SystemSounds]::${name}.Play()`],
+    };
+  }
+
+  return null;
+}
+
+export function playSound(preset, platform) {
+  const cmd = buildSoundCommand(preset, platform);
+  if (!cmd) return;
+
+  try {
+    const child = spawn(cmd.command, cmd.args, {
+      detached: true,
+      stdio: 'ignore',
+    });
+    child.unref();
+    child.on('error', () => {
+      if (cmd.fallback) {
+        const fb = spawn(cmd.fallback.command, cmd.fallback.args, {
+          detached: true,
+          stdio: 'ignore',
+        });
+        fb.unref();
+        fb.on('error', () => {});
+      }
+    });
+  } catch {
+    // Sound failure is non-fatal
+  }
+}


### PR DESCRIPTION
## Summary
  Adds **Claude Pager**, a plugin that fires native desktop notifications when a Claude Code session needs your attention — permission prompts, idle waits, or task completion. Each notification shows the project name in its title so you know which session to switch back to. Cross-platform (macOS / Linux / Windows) with a graceful stdout + terminal-bell fallback for headless/SSH sessions.
  
  ## Component Details
  - **Name**: claude-pager
  - **Type**: Hook
  - **Category**: hooks

  ## Testing
  - [x] Ran validation (`npm test`)
  - [x] Tested functionality
  - [x] No overlap with existing components

  ## Examples
  1. **Permission alert** — Claude pauses to request tool approval; you get a desktop notification titled with the project name plus a `funk` sound, so you can approve without watching the terminal.
  2. **Idle wait** — Claude finishes a turn and waits for your input; a `blow` sound + notification pulls you back to the right session.
  3. **Custom config** — In `~/.claude/settings.json`, set `"completion_enabled": "off"` to silence end-of-task pings while keeping permission/idle alerts, or set any `*_sound` to `"none"` for visual-only notifications.