### PR TITLE
Add gcf-proxy plugin

### DIFF
--- a/plugins/gcf-proxy/.claude-plugin/plugin.json
+++ b/plugins/gcf-proxy/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "gcf-proxy",
+  "description": "Save 71% on MCP tool call tokens. Wraps any MCP server with GCF encoding, zero code changes. Session stats hook shows savings per turn.",
+  "version": "1.0.0",
+  "author": {
+    "name": "Blackwell Systems",
+    "url": "https://blackwell-systems.com"
+  }
+}

--- a/plugins/gcf-proxy/README.md
+++ b/plugins/gcf-proxy/README.md
@@ -1,0 +1,18 @@
+# GCF Proxy
+
+Save 71% on MCP tool call tokens. Wraps any MCP server with GCF encoding, zero code changes.
+
+Install: `/plugin install blackwell-systems/gcf-claude-plugin`
+
+Skills:
+- `/gcf-proxy:setup <server>` - Wrap any MCP server with gcf-proxy
+- `/gcf-proxy:stats` - Show token savings for the current session
+
+Session stats hook shows calls rewritten, % saved, and tokens saved after each turn.
+
+100% comprehension accuracy across 1,700+ LLM evaluations, 10+ models, 3 providers.
+
+- [GitHub](https://github.com/blackwell-systems/gcf-claude-plugin)
+- [GCF Proxy](https://github.com/blackwell-systems/gcf-proxy)
+- [Benchmarks](https://gcformat.com/guide/benchmarks.html)
+- [Cost Calculator](https://gcformat.com/calculator)


### PR DESCRIPTION
## Summary
- Adds gcf-proxy plugin: wraps any MCP server with GCF encoding, saving 71% on tool call tokens
- Two skills (`/gcf-proxy:setup`, `/gcf-proxy:stats`) and a session stats hook
- 100% comprehension accuracy across 1,700+ LLM evaluations, 10+ models, 3 providers

## Component Details
- **Name**: gcf-proxy
- **Type**: Plugin (skills + hooks)
- **Category**: Token optimization / MCP

## Testing
- [x] Tested plugin loading in Claude Code (`--plugin-dir`)
- [x] Both skills appear in slash commands
- [x] E2E verified: proxy wraps MCP server, tool calls work, stats file written
- [x] No overlap with existing components

## Examples

```
/gcf-proxy:setup github       # Wrap the github MCP server
/gcf-proxy:stats              # Show session token savings
```

After each turn, the Stop hook shows:
```
gcf-proxy: 12 tool calls rewritten, 68% fewer tokens (~4.2K tokens saved)
```

**Links:**
- [Plugin repo](https://github.com/blackwell-systems/gcf-claude-plugin)
- [GCF Proxy](https://github.com/blackwell-systems/gcf-proxy)
- [Benchmarks](https://gcformat.com/guide/benchmarks.html)