### PR TITLE
Add claude-pager to marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -100,6 +100,30 @@
       "source": "./plugins/claude-hud"
     },
     {
+      "name": "claude-pager",
+      "description": "Native desktop notifications when Claude Code needs your attention",
+      "version": "1.0.0",
+      "author": {
+        "name": "Bharat Gupta",
+        "url": "https://github.com/bharat7gupta"
+      },
+      "repository": "https://github.com/bharat7gupta/claude-pager",
+      "license": "MIT",
+      "keywords": [
+        "notifications",
+        "alerts",
+        "desktop",
+        "sound",
+        "pager",
+        "idle",
+        "permission",
+        "task-completion",
+        "productivity"
+      ],
+      "category": "hooks",
+      "source": "./plugins/claude-pager"
+    },
+    {
       "name": "slopmop",
       "description": "Quality gates for AI-assisted codebases. Provides refit onboarding, the swab/scour/buff/sail remediation loop, and barnacle friction reporting as a Claude skill and slash commands.",
       "version": "1.1.0",


### PR DESCRIPTION
Registers the claude-pager plugin in the marketplace listing so it surfaces on the site's /plugins page.

## Summary
  Follow-up to the merged [claude-pager PR](https://github.com/davepoon/buildwithclaude/pull/177): registers the plugin in
  `.claude-plugin/marketplace.json` so it surfaces on the site's /plugins listing.

  ## Component Details
  - **Name**: claude-pager
  - **Type**: Hook
  - **Category**: hooks

  ## Testing
  - [x] Ran validation (`npm test`)
  - [x] No overlap with existing components

  ## Examples
  Single entry added after `claude-hud`, pointing at the existing
  `./plugins/claude-pager` source — no plugin code changes.