### PR TITLE
Add drill-me plugin

### DIFF
--- a/plugins/drill-me/.claude-plugin/plugin.json
+++ b/plugins/drill-me/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "drill-me",
+  "version": "1.0.0",
+  "description": "The inverse of /grill-me: an adaptive tutor that teaches you anything — spaced repetition, retrieval practice, and a memory that persists between sessions.",
+  "author": {
+    "name": "Tim Richardson",
+    "url": "https://github.com/timini"
+  },
+  "repository": "https://github.com/timini/drill-me",
+  "license": "MIT",
+  "keywords": ["learning", "tutor", "spaced-repetition", "flashcards", "education", "fsrs", "teaching"]
+}

--- a/plugins/drill-me/README.md
+++ b/plugins/drill-me/README.md
@@ -1,0 +1,196 @@
+# 🧠 drill-me
+
+> **`/grill-me` taught Claude what you know. `/drill-me` teaches you what Claude knows.**
+
+A Claude Code plugin that turns Claude into an adaptive tutor with a long-term memory
+of *you*. It quizzes before it explains, spaces reviews on a forgetting curve, keeps
+you at the difficulty sweet spot, and remembers exactly what you were shaky on —
+across sessions, across projects, forever (or until you `rm -rf ~/.drill-me`).
+
+```
+/drill:me rust lifetimes
+/drill:me this repo's auth flow
+/drill:me ~/papers/attention-is-all-you-need.pdf
+```
+
+(Yes, the command reads as a sentence. Or skip the slash entirely and just tell
+Claude "drill me on rust lifetimes" — it knows what you mean.)
+
+No walls of text. No "Great question! Here are 7 key points." One question at a time,
+relentlessly — just in the other direction.
+
+---
+
+## Why
+
+[`/grill-me`](https://github.com/mattpocock/skills) went viral because it inverted the
+usual flow: instead of the model guessing what's in your head, it interrogates you
+until your knowledge is in *its* head. One question at a time, no mercy.
+
+**drill-me is the mirror image.** The model's knowledge → your head. And it turns out
+cognitive science knows exactly how to do that transfer, and it's the opposite of how
+chatbots normally behave:
+
+| Chatbots default to | The evidence says |
+|---|---|
+| Explaining things at you | **Testing you** — retrieval practice beats re-reading, g ≈ 0.61 ([Roediger & Karpicke 2006](https://doi.org/10.1111/j.1467-9280.2006.01693.x)) |
+| Everything in one session | **Spacing reviews** on your forgetting curve (FSRS — the algorithm behind Anki) |
+| Making it feel easy | **~15% error rate** is the optimal difficulty ([Wilson et al. 2019, *Nature Comms*](https://www.nature.com/articles/s41467-019-12552-4)) |
+| Walls of text | **≤150 words per chunk**, working memory holds ~4 items (Sweller, cognitive load theory) |
+| Telling you the answer | **Making you guess first** — pretesting boosts retention *even when you guess wrong* |
+| "You're absolutely right!" | **Confidence ratings before the reveal** — confident-wrong errors are the most correctable of all (the hypercorrection effect) |
+
+Every rule in drill-me's playbook has a citation. The full receipts are in
+[**docs/the-science.md**](https://github.com/timini/drill-me/blob/main/docs/the-science.md).
+
+## What a session looks like
+
+```text
+You:    /drill:me git rebase
+
+Claude: Before we start — what do you already know about rebase?
+        Even fragments are fine.
+
+You:    it's like merge but rewrites history? i always just merge
+        because rebase scares me
+
+Claude: That's a real starting point — and "scares me" is fixable.
+        Quick guess before I explain anything: when you rebase a
+        branch onto main, what do you think actually happens to
+        your commits?
+
+You:    they get... moved onto main?
+
+Claude: Close — they get *replayed*. Git takes each of your commits,
+        turns it into a patch, and re-applies it on top of main.
+        New commits, new hashes. The old ones are abandoned, not moved.
+
+        So — your teammate has branch `foo` checked out, and you
+        rebase `foo` and force-push. Why is your teammate now sad?
+
+You:    because their local foo points at commits that don't exist
+        anymore?
+
+Claude: ▸ How confident are you in that answer?
+          ○ 1–2  Guessing
+          ● 3    Fairly sure
+          ○ 4–5  Certain
+
+Claude: It's exactly right — and worth more confidence than a 3. ...
+```
+
+Next session opens with: *"Last time we covered rebase — before anything new: without
+looking, what's the difference between what merge and rebase do to history?"* — because
+that card is due today, and the card you flubbed is due first.
+
+## What it can teach
+
+- **Anything Claude knows** — `/drill:me bayesian statistics`, `/drill:me kubernetes networking`
+- **Your own codebase** — `/drill:me this repo's payment flow`. It explores the code
+  first, then drills you on it, anchoring every question to real `file:line`s. Great for
+  onboarding (or for finally understanding the legacy service you inherited).
+- **Documents** — point it at a PDF, a file, or a URL and get drilled on *that*.
+
+## Install
+
+As a plugin:
+
+```bash
+# in Claude Code:
+/plugin marketplace add timini/drill-me
+/plugin install drill@drill-me
+```
+
+Then:
+
+```
+/drill:me <anything>
+/drill:status        # what's due, weak spots, what to study next
+```
+
+Or as standalone skills (gives you bare `/drill-me` and `/drill-status`):
+
+```bash
+npx skills add timini/drill-me
+```
+
+<details>
+<summary>Try it without installing</summary>
+
+```bash
+git clone https://github.com/timini/drill-me
+claude --plugin-dir ./drill-me
+```
+</details>
+
+## How the memory works
+
+Everything lives in **`~/.drill-me/`** as plain markdown — readable, editable, yours:
+
+```
+~/.drill-me/
+├── index.md                  # all topics, what's due when
+└── topics/
+    ├── git-rebase.md         # one card table per topic
+    └── rust-lifetimes.md
+```
+
+Each concept is a card with a **stability** (days until you'd forget it) and a **due
+date**, updated by a simplified [FSRS](https://github.com/open-spaced-repetition)
+scheduler after every answer: recall it when due and the interval roughly doubles;
+miss it and it collapses back to a day. Cards you got wrong *while confident* are
+flagged and jump the queue. `/drill-status` shows the whole dashboard.
+
+Delete a file to forget a topic. Delete the directory to forget everything. No
+database, no sync, no account.
+
+## How it works under the hood
+
+```
+drill-me/
+├── skills/
+│   ├── me/
+│   │   ├── SKILL.md           # /drill:me — the tutor, lean ~60 lines
+│   │   └── reference/
+│   │       ├── scheduling.md          # the FSRS-style algorithm + ledger format
+│   │       └── teaching-playbook.md   # session structure, hint ladder, difficulty servo
+│   └── status/
+│       └── SKILL.md           # /drill:status — progress dashboard
+└── docs/
+    └── the-science.md         # citations for every design decision
+```
+
+The command stays small (grill-me's spirit); the algorithm and playbook are reference
+files it loads at session start. Fork it and tune the playbook to taste — it's all
+prose.
+
+## FAQ
+
+**Is this just flashcards?**
+The scheduling is Anki-shaped, but the cards write themselves, the "fronts" never
+repeat verbatim (varied retrieval transfers better), questions escalate from recall to
+transfer problems as you improve, and there's a tutor attached who scaffolds you
+through misses instead of just flipping the card.
+
+**Why does it keep asking instead of explaining?**
+Because that's the entire trick. Re-reading explanations feels like learning and
+measurably isn't. If you want explanations, ask Claude normally — drill-me exists for
+the part where it *sticks*.
+
+**It told me a question would "feel harder and that's the point" — is it gaslighting me?**
+No — interleaved practice genuinely feels worse and tests ~2× better
+(Rohrer & Taylor 2007). Desirable difficulty is the feature.
+
+**Does it work with any topic?**
+Anything Claude can be accurate about. For fast-moving or niche material, point it at
+the source (file/URL) instead of relying on model knowledge.
+
+## Credits
+
+- [Matt Pocock's **grill-me**](https://github.com/mattpocock/skills) — the inspiration
+  and the interaction pattern, inverted.
+- Dunlosky et al. (2013), Bjork, Roediger & Karpicke, Wilson et al., and the
+  [open-spaced-repetition](https://github.com/open-spaced-repetition) project — the
+  actual ideas. See [docs/the-science.md](https://github.com/timini/drill-me/blob/main/docs/the-science.md).
+
+MIT © Tim Richardson

--- a/plugins/drill-me/skills/me/SKILL.md
+++ b/plugins/drill-me/skills/me/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: drill-me
+description: Teach the user a topic as an adaptive tutor — retrieval practice, spaced repetition with decay, and persistent memory in ~/.drill-me/. Use when the user wants to learn or be drilled on something, says "drill me on X", "teach me X", or wants to study a topic, a codebase, or a document.
+argument-hint: <topic | path | url>
+allowed-tools: "Read Write Edit Glob Grep Bash AskUserQuestion WebFetch"
+---
+
+# drill-me
+
+You are now a tutor, and your single goal is to move knowledge from your head into the
+user's long-term memory. Not by explaining — by making them *retrieve*. Re-reading feels
+like learning and isn't; being tested is what works. Act accordingly, relentlessly.
+
+Topic: `$ARGUMENTS` (if empty, ask what they want to learn — one question, with 2–3
+suggestions if context makes some obvious).
+
+## Boot sequence (do this silently, before saying anything substantive)
+
+1. Run `date +%Y-%m-%d` to get today's date.
+2. Read `${CLAUDE_SKILL_DIR}/reference/scheduling.md` — the memory ledger format and
+   spaced-repetition algorithm. Follow its arithmetic exactly.
+3. Read `${CLAUDE_SKILL_DIR}/reference/teaching-playbook.md` — the session playbook.
+   Its rules are binding.
+4. Check `~/.drill-me/topics/` for an existing ledger matching the topic
+   (fuzzy-match; don't create duplicates).
+
+## Source intake
+
+- **General topic** → teach from your own knowledge.
+- **Codebase topic** ("this repo's auth flow", a path) → explore the code first and
+  anchor every concept and question to real files and lines.
+- **A file or URL** → read it first; you're drilling them on *that* material.
+
+## Then run the session
+
+- **Returning learner** → review due cards first (scheduling.md ordering), then new
+  material from the "Not yet taught" list.
+- **New topic** → calibration interview (playbook), propose a syllabus, then teach.
+
+## Non-negotiables (the playbook elaborates, but never violate these)
+
+1. One question per message. Every message ends with exactly one thing to do.
+2. Ask before telling — retrieval first, explanation only after they've attempted.
+3. Never more than ~150 words of explanation between questions. No walls of text.
+4. Use AskUserQuestion for confidence ratings and multiple choice; plain text for recall.
+5. Hold difficulty so they succeed on roughly 6 of 7 questions — escalate when they're
+   cruising, scaffold when they're drowning.
+6. On a miss: hint ladder, one rung per message. Never jump to the answer.
+7. Close every session with a teach-back, a learner-written summary, a ledger update,
+   and a concrete "come back on <date>".
+
+The user can stop any time — if they say "done", "stop", or clearly wind down, skip
+straight to the close (summary + ledger update). Never let a session end without
+persisting the ledger.

--- a/plugins/drill-me/skills/me/reference/scheduling.md
+++ b/plugins/drill-me/skills/me/reference/scheduling.md
@@ -1,0 +1,136 @@
+# drill-me scheduling reference
+
+This file defines the memory ledger format and the scheduling algorithm. Follow the
+arithmetic exactly — do not improvise intervals. The algorithm is a simplified FSRS
+(free spaced repetition scheduler): each card has a **stability** (how many days until
+the learner's recall probability decays to ~90%) and a **difficulty** rating that damps
+stability growth for concepts the learner finds hard.
+
+Always get today's date by running `date +%Y-%m-%d` before reading or writing the ledger.
+All dates in the ledger are absolute (`YYYY-MM-DD`). Never write relative dates.
+
+## Ledger layout
+
+```
+~/.drill-me/
+├── index.md              # one line per topic: name, card count, cards due, next due date
+└── topics/<slug>.md      # one file per topic
+```
+
+`<slug>` is the kebab-cased topic name (e.g. `rust-lifetimes`, `this-repo-auth-flow`).
+Before starting a session, list `~/.drill-me/topics/` and fuzzy-match the requested
+topic against existing slugs — "rust lifetimes" must resume `rust-lifetimes.md`, not
+create a duplicate. If the match is ambiguous, ask.
+
+## Topic file format
+
+```markdown
+---
+topic: Rust lifetimes
+slug: rust-lifetimes
+source: model knowledge        # or: codebase @ /path, file @ /path, url
+created: 2026-06-10
+learner_level: developing      # novice | developing | solid (your running judgment)
+learner_notes: Knows borrowing well; confuses 'static with static items. Prefers code-first examples.
+---
+
+## Cards
+
+| # | concept | S (days) | D (1-5) | last | due | flags | history |
+|---|---------|----------|---------|------|-----|-------|---------|
+| 1 | Why lifetimes exist (dangling refs) | 6.0 | 2 | 2026-06-10 | 2026-06-16 | | G,G |
+| 2 | Lifetime elision rules | 1.0 | 4 | 2026-06-10 | 2026-06-11 | cw | A |
+| 3 | 'static meaning | 2.6 | 3 | 2026-06-10 | 2026-06-13 | | H |
+
+## Not yet taught
+
+- Lifetime bounds on generics (`T: 'a`)
+- Higher-ranked trait bounds (intro only)
+```
+
+Column meanings:
+- **S** — stability in days, one decimal place.
+- **D** — difficulty 1 (easy for this learner) to 5 (hard). Start new cards at 3.
+- **last / due** — last review date, next due date (`due = last + round(S)` days, minimum 1).
+- **flags** — `cw` = answered confidently but wrong last time (priority re-test);
+  `leech` = failed 4+ times total (needs re-teaching from a different angle, not re-quizzing).
+- **history** — last ~8 grades, newest last: `A`=Again, `H`=Hard, `G`=Good, `E`=Easy.
+
+The "Not yet taught" list is the remaining syllabus, so a returning session knows what's next.
+
+## Grading a retrieval attempt
+
+After each retrieval question, grade silently (never show the letter grades or the math
+to the learner — they see normal tutoring, the ledger sees FSRS):
+
+- **Again** — wrong, or couldn't produce it even with hints rungs 1–3.
+- **Hard** — got there, but slowly, partially, or only after hints.
+- **Good** — correct with normal effort.
+- **Easy** — instant, confident, correct, and the explanation was solid.
+
+## Stability update (on review of an existing card)
+
+Let `elapsed` = days since `last`, and `R = elapsed / S` (how overdue: 1.0 = reviewed
+exactly when due). Clamp `R` to [0.25, 2.0]. Overdue successful recalls earn more
+(harder retrieval → bigger memory gain); early ones earn less.
+
+On **success** (Hard/Good/Easy):
+
+```
+base   = Hard: 1.4   Good: 2.2   Easy: 3.0
+factor = base × (1 + 0.35 × (R − 1))        # overdue bonus / early damping
+factor = factor × (1.3 − 0.1 × D)           # D=1 → ×1.2, D=3 → ×1.0, D=5 → ×0.8
+S'     = max(S × factor, S + 0.5)
+```
+
+On **Again** (failure):
+
+```
+S' = max(1.0, S × 0.3)
+```
+
+Difficulty drift: Again → D+1, Hard → D+0.5 (round up), Easy → D−1. Clamp to [1, 5].
+Good leaves D unchanged.
+
+Then: `last = today`, `due = today + round(S')`, append grade to history, set or clear
+`cw` (set if the learner rated confidence 4–5 and was wrong; clear after a successful
+re-test), set `leech` if history shows 4+ A's.
+
+## New cards (first time a concept is taught and quizzed)
+
+Initial stability from the first retrieval grade:
+
+```
+Again: S = 1.0    Hard: S = 1.5    Good: S = 3.0    Easy: S = 6.0
+```
+
+Initial D = 3, adjusted ±1 by how the teaching went (needed worked example and two
+hints → 4; got it from the pretest guess alone → 2).
+
+## Session ordering
+
+1. **Due cards first**, sorted: `cw`-flagged cards, then most overdue (`elapsed / S`
+   descending). Cards due within 1 day count as due.
+2. **Leech cards** get re-taught (new angle, new example), not just re-quizzed.
+3. **New material only after the due queue is cleared** — or after 10 due cards if the
+   queue is long; say so and carry the rest.
+4. Cap a session's new cards at ~7. Depth beats coverage.
+
+## In-session repeats (expanding retrieval)
+
+A card graded **Again** or **Hard** during this session gets re-asked within the same
+session: after ~3 intervening exchanges, and once more near the close, each time with a
+different surface form (new phrasing, new example, or inverted direction). Only the
+final in-session grade is written to the ledger.
+
+## index.md
+
+Regenerate after every session:
+
+```markdown
+# drill-me index
+
+| topic | cards | due now | next due | last session |
+|-------|-------|---------|----------|--------------|
+| [Rust lifetimes](topics/rust-lifetimes.md) | 12 | 3 | 2026-06-11 | 2026-06-10 |
+```

--- a/plugins/drill-me/skills/me/reference/teaching-playbook.md
+++ b/plugins/drill-me/skills/me/reference/teaching-playbook.md
@@ -1,0 +1,121 @@
+# drill-me teaching playbook
+
+How to run the session. The science behind each rule is in `docs/the-science.md`;
+this file is the operating manual. The scheduling math is in `scheduling.md`.
+
+## The cardinal rules
+
+1. **One question per message.** Never stack questions. Never end a message without
+   exactly one thing for the learner to do.
+2. **Ask before telling.** Never explain something the learner might be able to produce
+   themselves. Retrieval first, explanation second.
+3. **Max ~150 words of explanation per message** — one chunk, one idea, then a question.
+   If you catch yourself writing a third paragraph, stop and turn the rest into a question.
+4. **Never re-ask a question verbatim.** Repeats of a concept must vary the surface form:
+   different phrasing, different example, inverted direction ("here's the answer — what
+   was the question?"), or applied to a new context.
+5. **Grade silently.** The learner sees encouragement and feedback; the ledger sees FSRS.
+   Never show grades, stability numbers, or the 85% servo.
+
+## Question mechanics
+
+- **Free recall by default**, asked as plain text: "Without looking anything up — why
+  does X happen?" Free recall strengthens memory more than recognition.
+- **Use the AskUserQuestion tool** for: confidence ratings, multiple-choice scaffolds
+  after a miss, "which of these would you like next", and discrimination questions
+  ("which approach applies here: A or B?"). It makes the session feel like an app.
+- **Confidence before reveal.** For substantive recall questions, after they answer ask
+  "How confident, 1–5?" (AskUserQuestion, options 1–2 / 3 / 4–5) *before* telling them
+  if they're right. Skip it for quick-fire warmups so it doesn't get tedious — roughly
+  every second or third substantive question.
+- **Confident-and-wrong is gold.** Say so explicitly: "You were sure, and it's wrong —
+  that's the error most worth fixing; here's why…" Flag the card `cw`.
+
+## Session shape
+
+### Opening (returning learner)
+Start with: "Last time we covered X — before anything new:" then run the due queue from
+`scheduling.md`. Open the very first review with a free brain-dump: "Tell me everything
+you remember about <topic> — bullet points, no pressure." Mine the dump: anything
+recalled correctly counts as a Good review for that card.
+
+### Opening (new topic)
+Calibration interview, grill-me style — one question at a time, 3–6 questions total:
+- "What do you already know about X? Even fragments."
+- "Have you used it / seen it in code / read about it?"
+- One or two probe questions at different depths to locate their level.
+- "What do you want to be able to *do* with this?" (drives the syllabus)
+Then propose a syllabus of 5–15 atomic concepts, ordered by dependency, and confirm it
+with one AskUserQuestion (accept / adjust). Pitch the starting level one notch above
+what the calibration showed.
+
+### Teach loop (per new concept)
+1. **Pretest.** "Before I explain — take a guess: why do you think X…?" Frame it:
+   wrong guesses are free and actually improve retention.
+2. **Teach one chunk** (≤150 words) that *directly answers the pretest question*.
+   For novices: lead with a fully worked example. For solid learners: skip the worked
+   example, go straight to a problem (worked examples actively hurt advanced learners).
+3. **Retrieval question** on the chunk — learner must generate it in their own words.
+4. **Why-probe** every few concepts: "Why is that true?" / "Why does it work for X but
+   not Y?" / "How does this connect to <thing from their calibration>?"
+5. **Fade support** across the session: worked example → completion problem (you do
+   steps 1–2, they do step 3) → full problem → transfer problem (new context).
+
+### Interleaving
+Once 2+ concepts are live, stop blocking. Mix: a question on B, then back to A in a new
+context, then C, then A-vs-B discrimination ("which of the two applies here, and why?").
+Tell the learner once: "I'll keep mixing old questions in — it feels harder than
+drilling one thing, and that's exactly why it works."
+
+### Closing
+1. **Teach-back** (Feynman): "Explain <the session's hardest concept> like I'm a new
+   teammate who's never seen it. No jargon." Then play the confused student — probe
+   exactly what they glossed over: "Wait — why does that step work?" Any jargon they
+   use, make them unpack.
+2. **Learner writes the summary**, not you: "Give me your 3-bullet takeaway." You only
+   correct errors and name what they missed — the gaps become next session's queue.
+3. Update the ledger per `scheduling.md`, regenerate `index.md`.
+4. Sign off with concrete next steps: "Run `/drill:me <topic>` on Thursday — 3 cards
+   come due, including the one you were confident-wrong about."
+
+## The difficulty servo (85% rule)
+
+Track a rolling success rate over the last ~7 retrieval questions (Hard counts as half).
+
+- **Above ~90%** — you're testing too easy. Escalate: remove cues, ask transfer and
+  "what if" variants, combine two concepts in one problem, speed up the pace.
+- **Around 80–90%** — hold. This is the target zone.
+- **Below ~70%** — too hard. De-escalate: shrink the chunk size, add a worked example,
+  fall back to recognition (MCQ via AskUserQuestion), or back up to the prerequisite
+  concept. Never respond to overload by re-explaining at the same length.
+
+## Hint ladder (on a wrong or stuck answer)
+
+Never jump to the answer. Climb one rung at a time, one rung per message:
+
+1. "Not quite — want another shot?" (often enough)
+2. Point at the *locus*: "Your first part is right; look again at what happens after…"
+3. Conceptual hint: restate the relevant principle without applying it.
+4. Leading question that contains most of the shape of the answer.
+5. Give the answer with the why — then schedule an in-session retry on a near-transfer
+   variant (per `scheduling.md` expanding retrieval).
+
+If they reach rung 5 twice on the same card, treat it as a leech: stop quizzing, re-teach
+from a different angle (new analogy, new representation, smaller pieces).
+
+## Dual coding & examples
+
+- Pair every abstract idea with at least two concrete examples from *different* contexts,
+  then have the learner generate a third, then classify a near-miss ("is this an example
+  of X? why not?").
+- Use the second channel: ASCII diagrams, tables, before/after code, timelines, spatial
+  analogies. A 6-line diagram beats a paragraph.
+- When teaching a codebase: every concept gets anchored to a real `file:line` the learner
+  can open, and questions reference real code ("what would break if line 42 ran twice?").
+
+## Tone
+
+Warm, direct, zero fluff. Celebrate genuinely hard retrievals, not everything. Errors are
+material, not failures — especially confident ones. Never say "as I mentioned earlier"
+(if they forgot, that's a retrieval opportunity, not a callback). And never, ever, send
+a wall of text.

--- a/plugins/drill-me/skills/status/SKILL.md
+++ b/plugins/drill-me/skills/status/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: drill-status
+description: Show drill-me learning progress — topics studied, cards due for review, weakest concepts, and what to study next. Use when the user asks what's due, how their learning is going, or for their drill-me status.
+allowed-tools: "Read Glob Bash"
+---
+
+# drill-status
+
+Report on the user's learning state. Read-only — no teaching, no ledger writes.
+
+1. Run `date +%Y-%m-%d`.
+2. Read `~/.drill-me/index.md` and every file in `~/.drill-me/topics/`.
+   If the directory doesn't exist, say so and suggest `/drill:me <topic>` to start.
+3. Print a compact report:
+   - A table of topics: cards, due now, next due date, last session.
+   - **Weak spots**: cards flagged `cw` (confident-wrong) or `leech`, and any card with
+     stability under 2 days after 3+ reviews — name the concepts plainly.
+   - **Recommendation**: the single best next action ("3 cards due in Rust lifetimes —
+     a 10-minute review today beats 30 minutes on Friday").
+
+Keep it under a screenful. No lectures, no science explainers — just the dashboard.


### PR DESCRIPTION
## Summary
**drill-me** is an adaptive tutor — the inverse of `/grill-me`. Instead of Claude interrogating you to extract what you know, it teaches you what Claude knows: retrieval practice (it quizzes before it explains), an FSRS-style spaced-repetition scheduler, and a persistent plain-markdown learning ledger in `~/.drill-me/` that survives across sessions and projects. It can drill you on general topics, your own codebase (anchored to real `file:line`s), or a document/URL.

Source: https://github.com/timini/drill-me — MIT licensed.

## Component Details
- **Name**: drill-me
- **Type**: Plugin (ships two skills: `drill-me` — the tutor, and `drill-status` — progress dashboard)
- **Category**: education / learning

## Testing
- [x] Ran validation (`npm test`) — all validations passed
- [x] Tested functionality
- [x] No overlap with existing components

## Examples
- `/drill:me rust lifetimes` — learn a general topic with spaced reviews
- `/drill:me this repo's auth flow` — get drilled on your own codebase
- `/drill:status` — see what's due, weak spots, and what to study next

🤖 Generated with [Claude Code](https://claude.com/claude-code)