### PR TITLE
Fix kegg-mcp-server .mcp.json: wrap config in mcpServers key

### DIFF
--- a/plugins/kegg-mcp-server/.mcp.json
+++ b/plugins/kegg-mcp-server/.mcp.json
@@ -1,6 +1,8 @@
 {
-  "kegg": {
-    "command": "uvx",
-    "args": ["kegg-mcp-server"]
+  "mcpServers": {
+    "kegg": {
+      "command": "uvx",
+      "args": ["kegg-mcp-server"]
+    }
   }
 }


### PR DESCRIPTION
## Problem

The vendored `plugins/kegg-mcp-server/.mcp.json` defines the server at the top level:

```json
{
  "kegg": { "command": "uvx", "args": ["kegg-mcp-server"] }
}
```

The Claude Code plugin spec requires server definitions under a top-level `mcpServers` key. Without it, `/plugin install` registers the plugin but finds no `mcpServers` map, so the `kegg` server (and its tools) never load. This matches the format already used by other plugins here (e.g. `cashflow`, `mortgage`).

## Fix

```json
{
  "mcpServers": {
    "kegg": { "command": "uvx", "args": ["kegg-mcp-server"] }
  }
}
```

Same fix was just merged upstream in the source repo (`Lucas-Servi/kegg-mcp-server-python`). No other changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)