### PR TITLE
Add claude-prompt plugin

### DIFF
--- a/plugins/claude-prompt/.claude-plugin/plugin.json
+++ b/plugins/claude-prompt/.claude-plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "claude-prompt",
+  "version": "0.1.0",
+  "description": "Rewrites your request into an optimized, reasoning-maximizing prompt (structured context, specificity, meta-instructions for extended thinking, skip-comments that preserve quoted text), then immediately carries it out. Ships the /p command.",
+  "author": {
+    "name": "Daniel Kremen",
+    "url": "https://github.com/danielkremen818"
+  },
+  "homepage": "https://github.com/danielkremen818/claude-prompt#readme",
+  "repository": "https://github.com/danielkremen818/claude-prompt",
+  "license": "MIT",
+  "keywords": [
+    "prompt-engineering",
+    "prompt-optimizer",
+    "meta-prompting",
+    "extended-thinking",
+    "reasoning",
+    "slash-command",
+    "productivity",
+    "claude-code"
+  ]
+}

--- a/plugins/claude-prompt/commands/p.md
+++ b/plugins/claude-prompt/commands/p.md
@@ -1,0 +1,21 @@
+---
+description: "Prompt optimizer — rewrite this request into an optimized prompt (ultrathink), then carry it out"
+category: "workflow-orchestration"
+argument-hint: "[your request]"
+---
+
+You are operating in **PROMPT OPTIMIZER** mode for Claude.
+
+**Step 1 — Optimize.** Rewrite the request below into an optimized prompt that maximizes reasoning quality, applying these techniques:
+1. **Structured context** — add explicit reasoning frameworks and step-by-step structure.
+2. **Specificity** — turn vague asks into detailed, actionable requirements with clear success criteria.
+3. **Meta-instructions** — add guidance that leverages extended thinking and planning.
+4. **Skip-comments** — do NOT alter any text inside double quotes ("like this").
+
+**Step 2 — Show it.** Output the rewritten prompt under a short `**Optimized prompt:**` heading.
+
+**Step 3 — Execute.** Immediately carry out the optimized prompt in full.
+
+Request to optimize and execute:
+
+$ARGUMENTS


### PR DESCRIPTION
Adds **claude-prompt** under `plugins/claude-prompt/` per CONTRIBUTING.md.

A single `/p` command that rewrites your request into an optimized, reasoning-maximizing prompt — structured context, specificity, meta-instructions for extended thinking, and skip-comments that preserve any text inside double quotes — then immediately carries it out.

- `.claude-plugin/plugin.json` — manifest
- `commands/p.md` — the command (frontmatter validates against `scripts/command-schema.json`: `description` + `category: workflow-orchestration`)

Source repo: https://github.com/danielkremen818/claude-prompt (MIT, zero dependencies, no code/hooks — just the command).