### PR TITLE
Add conventional-commits hook

### DIFF
--- a/plugins/all-hooks/hooks/conventional-commits.md
+++ b/plugins/all-hooks/hooks/conventional-commits.md
@@ -1,0 +1,95 @@
+---
+name: conventional-commits
+description: Enforce Conventional Commits — validates git commit messages before the command runs and blocks non-conforming ones
+category: git
+event: PreToolUse
+matcher: Bash
+language: bash
+version: 0.1.0
+---
+
+# conventional-commits
+
+Enforce [Conventional Commits](https://www.conventionalcommits.org/) at the agent layer. This `PreToolUse(Bash)` hook inspects every `git commit` command **before it runs**. If the subject line does not match `<type>[optional scope][!]: <description>`, the hook blocks the command (exit code 2) and returns guidance to Claude, which then rewrites the message and retries.
+
+Because it intercepts the Bash tool call itself, it cannot be bypassed with `git commit --no-verify` (unlike a git `commit-msg` hook).
+
+## Event Configuration
+
+- **Event Type**: `PreToolUse`
+- **Tool Matcher**: `Bash`
+- **Category**: git
+
+## Environment Variables
+
+- `CC_TYPES` - Optional. Comma-separated list of allowed types, replacing the default set (e.g. `feat,fix,chore,wip`).
+- `CC_SKIP` - Optional. Set to `1`/`true`/`yes` to disable enforcement.
+
+## Requirements
+
+- `jq` (parse the hook payload)
+- `bash` 3.2+ and `xargs` (standard on macOS and Linux)
+
+Conforming examples: `feat: add login`, `fix(api): handle null`, `feat!: drop Node 16`.
+Not blocked: editor commits (no `-m`), `-F`/`--file` messages, and auto-generated `Merge`/`Revert`/`fixup!`/`squash!` subjects.
+
+### Script
+
+```bash
+# Conventional Commits enforcement — PreToolUse(Bash) hook (bash 3.2+ compatible).
+# Reads the hook JSON on stdin; exits 0 to allow, 2 to block with guidance on stderr.
+case "${CC_SKIP:-}" in 1|[Tt]rue|[Yy]es) exit 0;; esac
+
+input="$(cat)"
+command -v jq >/dev/null 2>&1 || exit 0
+tool="$(printf '%s' "$input" | jq -r '.tool_name // empty')"
+[ "$tool" = "Bash" ] || exit 0
+cmd="$(printf '%s' "$input" | jq -r '.tool_input.command // empty')"
+[ -n "$cmd" ] || exit 0
+case "$cmd" in *commit*) ;; *) exit 0;; esac
+
+# Tokenize respecting shell quoting WITHOUT executing (xargs does not exec).
+toks=(); while IFS= read -r _t; do toks+=("$_t"); done < <(printf '%s' "$cmd" | xargs -n1 2>/dev/null)
+[ "${#toks[@]}" -gt 0 ] || exit 0
+
+# Locate the `commit` subcommand preceded somewhere by `git`.
+ci=-1; seen_git=0
+for i in "${!toks[@]}"; do
+  [ "${toks[$i]}" = "git" ] && seen_git=1
+  if [ "${toks[$i]}" = "commit" ] && [ "$seen_git" = 1 ]; then ci=$i; break; fi
+done
+[ "$ci" -ge 0 ] || exit 0
+
+# Extract the first -m/--message value; allow (cannot validate) on -F/--file or editor commits.
+msg=""; have=0; n=${#toks[@]}; i=$((ci+1))
+while [ $i -lt $n ]; do
+  t="${toks[$i]}"
+  case "$t" in
+    --) break;;
+    -m|--message) j=$((i+1)); if [ $j -lt $n ]; then msg="${toks[$j]}"; have=1; break; fi;;
+    --message=*) msg="${t#--message=}"; have=1; break;;
+    -F|--file|--file=*) exit 0;;
+    -m?*) msg="${t#-m}"; have=1; break;;
+    -[A-Za-z]*m) j=$((i+1)); if [ $j -lt $n ]; then msg="${toks[$j]}"; have=1; break; fi;;
+  esac
+  i=$((i+1))
+done
+[ "$have" = 1 ] || exit 0
+
+subject="${msg%%$'\n'*}"
+case "$subject" in "Merge "*|"Revert "*|"fixup! "*|"squash! "*|"amend! "*) exit 0;; esac
+
+types="${CC_TYPES:-feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert}"
+types="${types//,/|}"
+if [[ "$subject" =~ ^(${types})(\([^\)]+\))?(!)?:\ .+ ]]; then exit 0; fi
+
+{
+  echo "Commit message does not follow Conventional Commits."
+  echo "  Got:      '$subject'"
+  echo "  Expected: <type>[optional scope][!]: <description>"
+  echo "  Example:  feat(parser): add ability to parse arrays"
+  echo "  Allowed types: ${types//|/, }"
+  echo "Rewrite the commit message to match, then retry. (Set CC_SKIP=1 to disable this check.)"
+} >&2
+exit 2
+```

--- a/plugins/hooks-git/.claude-plugin/plugin.json
+++ b/plugins/hooks-git/.claude-plugin/plugin.json
@@ -14,6 +14,7 @@
     "git",
     "auto-git-add",
     "git-add-changes",
-    "smart-commit"
+    "smart-commit",
+    "conventional-commits"
   ]
 }

