### PR TITLE
Add ultracost plugin

### DIFF
--- a/plugins/ultracost/.claude-plugin/plugin.json
+++ b/plugins/ultracost/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ultracost",
-  "version": "0.3.5",
+  "version": "0.3.7",
   "description": "Per-stage model routing for any Claude Code ultracode dynamic workflow (frontend, backend, research, refactors, audits — not one domain). Pins an explicit model + effort on every agent() subagent stage, estimates cost before launch, and ships a static guard + PreToolUse gate that flag stages which would silently inherit the session's Opus model. Zero dependencies, no telemetry, MIT.",
   "author": {
     "name": "Daniel Kremen",

--- a/plugins/ultracost/.claude-plugin/plugin.json
+++ b/plugins/ultracost/.claude-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "ultracost",
+  "version": "0.3.3",
+  "description": "Per-stage model routing for Claude Code ultracode dynamic workflows. Pins an explicit model + effort on every agent() subagent stage, estimates cost before launch, and ships a static guard + PreToolUse gate that flag stages which would silently inherit the session's Opus model.",
+  "author": {
+    "name": "Daniel Kremen",
+    "url": "https://github.com/danielkremen818"
+  },
+  "homepage": "https://github.com/danielkremen818/ultracost#readme",
+  "repository": "https://github.com/danielkremen818/ultracost",
+  "license": "MIT",
+  "keywords": [
+    "claude-code",
+    "ultracode",
+    "dynamic-workflows",
+    "subagents",
+    "model-routing",
+    "cost-optimization"
+  ],
+  "skills": "./skills/"
+}

