### PR TITLE
Add glitchwerks plugins (wayfinder, prospector, github-tools)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1615,6 +1615,85 @@
       ],
       "category": "mcp-servers",
       "source": "./plugins/kegg-mcp-server"
+    },
+    {
+      "name": "claude-wayfinder",
+      "description": "Helps Claude make deterministic, auditable choices about which agent and skills to use for a given task — replacing prose-scanning agent/skill selection with a typed scoring kernel that returns one of seven typed decisions with confidence, rationale, and alternatives.",
+      "version": "1.2.0",
+      "author": {
+        "name": "Christopher Beaulieu",
+        "url": "https://github.com/glitchwerks"
+      },
+      "homepage": "https://github.com/glitchwerks/claude-wayfinder",
+      "repository": "https://github.com/glitchwerks/claude-wayfinder",
+      "license": "MIT",
+      "keywords": [
+        "dispatch",
+        "routing",
+        "matcher",
+        "claude-code",
+        "deterministic",
+        "agent-selection",
+        "auditable"
+      ],
+      "category": "orchestration",
+      "source": {
+        "source": "github",
+        "repo": "glitchwerks/claude-wayfinder"
+      }
+    },
+    {
+      "name": "claude-prospector",
+      "description": "Claude Code efficiency and hygiene toolkit. Surfaces token spend across the 5h / 7d / Sonnet-7d billing windows with per-model / per-agent / per-skill attribution, and audits your effective Claude Code configuration (custom + plugin agents and skills) for overlap and conflicts. Ships an interactive dashboard, a conversational usage-analysis skill, and a structured config-audit skill.",
+      "version": "0.10.0",
+      "author": {
+        "name": "Christopher Beaulieu",
+        "url": "https://github.com/glitchwerks"
+      },
+      "homepage": "https://github.com/glitchwerks/claude-prospector",
+      "repository": "https://github.com/glitchwerks/claude-prospector",
+      "license": "MIT",
+      "keywords": [
+        "claude-code",
+        "usage",
+        "tokens",
+        "billing",
+        "dashboard",
+        "observability",
+        "audit",
+        "config-hygiene"
+      ],
+      "category": "monitoring",
+      "source": {
+        "source": "github",
+        "repo": "glitchwerks/claude-prospector"
+      }
+    },
+    {
+      "name": "claude-github-tools",
+      "description": "GitHub workflow skills for Claude Code - issue creation, PR review triage, backlog summaries/quick-wins, release status, and GitHub Actions authoring. Seven skills; three pure-LLM, four script-backed via an auto-materialized plugin venv.",
+      "version": "0.3.0",
+      "author": {
+        "name": "Christopher Beaulieu",
+        "url": "https://github.com/glitchwerks"
+      },
+      "homepage": "https://github.com/glitchwerks/claude-github-tools",
+      "repository": "https://github.com/glitchwerks/claude-github-tools",
+      "license": "MIT",
+      "keywords": [
+        "claude-code",
+        "github",
+        "issues",
+        "pull-requests",
+        "github-actions",
+        "ci",
+        "workflow"
+      ],
+      "category": "productivity",
+      "source": {
+        "source": "github",
+        "repo": "glitchwerks/claude-github-tools"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary

Registers three Claude Code plugins from the glitchwerks marketplace as **github-source references** in `.claude-plugin/marketplace.json`. Each entry is self-contained — Claude Code resolves `<name>@buildwithclaude` by cloning the referenced repo and reading its own `plugin.json`, so no local stub under `plugins/` is required (matching the existing stub-less `backlogd` github-source entry). Single-file change, +79 lines.

## Component Details

| Name | Type | Category | Source |
|---|---|---|---|
| `claude-wayfinder` | Plugin (skills + hooks) | orchestration | `github:glitchwerks/claude-wayfinder` |
| `claude-prospector` | Plugin (skills + hooks) | monitoring | `github:glitchwerks/claude-prospector` |
| `claude-github-tools` | Plugin (skills + hooks) | productivity | `github:glitchwerks/claude-github-tools` |

- **claude-wayfinder** — a typed, auditable dispatch matcher: deterministic agent/skill selection returning one of seven typed decisions with confidence and rationale.
- **claude-prospector** — Claude Code token-spend observability (per-model/agent/skill across the 5h/7d/Sonnet-7d windows) plus a config overlap/conflict audit.
- **claude-github-tools** — seven GitHub workflow skills: issue creation, PR review triage, backlog quick-wins/summaries, release status, and GitHub Actions authoring.

## Testing

- [x] `marketplace.json` parses as valid JSON; 66 plugins total, all three new entries present
- [x] Ran `node scripts/validate-all.js` — **Skills** and **Hooks** validators pass; the **Subagents & Commands** validator reports the same 510 pre-existing errors on `main` (in the `all-commands`/`all-agents` bundles), unchanged by this PR. This change touches only `marketplace.json` and adds zero new validation errors.
- [x] No overlap — none of the three names exist in the marketplace today

## Examples

```text
/plugin marketplace add davepoon/buildwithclaude
/plugin install claude-wayfinder@buildwithclaude
/plugin install claude-prospector@buildwithclaude
/plugin install claude-github-tools@buildwithclaude
```

Each installs directly from its upstream glitchwerks repo.

🤖 Generated by Claude Code on behalf of @cbeaulieu-gt