### PR TITLE
Register ultracost in marketplace.json (follow-up to #190)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1790,6 +1790,32 @@
         "source": "github",
         "repo": "glitchwerks/claude-github-tools"
       }
+    },
+    {
+      "name": "ultracost",
+      "description": "Per-stage model routing + pre-flight cost gate for Claude Code ultracode dynamic workflows. Pins an explicit model + effort on every agent() subagent stage, estimates cost before launch, and ships a static guard + PreToolUse gate that flag stages which would silently inherit the session's Opus model. Zero dependencies, no telemetry, MIT.",
+      "version": "0.3.7",
+      "author": {
+        "name": "Daniel Kremen",
+        "url": "https://github.com/danielkremen818"
+      },
+      "repository": "https://github.com/danielkremen818/ultracost",
+      "license": "MIT",
+      "keywords": [
+        "claude-code",
+        "claude-code-plugin",
+        "ultracode",
+        "dynamic-workflows",
+        "subagents",
+        "model-routing",
+        "cost-optimization",
+        "finops"
+      ],
+      "category": "development",
+      "source": {
+        "source": "github",
+        "repo": "danielkremen818/ultracost"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary

PR #190 merged the `plugins/ultracost/` directory but did **not** add an entry to `.claude-plugin/marketplace.json`. As a result:

- ultracost does not appear on https://buildwithclaude.com (the catalog is sourced from this manifest)
- `/plugin install ultracost@buildwithclaude` does not resolve (no `plugins[]` entry)

This is the missing follow-up: it adds the `plugins[]` entry, pointing `source` at the canonical repo `danielkremen818/ultracost` — the same pattern every other entry uses (e.g. `archcore` → `archcore-ai/plugin`).

## Details

- Single-file change: `.claude-plugin/marketplace.json` (+26 lines, append only)
- `category: development`, `version: 0.3.7` (matches the merged `plugins/ultracost/.claude-plugin/plugin.json`)
- `source: { source: github, repo: danielkremen818/ultracost }`
- JSON validated

## Test plan

- [x] `python3 -c 'import json; json.load(open(".claude-plugin/marketplace.json"))'` passes
- [ ] Catalog ingest picks up ultracost after merge
- [ ] `/plugin marketplace add davepoon/buildwithclaude` → `/plugin install ultracost@buildwithclaude` resolves