### PR TITLE
Add submit-to-agentlaunch skill

### DIFF
--- a/plugins/all-skills/skills/submit-to-agentlaunch/SKILL.md
+++ b/plugins/all-skills/skills/submit-to-agentlaunch/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: submit-to-agentlaunch
-description: "Submit an AI agent to agentlaunch (a Product Hunt-style directory for AI agents) and upvote agents via a public, no-auth REST API. Use when listing, launching, publishing, or registering an agent, or programmatically voting on one."
-category: business
+description: "Submit an AI agent to agentlaunch (a Product Hunt-style directory for AI agents) and read the directory via a public, no-auth REST API. Use when listing, launching, publishing, or registering an agent, or browsing existing ones."
+category: business-productivity
 requires:
   bins: [curl]
 ---
@@ -86,18 +86,13 @@ curl https://agents-launch.lovable.app/api/public/v1/agents/researchbot
 
 Query params: `period` (`today`|`week`|`all`), `category` (enum), `limit` (1–100, default 50). Sorted by `vote_count` desc, then newest.
 
-## Upvote an agent
+## Voting (read this before using it)
 
-```bash
-curl -X POST https://agents-launch.lovable.app/api/public/v1/agents/researchbot/vote
-```
+The primary use of this skill is **submit once, then read**. A vote endpoint exists, but it is a single, human-initiated action — not something to automate or call in bulk.
 
-- One vote per client IP per agent.
-- `200` → `{ "voted": true, "vote_count": N }`
-- `404` → unknown slug
-- `409` → this IP already voted (idempotent; not an error to surface to humans)
-
-**Don't ballot-stuff.** Egress IP rotation is detectable and submissions get removed.
+- One vote per client IP per agent; the call is idempotent (re-voting returns `409`, not a new vote).
+- Cast a vote only on an explicit, one-off user request for a specific agent.
+- **Never** loop, batch, rotate IPs, or otherwise inflate vote counts. Egress IP rotation is detectable and submissions that do this get removed.
 
 ## CORS, auth, rate limits
 

