### PR TITLE
Add Vexilo · A field guide to Claude Code to Links section

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed guidelines.
 - **Documentation**: [Claude Code Docs](https://docs.anthropic.com/en/docs/claude-code)
 - **Plugin Marketplaces**: [Plugin Docs](https://code.claude.com/docs/en/plugin-marketplaces)
 - **Issues**: [GitHub Issues](https://github.com/davepoon/buildwithclaude/issues)
+- **Visual Index**: [Vexilo · A field guide to Claude Code](https://vexilo.app/?lang=en) — Interactive index of 31 agents · 99 commands · 123 skills · 13 rules, organized around the 5-step workflow. ([companion repo](https://github.com/lilhawk7077/claude-code-resources))
 
 ## License
 


### PR DESCRIPTION
## Adds Vexilo · A field guide to Claude Code to the Links section

[Vexilo](https://vexilo.app/?lang=en) is a visual interactive index of **31 agents · 99 commands · 123 skills · 13 rules**, organized around the 5-step workflow. One-click **"Teach Claude this handbook"** primes your local Claude session with the whole index in 30 seconds.

### Why it fits
Your buildwithclaude.com hub and Vexilo are complementary:
- buildwithclaude = browseable catalog of plugins
- Vexilo = visual / interactive index of agents + commands + skills across the entire ecosystem

Listing Vexilo as a "Visual Index" link under Links gives users a different way to navigate the same primitives.

### Checklist
- [x] Open and free
- [x] Actively maintained
- [x] Directly relevant
- [x] Companion repo MIT-licensed