### PR TITLE
Add forge plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1816,6 +1816,32 @@
         "source": "github",
         "repo": "danielkremen818/ultracost"
       }
+    },
+    {
+      "name": "forge",
+      "description": "Full-lifecycle SDLC orchestrator: a 12-stage pipeline (SRS, architecture, spec, plan, build, eval, deploy, monitor, release) driven by specialized agents, persistent cross-session memory, auto-reflection, gate enforcement, and semantic skill mining that proposes new skills from recurring workflows.",
+      "version": "0.3.6",
+      "author": {
+        "name": "Saddam",
+        "url": "https://github.com/tonmoy007/forge-plugins"
+      },
+      "repository": "https://github.com/tonmoy007/forge-plugins",
+      "license": "MIT",
+      "keywords": [
+        "sdlc",
+        "orchestration",
+        "agents",
+        "pipeline",
+        "memory",
+        "skills",
+        "automation",
+        "workflow"
+      ],
+      "category": "development",
+      "source": {
+        "source": "github",
+        "repo": "tonmoy007/forge-plugins"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary
Adds **Forge** to the marketplace — a full-lifecycle SDLC orchestrator for Claude Code. Forge drives a 12-stage pipeline (SRS → architecture → spec → plan → build → eval → deploy → monitor → release) with specialized agents, persistent cross-session memory, auto-reflection, gate enforcement, and semantic skill mining that proposes new skills from recurring workflows.

Registered via the **external GitHub source** pattern (same as `archcore`, `backlogd`, `ultracost`), so it tracks the upstream repo and needs no vendored copy.

## Component Details
- **Name**: forge
- **Type**: Plugin
- **Category**: development
- **Source**: `tonmoy007/forge-plugins` (`{ "source": "github", "repo": "tonmoy007/forge-plugins" }`)
- The source repo has a valid `.claude-plugin/plugin.json` (v0.3.6) at its root with SessionStart/Stop/PreToolUse/etc. hooks wired.

## Testing
- [x] Ran validation (`npm test` → `node scripts/validate-all.js`): Subagents & Commands ✅, Hooks ✅, Skills ✅
- [x] `marketplace.json` parses as valid JSON (73 plugins) and the entry matches the existing external-source schema
- [x] No overlap with existing components (no SDLC pipeline orchestrator currently listed)

## Examples
- `/forge:init` — scaffold the pipeline in a project, auto-detect project type
- `/forge:srs` — describe the project, get an SRS with numbered REQ-IDs and acceptance criteria
- `/forge:build` — implement tasks one at a time from the generated task DAG with gate enforcement