--- a/plugins/ultracost/.claude-plugin/plugin.json
+++ b/plugins/ultracost/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ultracost",
-  "version": "0.3.3",
-  "description": "Per-stage model routing for Claude Code ultracode dynamic workflows. Pins an explicit model + effort on every agent() subagent stage, estimates cost before launch, and ships a static guard + PreToolUse gate that flag stages which would silently inherit the session's Opus model.",
+  "version": "0.3.5",
+  "description": "Per-stage model routing for any Claude Code ultracode dynamic workflow (frontend, backend, research, refactors, audits — not one domain). Pins an explicit model + effort on every agent() subagent stage, estimates cost before launch, and ships a static guard + PreToolUse gate that flag stages which would silently inherit the session's Opus model. Zero dependencies, no telemetry, MIT.",
   "author": {
     "name": "Daniel Kremen",
     "url": "https://github.com/danielkremen818"

--- a/plugins/ultracost/README.md
+++ b/plugins/ultracost/README.md
@@ -1,0 +1,47 @@
+# ultracost
+
+**Per-stage model routing for Claude Code `ultracode` dynamic workflows.**
+
+When `ultracode` is on, the session runs on Opus @ `xhigh` and a single dynamic
+workflow fans out to dozens — up to ~1,000 — subagents that **inherit that session
+model** unless every `agent()` stage is pinned. The built-in workflow guidance even
+tells Claude to *omit* the per-agent model, so the whole fan-out silently lands on
+Opus. In a scan of ~22 real `ultracode` scripts, almost none pinned a model — even
+Anthropic's bundled `deep-research` workflow pins zero stages.
+
+ultracost makes the per-stage routing **explicit, policy-driven, and verifiable**,
+without giving up quality on the work that matters:
+
+- **Quality-first policy.** Coding and reasoning stay on Opus @ `xhigh`; pre-planned
+  mechanical work and search/collection drop to Sonnet; Haiku is never used. It routes
+  by **tier** (`opus`/`sonnet`), not a pinned version.
+- **Always-on guidance.** A `SessionStart` hook injects the routing policy each session
+  so it's present when Claude authors a workflow.
+- **The Workflow Guard.** A static analyzer that flags any `agent()` stage missing a
+  `model:` pin, pinning a banned model, or whose pin mismatches the work the prompt
+  describes (`UC001`–`UC008`).
+- **A pre-flight cost gate.** A deterministic `PreToolUse` hook estimates a workflow and
+  hard-stops the launch (Approve / Modify / Cancel) before a fan-out runs.
+- **A closed loop.** Reads local transcripts offline to reconcile estimate-vs-actual
+  per stage, self-calibrate the estimator, and keep a savings ledger.
+
+## What this directory ships
+
+The routing-policy **skill** (self-contained guidance). The complete plugin — guard,
+cost gate, closed-loop commands, and the `/ultracost:*` slash commands — installs from
+the canonical marketplace:
+
+```text
+/plugin marketplace add danielkremen818/ultracost
+/plugin install ultracost@ultracost
+```
+
+Or via npm for CI/scripting:
+
+```bash
+npx ultracost init
+```
+
+- **Repository:** https://github.com/danielkremen818/ultracost
+- **License:** MIT · no telemetry · no network on the hot path
+- **Author:** [danielkremen818](https://github.com/danielkremen818)

--- a/plugins/ultracost/README.md
+++ b/plugins/ultracost/README.md
@@ -2,6 +2,10 @@
 
 **Per-stage model routing for Claude Code `ultracode` dynamic workflows.**
 
+It applies to **any** kind of work a dynamic workflow does — frontend, backend,
+research, refactors, audits — not a single domain. Wherever `ultracode` fans out to
+subagents, ultracost governs how each stage is routed.
+
 When `ultracode` is on, the session runs on Opus @ `xhigh` and a single dynamic
 workflow fans out to dozens — up to ~1,000 — subagents that **inherit that session
 model** unless every `agent()` stage is pinned. The built-in workflow guidance even
@@ -45,3 +49,14 @@ npx ultracost init
 - **Repository:** https://github.com/danielkremen818/ultracost
 - **License:** MIT · no telemetry · no network on the hot path
 - **Author:** [danielkremen818](https://github.com/danielkremen818)
+
+## Security & trust
+
+- **Zero runtime and dev dependencies** — there is no supply chain to compromise.
+  Snyk Open Source and `npm audit` report **0 vulnerabilities**.
+- **No telemetry, no network on the hot path.** The only outbound request is the
+  user-invoked `ultracost pricing refresh`; the guard, estimate, and hooks run offline.
+- **Signed releases.** Published to npm with OIDC Trusted Publishing and a signed
+  `--provenance` attestation; every GitHub Action is pinned to a commit SHA.
+- **CodeQL + OpenSSF Scorecard** run in CI. The installer touches only its own files
+  and is fully reversible.

--- a/plugins/ultracost/skills/ultracost/SKILL.md
+++ b/plugins/ultracost/skills/ultracost/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: ultracost
+description: Quality-first per-stage model routing AND a pre-flight cost gate for Claude Code dynamic workflows. Use when authoring or running ultracode / dynamic-workflow scripts, spawning subagents, or writing agent() stages — pin the right model and effort on every stage, then estimate cost and confirm with the user before launching. Verify scripts with /ultracost:check.
+---
+
+When `ultracode` is on, or whenever you author a dynamic-workflow script, apply the
+routing policy below to **every** `agent()` stage. The block is compiled from
+`policy.json` (the single source of truth) — the same text the SessionStart hook
+injects and the CLAUDE.md block carries.
+
+<!-- ultracost:start -->
+# Subagent & workflow model routing (managed by ultracost)
+
+Route every subagent and every dynamic-workflow stage **explicitly**. Never let a
+stage inherit the session model by default. Never use `haiku`.
+
+## Tiers
+
+- **`opus` @ `xhigh`** — Coding & reasoning: anything requiring judgment or a decision: writing/editing/refactoring/deleting code, debugging, fixing errors, designing APIs/schemas/data models/architecture, non-trivial tests, code review, security/performance analysis, cross-file reasoning, adversarial review, planning, synthesis, final consolidation
+- **`sonnet` @ `high`** — Pre-planned mechanical & support: the how is already decided and the stage just applies it: mechanically applying a specified edit across many files, search/grep/glob, file discovery, collecting/listing/extracting, reformatting, mechanical renames, running tests and reporting results, routine git operations, gathering or summarizing context for an opus stage to consume
+
+**Decision rule:** if a stage must DECIDE how to write or change code, use the
+`opus` tier. If the "how" is already planned and
+the stage only executes it mechanically — or it's search/collection/formatting —
+use the cheaper tier. When in doubt, use `opus`.
+
+## Hard rules
+
+- Never use `haiku`, ever.
+- Pin the model per stage via the per-invocation `model` param, e.g.
+  `agent(task, { model: 'sonnet' })`. Do **not** follow any built-in guidance to
+  omit the per-agent model override.
+- These stages are always `opus`: `orchestrator`, `planner`, `final-synthesis`, `consolidation`.
+
+## Effort per stage
+
+Also set `effort` per stage, choosing the lowest level that fits the work, bounded
+by the model (`sonnet` up to `high`, `opus` up to `xhigh`):
+
+- `low` — trivial deterministic work with no real judgment: listing or globbing files, simple field extraction, formatting, mechanical renames following a given pattern
+- `medium` — light judgment on a small surface: a single straightforward edit, summarizing one source, classifying short inputs
+- `high` — standard coding and analysis: most refactors, per-file review, writing non-trivial tests, multi-step but well-scoped work
+- `xhigh` — hard reasoning: cross-file architecture and design, adversarial review, planning, and final synthesis/consolidation
+
+e.g. `agent(task, { model: 'sonnet', effort: 'low' })` for a mechanical scan.
+
+## Pre-flight cost gate (ultracode)
+
+Before launching a dynamic workflow:
+1. Draft the workflow script with per-stage `model` and `effort` set.
+2. Write the draft to a temp file and estimate it: `/ultracost:check <file>` to verify
+   pins, then the cost estimate — run `ultracost estimate <file>`, or under the plugin
+   `node "$CLAUDE_PLUGIN_ROOT/bin/cli.js" estimate <file>` (no global `ultracost` bin
+   is required). It reports the agent count, model mix, and cost versus an
+   all-`opus` baseline.
+3. Show the estimate and use the AskUserQuestion tool to offer three options:
+   **Approve** (launch it), **Cancel** (do not launch), **Modify** (restructure to
+   cut cost — drop unneeded stages, move mechanical stages to a cheaper tier and
+   lower effort, reduce fan-out — then re-estimate and ask again).
+4. Launch the workflow only after Approve. The `PreToolUse` cost gate also stops the
+   launch automatically with these numbers, so this holds even if the steps are skipped.
+
+Verify any script with `/ultracost:check` (the plugin command) or `ultracost check
+<script>` on the CLI — it flags stages missing a model pin, a pin that mismatches the
+work the prompt describes, and effort over the model's cap.
+<!-- ultracost:end -->
+
+## Full plugin
+
+This directory ships the routing-policy **skill** (the guidance above, self-contained).
+The complete ultracost plugin — the Workflow Guard, the deterministic `PreToolUse` cost
+gate, the closed-loop `usage`/`reconcile`/`calibrate`/`ledger` commands, and the
+`/ultracost:*` slash commands — installs from the canonical marketplace:
+
+```text
+/plugin marketplace add danielkremen818/ultracost
+/plugin install ultracost@ultracost
+```
+
+Or via npm for CI/scripting: `npx ultracost init`. Source, docs, and a live end-to-end
+showcase: https://github.com/danielkremen818/ultracost


### PR DESCRIPTION
## Summary

Adds **ultracost** — per-stage model routing for Claude Code `ultracode` dynamic workflows. It applies to **any** kind of work a dynamic workflow does (frontend, backend, research, refactors, audits), not one domain. When `ultracode` is on, the session runs on Opus @ `xhigh` and a workflow fans out to dozens of subagents that **inherit that session model** unless every `agent()` stage is pinned — so a fan-out silently runs everything on Opus. ultracost makes the routing explicit and verifiable: a quality-first policy (Opus for reasoning, Sonnet for mechanical work, never Haiku), a static guard, and a pre-flight cost gate.

This directory ships the self-contained **routing-policy skill**. The full plugin (Workflow Guard, deterministic `PreToolUse` cost gate, closed-loop `usage`/`reconcile`/`calibrate`/`ledger`, and the `/ultracost:*` slash commands) installs from the canonical marketplace `danielkremen818/ultracost`, linked in the entry's README/plugin.json.

## Component Details

- **Name:** ultracost
- **Type:** Plugin (ships a Skill)
- **Category:** cost-optimization / developer-productivity (applies to any workflow domain)
- **License:** MIT
- **Repository:** https://github.com/danielkremen818/ultracost

## Security & trust

- **Zero runtime and dev dependencies** — no supply chain to compromise; Snyk Open Source and `npm audit` report 0 vulnerabilities.
- **No telemetry, no network on the hot path** (only the user-invoked `pricing refresh` makes a request).
- Releases publish to npm with **OIDC Trusted Publishing + signed provenance**; every GitHub Action is **pinned to a commit SHA**; **CodeQL + OpenSSF Scorecard** run in CI.
- The installer touches only its own files and is fully reversible.

## Testing

- [x] `node scripts/validate-all.js` passes (Subagents & Commands, Hooks, Skills all green)
- [x] `plugin.json` is valid JSON and declares `skills: ./skills/`
- [x] Entry contains only `plugins/ultracost/` (no lockfile/report changes)
- [x] Skill frontmatter (`name`, `description`) conforms to the skill schema

## Example usages

1. **Author a workflow safely:** with `ultracode` on, the skill guidance has Claude pin `{ model, effort }` on every `agent()` stage (Opus for planning/review/synthesis, Sonnet for per-file scans) instead of inheriting Opus everywhere.
2. **Verify before launch:** `/ultracost:check ./path/to/workflow.js` flags any stage missing a model pin or pinning the wrong tier.
3. **See the cost first:** `/ultracost:estimate ./workflow.js` reports agent count, model mix, and tiered cost vs an all-opus baseline before the fan-out runs.