### PR TITLE
Update codex-hud to v0.10.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1596,7 +1596,7 @@
     {
       "name": "codex-hud",
       "description": "Display OpenAI Codex usage and rate limits inside Claude Code. Real-time statusline integration with claude-hud (auto-installed via /codex-hud:setup).",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "author": {
         "name": "Haenara Shin",
         "url": "https://github.com/haenara-shin"

--- a/plugins/codex-hud/.claude-plugin/plugin.json
+++ b/plugins/codex-hud/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "codex-hud",
   "description": "Display OpenAI Codex API usage and costs inside Claude Code",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "author": {
     "name": "Haenara Shin"
   },

--- a/plugins/codex-hud/README.md
+++ b/plugins/codex-hud/README.md
@@ -24,31 +24,30 @@ If you use [codex-plugin-cc](https://github.com/openai/codex-plugin-cc) to deleg
 
 ## Features
 
-- **Real-time statusline**: Integrates with [claude-hud](https://github.com/jarrodwatts/claude-hud) to show Codex Usage/Weekly rate limits alongside Claude Code's own statusline, with a 60s refresh so reset countdowns stay current while the session is idle
-- **Slash commands**: Dedicated commands for usage, costs, and summary
-- **Dual data sources**: Local Codex CLI session logs (no API key needed) + OpenAI Usage API (optional, for dollar costs)
-- **Plan-agnostic**: Renders correctly on any Codex plan (free, Plus, Pro, Team, Enterprise) — rate-limit windows that aren't reported are simply skipped, never crash the statusline
-- **Zero npm runtime dependencies**: Only uses Node.js built-in modules (statusline wrapper requires Bash and Perl)
-- **Graceful degradation**: Works with just local logs if no API key is configured
+- **Real-time statusline**: shows your active model + reasoning effort, the **5h** and **Weekly** quota as **% left** (like Codex's own `/status`), and context-window usage below [claude-hud](https://github.com/jarrodwatts/claude-hud)'s statusline — with a 60s refresh so reset countdowns stay current while idle
+- **Works with both Codex paths**: reads rate limits from the rollout logs (interactive TUI) AND from `~/.codex/logs_2.sqlite` (the **app-server / Claude Code codex plugin** path, Codex 0.140+) — all local, no API key, no network
+- **4 layouts**: expanded / horizontal / inline / compact, configurable with live previews
+- **Slash commands**: setup, configure, usage, costs, summary, and more
+- **Plan-agnostic**: renders on any Codex plan (free, Plus, Pro, Team, Enterprise) — unreported rate-limit windows are skipped, never crash the statusline
+- **Zero npm runtime dependencies**: Node.js built-ins only (statusline wrapper uses Bash; the app-server source needs Node ≥ 22.5 or the `sqlite3` CLI)
+- **Optional dollar costs**: OpenAI Admin API key enables the `costs-*` commands; everything else works without it
 
 ## Statusline Integration
 
 When paired with [claude-hud](https://github.com/jarrodwatts/claude-hud), codex-hud adds Codex rate limits below the Claude Code statusline:
 
 ```
-[Opus 4.6 (1M context)]              <- claude-hud
+[Opus 4.6 (1M context)]                                  <- claude-hud
 my-project
 Context ██░░░░░░░░ 19%
-Usage   █░░░░░░░░░ 14% (resets in 4h 37m)
-Weekly  ██░░░░░░░░ 22% (resets in 5d 18h)
-── Codex gpt-5.5·medium ──            <- codex-hud
-Usage   █░░░░░░░░░ 1% (resets in 5h)
-Weekly  ░░░░░░░░░░ 0% (resets in 7d)
-Context ██░░░░░░░░ 18% (47k/258k)
-1 session | team
+── Codex gpt-5.5·xhigh ──                                 <- codex-hud
+5h Usage ██████████ 99% left (resets 19:38 · 3h 55m)
+Weekly   ███████░░░ 71% left (resets 15:04 on 22 Jun · 5d 23h)
+Context  ██░░░░░░░░ 18% (47k/258k)
+team
 ```
 
-The header shows the model and reasoning effort of your most recent Codex turn, and the Context bar tracks that session's context-window occupancy. When Codex reports a reached rate limit, a red `⚠ LIMIT` alert appears in the header (even when the percentage bars sit below 100%).
+The header shows the model and reasoning effort of your most recent Codex turn. The **5h** and **Weekly** rows show how much quota is **left** (bars fill as remaining, matching Codex's `/status`), with both the absolute reset time and the time remaining; the Context bar tracks context-window occupancy (shown as used). When Codex reports a reached rate limit, a red `⚠ LIMIT` alert appears in the header. The reset format (absolute / relative / both) and which elements show are configurable via `/codex-hud:configure`.
 
 ## Installation
 
@@ -165,7 +164,7 @@ Show token usage broken down by metrics.
 | Reasoning    | 82.4k    |
 | **Total**    | **3.5M** |
 
-Rate limit: 6.0% (5h) / 14.0% (7d) | Plan: team
+Rate limit: 94% left (5h) / 86% left (7d) | Plan: team
 ```
 
 ### `/codex-hud:costs-today` / `costs-week` / `costs-month` *(beta)*
@@ -179,14 +178,16 @@ Show cost breakdown by billing line item (requires Admin API key).
 Quick one-line summary of today's Codex activity.
 
 ```
-Codex today: $1.23 | 1.8M tokens (1.4M cached) | 3 sessions | Rate: 1%/0%
+Codex today: $1.23 | 1.8M tokens (1.4M cached) | 3 sessions | Rate: 99%/100% left
 ```
 
 ## Data Sources
 
 | Source | Data | Auth Required |
 |--------|------|---------------|
-| Local Codex CLI logs (`~/.codex/sessions/`) | Token usage, rate limits, session count | None |
+| Rollout logs (`~/.codex/sessions/`) | Token usage, rate limits, session count, model (interactive Codex TUI) | None |
+| App-server DB (`~/.codex/logs_2.sqlite`) | Rate limits + model for Codex **0.140–0.141** via the app-server / codex plugin | None (Node ≥ 22.5 or `sqlite3` CLI) |
+| Codex app-server RPC (`codex app-server`) | Rate limits for Codex **0.142+** (which writes none to disk); cached 5 min, refreshed in the background; model/effort from `~/.codex/config.toml` | None (Codex CLI on PATH) |
 | OpenAI Usage API (`/v1/organization/costs`) | Dollar costs by billing line item | Admin API key |
 | OpenAI Usage API (`/v1/organization/usage/completions`) | Org-wide token usage by model | Admin API key |
 
@@ -215,6 +216,12 @@ Substitute `codex-hud` with your marketplace alias — `claude-community` for An
 codex-hud was inspired by [claude-hud](https://github.com/jarrodwatts/claude-hud) — which solved the same usage-visibility problem for Claude Code itself. codex-hud extends that idea to OpenAI Codex and integrates with claude-hud via the included wrapper script when both are installed.
 
 ## Changelog
+
+### v0.10.0
+
+- **Codex 0.142+ support.** Codex 0.142 stopped writing rate limits to disk entirely (it fetches them live and hands them to clients over the app-server). codex-hud now reads them by calling `codex app-server` JSON-RPC `account/rateLimits/read` itself, caching the result (5-min TTL) and refreshing in a detached background process so the statusline stays fast. Fixes the disappearing 5h / Weekly bars on 0.142.
+- Maps the new camelCase fields (`usedPercent` / `windowDurationMins` / `resetsAt` / `rateLimitReachedType`); model + effort fall back to `~/.codex/config.toml` since the RPC doesn't return them.
+- Source priority is newest-wins across rollout logs, `logs_2.sqlite` (0.140–0.141), and the app-server RPC (0.142+), so it works across Codex versions.
 
 ### v0.9.0
 

--- a/plugins/codex-hud/README.md
+++ b/plugins/codex-hud/README.md
@@ -25,11 +25,11 @@ If you use [codex-plugin-cc](https://github.com/openai/codex-plugin-cc) to deleg
 ## Features
 
 - **Real-time statusline**: shows your active model + reasoning effort, the **5h** and **Weekly** quota as **% left** (like Codex's own `/status`), and context-window usage below [claude-hud](https://github.com/jarrodwatts/claude-hud)'s statusline — with a 60s refresh so reset countdowns stay current while idle
-- **Works with both Codex paths**: reads rate limits from the rollout logs (interactive TUI) AND from `~/.codex/logs_2.sqlite` (the **app-server / Claude Code codex plugin** path, Codex 0.140+) — all local, no API key, no network
+- **Works across every Codex path & version**: reads rate limits from the rollout logs (interactive TUI), `~/.codex/logs_2.sqlite` (app-server, Codex 0.140–0.141), and the `codex app-server` RPC (Codex 0.142+, which writes nothing to disk) — newest-wins, all local, no API key, no network
 - **4 layouts**: expanded / horizontal / inline / compact, configurable with live previews
 - **Slash commands**: setup, configure, usage, costs, summary, and more
 - **Plan-agnostic**: renders on any Codex plan (free, Plus, Pro, Team, Enterprise) — unreported rate-limit windows are skipped, never crash the statusline
-- **Zero npm runtime dependencies**: Node.js built-ins only (statusline wrapper uses Bash; the app-server source needs Node ≥ 22.5 or the `sqlite3` CLI)
+- **Zero npm runtime dependencies**: Node.js built-ins only (statusline wrapper uses Bash; the 0.140–0.141 DB source needs Node ≥ 22.5 or the `sqlite3` CLI; the 0.142+ source needs the `codex` CLI on PATH)
 - **Optional dollar costs**: OpenAI Admin API key enables the `costs-*` commands; everything else works without it
 
 ## Statusline Integration
@@ -205,7 +205,7 @@ Substitute `codex-hud` with your marketplace alias — `claude-community` for An
 
 ## Requirements
 
-- Node.js >= 18.0.0 — but **Node >= 22.5 (or the `sqlite3` CLI on PATH)** is needed to read rate limits from `~/.codex/logs_2.sqlite` (the source used when you drive Codex via the app-server / Claude Code codex plugin). Older Node still works for rollout-based usage.
+- Node.js >= 18.0.0. For app-server rate limits: Codex **0.142+** reads them via the `codex` CLI on PATH; Codex **0.140–0.141** needs **Node >= 22.5 (or the `sqlite3` CLI)** to read `~/.codex/logs_2.sqlite`. Older Node still works for rollout-based usage.
 - [Claude Code](https://claude.ai/code)
 - [Codex CLI](https://github.com/openai/codex) or [codex-plugin-cc](https://github.com/openai/codex-plugin-cc)
 - [claude-hud](https://github.com/jarrodwatts/claude-hud) (optional, for statusline integration)

--- a/plugins/codex-hud/dist/codex-appserver.d.ts
+++ b/plugins/codex-hud/dist/codex-appserver.d.ts
@@ -1,0 +1,25 @@
+import type { RateLimits } from "./types.js";
+export interface AppServerTelemetry {
+    rateLimits: RateLimits;
+    /** Configured model from ~/.codex/config.toml (the app-server RPC doesn't
+     *  return the model, and 0.142 logs nothing on disk). */
+    model: string | null;
+    /** Reasoning effort from ~/.codex/config.toml, e.g. "xhigh". */
+    effort: string | null;
+    /** Epoch ms the snapshot was fetched. */
+    timestampMs: number;
+}
+/** Extract + write the rate-limit snapshot from app-server stdout. Used by the
+ *  detached refresh child (via the `refresh-ratelimits` CLI command). */
+export declare function writeRateLimitCacheFrom(stdout: string): boolean;
+/** Run the app-server rate-limit RPC (used by the detached refresh child,
+ *  where ~1s is fine). The app-server stays alive until its stdin closes, so
+ *  we must keep stdin OPEN until the id:2 reply arrives, then kill it —
+ *  closing stdin up front makes it exit before answering. Returns stdout/null. */
+export declare function fetchRateLimitStdout(): Promise<string | null>;
+/**
+ * Newest app-server rate-limit snapshot from cache (fast, sync). If the cache
+ * is stale/missing, fire a detached background refresh so the NEXT render is
+ * current. Returns null if nothing usable is cached yet.
+ */
+export declare function readAppServerTelemetry(): AppServerTelemetry | null;

--- a/plugins/codex-hud/dist/codex-appserver.js
+++ b/plugins/codex-hud/dist/codex-appserver.js
@@ -1,0 +1,220 @@
+import { existsSync, readFileSync, writeFileSync, renameSync, statSync, } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { spawn, spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { getCacheDir } from "./config.js";
+const CACHE_TTL_MS = 5 * 60_000;
+// If the cache is older than this, don't even use it — Codex is probably idle.
+const CACHE_MAX_AGE_MS = 24 * 60 * 60_000;
+function cachePath() {
+    return join(getCacheDir(), "ratelimit_cache.json");
+}
+function readConfigToml() {
+    try {
+        const p = join(homedir(), ".codex", "config.toml");
+        return existsSync(p) ? readFileSync(p, "utf-8") : "";
+    }
+    catch {
+        return "";
+    }
+}
+function configEffort(toml = readConfigToml()) {
+    const m = /^\s*model_reasoning_effort\s*=\s*"?([A-Za-z]+)"?/m.exec(toml);
+    return m ? m[1] : null;
+}
+function configModel(toml = readConfigToml()) {
+    const m = /^\s*model\s*=\s*"([^"]+)"/m.exec(toml);
+    return m ? m[1] : null;
+}
+function mapWindow(w) {
+    if (!w || typeof w.usedPercent !== "number")
+        return null;
+    return {
+        used_percent: w.usedPercent,
+        window_minutes: typeof w.windowDurationMins === "number" ? w.windowDurationMins : null,
+        resets_at: typeof w.resetsAt === "number" ? w.resetsAt : null,
+    };
+}
+function mapRateLimits(rl) {
+    if (!rl)
+        return null;
+    const primary = mapWindow(rl.primary);
+    const secondary = mapWindow(rl.secondary);
+    if (!primary && !secondary && !rl.rateLimitReachedType)
+        return null;
+    return {
+        limit_id: typeof rl.limitId === "string" ? rl.limitId : "codex",
+        limit_name: rl.limitName ?? null,
+        primary,
+        secondary,
+        credits: rl.credits ?? null,
+        plan_type: typeof rl.planType === "string" ? rl.planType : null,
+        rate_limit_reached_type: rl.rateLimitReachedType ?? null,
+    };
+}
+function readCache() {
+    try {
+        const raw = readFileSync(cachePath(), "utf-8");
+        const c = JSON.parse(raw);
+        if (!c.rateLimits || typeof c.fetchedAt !== "number")
+            return null;
+        if (Date.now() - c.fetchedAt > CACHE_MAX_AGE_MS)
+            return null;
+        return {
+            rateLimits: c.rateLimits,
+            model: c.model ?? null,
+            effort: c.effort ?? null,
+            timestampMs: c.fetchedAt,
+        };
+    }
+    catch {
+        return null;
+    }
+}
+function cacheIsFresh() {
+    try {
+        return Date.now() - statSync(cachePath()).mtimeMs < CACHE_TTL_MS;
+    }
+    catch {
+        return false;
+    }
+}
+// ── Parse a JSON-RPC `account/rateLimits/read` response into a cache write ──
+/** Extract + write the rate-limit snapshot from app-server stdout. Used by the
+ *  detached refresh child (via the `refresh-ratelimits` CLI command). */
+export function writeRateLimitCacheFrom(stdout) {
+    for (const line of stdout.split("\n")) {
+        if (!line.includes('"id":2'))
+            continue;
+        try {
+            const msg = JSON.parse(line);
+            const rl = mapRateLimits(msg?.result?.rateLimits);
+            if (!rl)
+                continue;
+            const toml = readConfigToml();
+            const payload = {
+                rateLimits: rl,
+                model: configModel(toml),
+                effort: configEffort(toml),
+                fetchedAt: Date.now(),
+            };
+            const p = cachePath();
+            const tmp = `${p}.tmp.${process.pid}`;
+            writeFileSync(tmp, JSON.stringify(payload, null, 2) + "\n", { mode: 0o600 });
+            renameSync(tmp, p);
+            return true;
+        }
+        catch {
+            // try next line
+        }
+    }
+    return false;
+}
+function findCodexBin() {
+    // PATH first (covers most setups), then common install locations — the
+    // statusline runs outside a login shell so PATH can be minimal.
+    const candidates = [
+        "codex",
+        join(homedir(), ".local", "bin", "codex"),
+        "/opt/homebrew/bin/codex",
+        "/usr/local/bin/codex",
+    ];
+    for (const c of candidates) {
+        try {
+            const r = spawnSync(c, ["--version"], { timeout: 4000, stdio: "ignore" });
+            if (r.status === 0)
+                return c;
+        }
+        catch {
+            // next
+        }
+    }
+    return null;
+}
+/** Run the app-server rate-limit RPC (used by the detached refresh child,
+ *  where ~1s is fine). The app-server stays alive until its stdin closes, so
+ *  we must keep stdin OPEN until the id:2 reply arrives, then kill it —
+ *  closing stdin up front makes it exit before answering. Returns stdout/null. */
+export function fetchRateLimitStdout() {
+    const bin = findCodexBin();
+    if (!bin)
+        return Promise.resolve(null);
+    const requests = '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"clientInfo":{"name":"codex-hud","version":"0.10.0","title":"codex-hud"}}}\n' +
+        '{"jsonrpc":"2.0","method":"initialized","params":{}}\n' +
+        '{"jsonrpc":"2.0","id":2,"method":"account/rateLimits/read","params":{}}\n';
+    return new Promise((resolve) => {
+        let done = false;
+        const finish = (val) => {
+            if (done)
+                return;
+            done = true;
+            try {
+                child.kill();
+            }
+            catch {
+                // already gone
+            }
+            clearTimeout(timer);
+            resolve(val);
+        };
+        let child;
+        try {
+            child = spawn(bin, ["app-server"], { stdio: ["pipe", "pipe", "ignore"] });
+        }
+        catch {
+            return resolve(null);
+        }
+        const timer = setTimeout(() => finish(buf || null), 12_000);
+        let buf = "";
+        child.stdout?.on("data", (d) => {
+            buf += d.toString();
+            if (buf.includes('"id":2'))
+                finish(buf);
+        });
+        child.on("error", () => finish(null));
+        try {
+            child.stdin?.write(requests);
+        }
+        catch {
+            finish(null);
+        }
+    });
+}
+// ── Public: read cache (sync, fast) + kick a detached refresh if stale ──
+let triggered = false;
+function triggerBackgroundRefresh() {
+    if (triggered)
+        return;
+    triggered = true;
+    try {
+        // fileURLToPath (not URL.pathname) so a path with spaces/non-ASCII isn't
+        // left percent-encoded — that would make the child fail to find index.js.
+        const self = fileURLToPath(import.meta.url);
+        const entry = join(self, "..", "index.js");
+        const child = spawn(process.execPath, [entry, "refresh-ratelimits"], {
+            detached: true,
+            stdio: "ignore",
+        });
+        child.unref();
+    }
+    catch {
+        // best-effort
+    }
+}
+let memo = null;
+/**
+ * Newest app-server rate-limit snapshot from cache (fast, sync). If the cache
+ * is stale/missing, fire a detached background refresh so the NEXT render is
+ * current. Returns null if nothing usable is cached yet.
+ */
+export function readAppServerTelemetry() {
+    if (memo)
+        return memo.value;
+    const cached = readCache();
+    if (!cached || !cacheIsFresh()) {
+        triggerBackgroundRefresh();
+    }
+    memo = { value: cached };
+    return cached;
+}

--- a/plugins/codex-hud/dist/config.d.ts
+++ b/plugins/codex-hud/dist/config.d.ts
@@ -1,4 +1,6 @@
 import type { PluginConfig } from "./types.js";
+/** Plugin dir for caches (rate-limit snapshot etc.); created 0700 on demand. */
+export declare function getCacheDir(): string;
 export declare function loadConfig(): PluginConfig;
 export declare function saveConfig(config: PluginConfig): void;
 export declare function resolveAdminKey(): string | null;

--- a/plugins/codex-hud/dist/config.js
+++ b/plugins/codex-hud/dist/config.js
@@ -5,6 +5,14 @@ function getConfigDir() {
     const claudeConfigDir = process.env["CLAUDE_CONFIG_DIR"] || join(homedir(), ".claude");
     return join(claudeConfigDir, "plugins", "codex-hud");
 }
+/** Plugin dir for caches (rate-limit snapshot etc.); created 0700 on demand. */
+export function getCacheDir() {
+    const dir = getConfigDir();
+    if (!existsSync(dir)) {
+        mkdirSync(dir, { recursive: true, mode: 0o700 });
+    }
+    return dir;
+}
 function getConfigPath() {
     return join(getConfigDir(), "config.json");
 }

--- a/plugins/codex-hud/dist/index.js
+++ b/plugins/codex-hud/dist/index.js
@@ -365,6 +365,22 @@ async function main() {
             }
             break;
         }
+        case "refresh-ratelimits": {
+            // Detached background helper: fetch live rate limits from the Codex
+            // app-server (~1s) and write them to the cache for the next render.
+            const { fetchRateLimitStdout, writeRateLimitCacheFrom } = await import("./codex-appserver.js");
+            const out = await fetchRateLimitStdout();
+            const ok = out ? writeRateLimitCacheFrom(out) : false;
+            if (rest.includes("--json")) {
+                console.log(JSON.stringify({ ok }));
+            }
+            else {
+                console.log(ok ? "Rate-limit cache updated." : "Could not fetch rate limits.");
+            }
+            if (!ok)
+                process.exit(1);
+            break;
+        }
         case "preview": {
             // Plain-text render of sample data with ad-hoc overrides, for the
             // configure flow's live previews. e.g. preview --set layout=compact

--- a/plugins/codex-hud/dist/local-logs.js
+++ b/plugins/codex-hud/dist/local-logs.js
@@ -2,6 +2,7 @@ import { readdirSync, readFileSync, existsSync, openSync, readSync, closeSync, s
 import { join } from "node:path";
 import { homedir } from "node:os";
 import { readDbTelemetry } from "./codex-db.js";
+import { readAppServerTelemetry } from "./codex-appserver.js";
 // Files at or below this size are read whole; larger ones are tail-read.
 // total_token_usage is cumulative, so only the LAST token_count per file
 // matters — full-parsing a multi-MB active session on every statusline
@@ -241,9 +242,11 @@ export function aggregateLocalUsage(range) {
             considerTelemetry(parseSessionLog(file));
         }
     }
-    // Codex 0.140+ run via the app-server (the Claude Code codex plugin) doesn't
-    // write rate limits to rollout files — it logs them to ~/.codex/logs_2.sqlite.
-    // Merge that snapshot in if it's fresher than anything from the rollouts.
+    // App-server / Claude Code codex plugin path (Codex 0.140+) doesn't write
+    // rate limits to rollout files. Two sources, newest-wins:
+    //  - 0.140: logged the codex.rate_limits event to ~/.codex/logs_2.sqlite
+    //  - 0.142+: nothing on disk — must ask the app-server over JSON-RPC, which
+    //    codex-appserver caches (refreshed in the background).
     const db = readDbTelemetry();
     if (db) {
         if (db.timestampMs > latestRlTimestamp) {
@@ -251,10 +254,21 @@ export function aggregateLocalUsage(range) {
             latestRlTimestamp = db.timestampMs;
         }
         if (db.model && db.timestampMs > latestModelTimestamp) {
-            // Model from the log; effort from the Codex config (config.toml).
             latestModel = { model: db.model, effort: db.effort };
             latestModelTimestamp = db.timestampMs;
         }
+    }
+    const app = readAppServerTelemetry();
+    if (app && app.timestampMs > latestRlTimestamp) {
+        latestRateLimits = app.rateLimits;
+        latestRlTimestamp = app.timestampMs;
+    }
+    // Model/effort: the app-server RPC doesn't return them and 0.142 logs
+    // nothing, so fall back to the configured values when we have no fresher
+    // model from a rollout/db source.
+    if (app && app.model && app.timestampMs > latestModelTimestamp) {
+        latestModel = { model: app.model, effort: app.effort };
+        latestModelTimestamp = app.timestampMs;
     }
     return {
         sessions,


### PR DESCRIPTION
Updates vendored **codex-hud** to **v0.10.0**.

Source: [haenara-shin/codex-hud@v0.10.0](https://github.com/haenara-shin/codex-hud/releases/tag/v0.10.0)

### What's new
Codex 0.142 stopped writing rate limits to disk entirely — it serves them live over the app-server. codex-hud now reads them by calling `codex app-server` JSON-RPC (`account/rateLimits/read`) itself, caching the result (5-min TTL) and refreshing in a detached background process so the statusline stays fast. Fixes the disappearing 5h / Weekly bars on Codex 0.142+. Newest-wins across rollout logs / `logs_2.sqlite` (0.140–0.141) / app-server RPC (0.142+).

Validated with `claude plugin validate` and `tsc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)