--- a/plugins/hooks-git/hooks/conventional-commits.md
+++ b/plugins/hooks-git/hooks/conventional-commits.md
@@ -1,0 +1,95 @@
+---
+name: conventional-commits
+description: Enforce Conventional Commits — validates git commit messages before the command runs and blocks non-conforming ones
+category: git
+event: PreToolUse
+matcher: Bash
+language: bash
+version: 0.1.0
+---
+
+# conventional-commits
+
+Enforce [Conventional Commits](https://www.conventionalcommits.org/) at the agent layer. This `PreToolUse(Bash)` hook inspects every `git commit` command **before it runs**. If the subject line does not match `<type>[optional scope][!]: <description>`, the hook blocks the command (exit code 2) and returns guidance to Claude, which then rewrites the message and retries.
+
+Because it intercepts the Bash tool call itself, it cannot be bypassed with `git commit --no-verify` (unlike a git `commit-msg` hook).
+
+## Event Configuration
+
+- **Event Type**: `PreToolUse`
+- **Tool Matcher**: `Bash`
+- **Category**: git
+
+## Environment Variables
+
+- `CC_TYPES` - Optional. Comma-separated list of allowed types, replacing the default set (e.g. `feat,fix,chore,wip`).
+- `CC_SKIP` - Optional. Set to `1`/`true`/`yes` to disable enforcement.
+
+## Requirements
+
+- `jq` (parse the hook payload)
+- `bash` 3.2+ and `xargs` (standard on macOS and Linux)
+
+Conforming examples: `feat: add login`, `fix(api): handle null`, `feat!: drop Node 16`.
+Not blocked: editor commits (no `-m`), `-F`/`--file` messages, and auto-generated `Merge`/`Revert`/`fixup!`/`squash!` subjects.
+
+### Script
+
+```bash
+# Conventional Commits enforcement — PreToolUse(Bash) hook (bash 3.2+ compatible).
+# Reads the hook JSON on stdin; exits 0 to allow, 2 to block with guidance on stderr.
+case "${CC_SKIP:-}" in 1|[Tt]rue|[Yy]es) exit 0;; esac
+
+input="$(cat)"
+command -v jq >/dev/null 2>&1 || exit 0
+tool="$(printf '%s' "$input" | jq -r '.tool_name // empty')"
+[ "$tool" = "Bash" ] || exit 0
+cmd="$(printf '%s' "$input" | jq -r '.tool_input.command // empty')"
+[ -n "$cmd" ] || exit 0
+case "$cmd" in *commit*) ;; *) exit 0;; esac
+
+# Tokenize respecting shell quoting WITHOUT executing (xargs does not exec).
+toks=(); while IFS= read -r _t; do toks+=("$_t"); done < <(printf '%s' "$cmd" | xargs -n1 2>/dev/null)
+[ "${#toks[@]}" -gt 0 ] || exit 0
+
+# Locate the `commit` subcommand preceded somewhere by `git`.
+ci=-1; seen_git=0
+for i in "${!toks[@]}"; do
+  [ "${toks[$i]}" = "git" ] && seen_git=1
+  if [ "${toks[$i]}" = "commit" ] && [ "$seen_git" = 1 ]; then ci=$i; break; fi
+done
+[ "$ci" -ge 0 ] || exit 0
+
+# Extract the first -m/--message value; allow (cannot validate) on -F/--file or editor commits.
+msg=""; have=0; n=${#toks[@]}; i=$((ci+1))
+while [ $i -lt $n ]; do
+  t="${toks[$i]}"
+  case "$t" in
+    --) break;;
+    -m|--message) j=$((i+1)); if [ $j -lt $n ]; then msg="${toks[$j]}"; have=1; break; fi;;
+    --message=*) msg="${t#--message=}"; have=1; break;;
+    -F|--file|--file=*) exit 0;;
+    -m?*) msg="${t#-m}"; have=1; break;;
+    -[A-Za-z]*m) j=$((i+1)); if [ $j -lt $n ]; then msg="${toks[$j]}"; have=1; break; fi;;
+  esac
+  i=$((i+1))
+done
+[ "$have" = 1 ] || exit 0
+
+subject="${msg%%$'\n'*}"
+case "$subject" in "Merge "*|"Revert "*|"fixup! "*|"squash! "*|"amend! "*) exit 0;; esac
+
+types="${CC_TYPES:-feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert}"
+types="${types//,/|}"
+if [[ "$subject" =~ ^(${types})(\([^\)]+\))?(!)?:\ .+ ]]; then exit 0; fi
+
+{
+  echo "Commit message does not follow Conventional Commits."
+  echo "  Got:      '$subject'"
+  echo "  Expected: <type>[optional scope][!]: <description>"
+  echo "  Example:  feat(parser): add ability to parse arrays"
+  echo "  Allowed types: ${types//|/, }"
+  echo "Rewrite the commit message to match, then retry. (Set CC_SKIP=1 to disable this check.)"
+} >&2
+exit 2
+```


### PR DESCRIPTION
## Summary
Adds a `conventional-commits` hook that enforces [Conventional Commits](https://www.conventionalcommits.org/) at the agent layer. A `PreToolUse(Bash)` hook inspects every `git commit` command **before it runs**; if the subject doesn't match `<type>[optional scope][!]: <description>` it blocks the command (exit 2) and returns guidance to Claude, which then rewrites the message and retries.

Unlike a git `commit-msg` hook, this intercepts the Bash tool call itself, so it **cannot be bypassed with `git commit --no-verify`**.

## Component Details
- **Name**: conventional-commits
- **Type**: Hook
- **Category**: git
- **Event/Matcher**: `PreToolUse` / `Bash`

Added to `plugins/hooks-git/` and the `plugins/all-hooks/` bundle, plus a keyword in `hooks-git`'s `plugin.json`.

## Testing
- [x] Ran validation (`node scripts/validate-all.js` → all passed; `validate:hooks` reports 0 errors)
- [x] Tested functionality — the script was verified against 15 cases on bash 3.2.57 (conforming subjects, scopes, `!`, chained `-am`, `--message=`, editor/`-F` skip, `Merge`/`Revert` bypass, and 4 non-conforming subjects that are correctly blocked), plus `CC_TYPES` and `CC_SKIP`.
- [x] No overlap with existing components (existing git hooks are `auto-git-add`, `git-add-changes`, `smart-commit`; none enforce commit-message format)

## Examples
1. `git commit -m "add login"` → **blocked**; Claude is told to add a type prefix and retries with e.g. `feat: add login`.
2. `git commit -m "fix(api): handle null pointer"` → **allowed**.
3. `CC_TYPES="feat,fix,chore,wip" git commit -m "wip: scratch"` → **allowed** (custom types); `CC_SKIP=1` disables the check entirely.

## Configuration
- `CC_TYPES` — comma-separated allowed types (defaults to the Angular/CC set).
- `CC_SKIP` — set to `1`/`true`/`yes` to disable.

A standalone (Python) version with a CI-run test suite also lives at https://github.com/clown6613/conventional-commits.