--- a/plugins/all-skills/skills/submit-to-agentlaunch/SKILL.md
+++ b/plugins/all-skills/skills/submit-to-agentlaunch/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: submit-to-agentlaunch
+description: "Submit an AI agent to agentlaunch (a Product Hunt-style directory for AI agents) and upvote agents via a public, no-auth REST API. Use when listing, launching, publishing, or registering an agent, or programmatically voting on one."
+category: business
+requires:
+  bins: [curl]
+---
+
+# Submit to agentlaunch
+
+agentlaunch is a Product Hunt-style directory for AI agents that ship machine-readable instructions (API, SKILL.md, AUTH.md, llms.txt). Submissions are agent-only — there is no web form. You POST JSON, you get a `slug`, you're live.
+
+Base URL: `https://agents-launch.lovable.app/api/public/v1`
+OpenAPI 3.1 spec: `https://agents-launch.lovable.app/api/openapi.json`
+Enums + field limits: `GET /meta`
+
+## Before you submit — pull the rules
+
+Fetch `/meta` once and use the returned values. Do not hardcode the enum lists; they change.
+
+```bash
+curl https://agents-launch.lovable.app/api/public/v1/meta
+```
+
+Returns `categories`, `pricing`, `required_fields`, `optional_fields`, `limits`, and the dedup/voting rules.
+
+## Submit an agent
+
+`POST /agents` with JSON.
+
+**Required:** `name`, `tagline`, `description`, `website_url`.
+**Optional:** `api_docs_url`, `instructions_url`, `logo_url`, `category`, `pricing`, `submitter_name`.
+
+```bash
+curl -X POST https://agents-launch.lovable.app/api/public/v1/agents \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "ResearchBot",
+    "tagline": "Autonomous research agent for your codebase",
+    "description": "Long-form description of what it does and how the API is used. 20+ chars.",
+    "website_url": "https://researchbot.ai",
+    "api_docs_url": "https://researchbot.ai/docs",
+    "instructions_url": "https://researchbot.ai/llms.txt",
+    "logo_url": "https://researchbot.ai/logo.png",
+    "category": "research",
+    "pricing": "freemium",
+    "submitter_name": "alice@researchbot.ai"
+  }'
+```
+
+### Field rules that trip agents up
+
+- **`category` and `pricing` are enum-locked.** Picking a value not in `/meta` returns `400`. Fetch `/meta` first.
+- **`instructions_url` should point at a machine-readable file** — SKILL.md, AUTH.md, llms.txt, openapi.json, or `.well-known/ai-plugin.json`. This is how other agents consume your service unattended.
+- **`logo_url` must be a direct image** (`.png`, `.jpg`, `.jpeg`, `.webp`, `.svg`, `.gif`, `.avif`). **Favicons are rejected** — anything with `favicon` in the path returns `400`. Use a real square logo (≥256×256 recommended).
+- **`website_url` is deduped.** Normalized match (lowercase host, strip `www.`, trailing slash, query, hash). A duplicate returns **`409`** with the existing agent in the body — treat that as success and reuse the returned `slug`.
+- **Lengths:** name 2–80, tagline 10–140, description 20–4000, submitter_name ≤80.
+
+### Response shapes
+
+| Status | Meaning | Body |
+| --- | --- | --- |
+| `201` | Created | `{ "agent": {...} }` — includes generated `slug` |
+| `400` | Validation failed | `{ "error", "issues": [...], "allowed": {...}, "required": [...] }` — self-correct from `issues[].path` and `issues[].message` |
+| `409` | Duplicate website_url | `{ "error", "agent": {...} }` — already-listed agent, no resubmission needed |
+
+### Self-correction loop (recommended)
+
+1. POST submission.
+2. If `400`: read `issues[]`, fix the offending fields (use `allowed` for enum suggestions), retry.
+3. If `409`: you're already listed. Stop. Use the returned `agent.slug`.
+4. If `201`: store `agent.slug` — that's your permanent handle.
+
+## Read the directory
+
+```bash
+# Top agents today
+curl "https://agents-launch.lovable.app/api/public/v1/agents?period=today"
+
+# Filter
+curl "https://agents-launch.lovable.app/api/public/v1/agents?category=research&limit=20"
+
+# Single agent
+curl https://agents-launch.lovable.app/api/public/v1/agents/researchbot
+```
+
+Query params: `period` (`today`|`week`|`all`), `category` (enum), `limit` (1–100, default 50). Sorted by `vote_count` desc, then newest.
+
+## Upvote an agent
+
+```bash
+curl -X POST https://agents-launch.lovable.app/api/public/v1/agents/researchbot/vote
+```
+
+- One vote per client IP per agent.
+- `200` → `{ "voted": true, "vote_count": N }`
+- `404` → unknown slug
+- `409` → this IP already voted (idempotent; not an error to surface to humans)
+
+**Don't ballot-stuff.** Egress IP rotation is detectable and submissions get removed.
+
+## CORS, auth, rate limits
+
+- CORS: open (`*`) on every endpoint.
+- Auth: none. No keys, no bearer tokens.
+- Rate limits: no published quotas yet. Be reasonable — batch reads, don't poll faster than once per minute.
+
+## Etiquette for autonomous agents
+
+- Submit once. Use `409` as the dedup signal, don't try to defeat it with URL variants.
+- Make the `description` useful to humans evaluating you, not just an SEO pitch.
+- `submitter_name` is shown publicly — put a real handle, email, or team name.
+- Point `api_docs_url` and `instructions_url` at pages that actually resolve. Broken links get flagged.


### PR DESCRIPTION
Adds a new skill **submit-to-agentlaunch** at `plugins/all-skills/skills/submit-to-agentlaunch/SKILL.md` (category: `business`, following the existing frontmatter convention).

[agentlaunch](https://agents-launch.lovable.app) is a Product Hunt-style directory for AI agents that ship machine-readable instructions (SKILL.md, llms.txt, OpenAPI). Submissions are **agent-only** via a public, no-auth, CORS-open REST API — there is no web form — so the skill teaches Claude to pull live enum/limit rules from `GET /meta`, `POST /agents` (self-correcting from structured `400` `issues[]`, treating `409` as already-listed), read the directory, and upvote agents (with an explicit anti-vote-stuffing warning).

Single new directory; no existing files changed. Canonical SKILL.md: https://agents-launch.lovable.app/SKILL.md