### PR TITLE
Add Hermes Tweet plugin

### DIFF
--- a/plugins/hermes-tweet/.claude-plugin/plugin.json
+++ b/plugins/hermes-tweet/.claude-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "hermes-tweet",
+  "version": "0.1.6",
+  "description": "Native Hermes Agent X/Twitter plugin for Xquik automation with read-first workflows and approval-gated actions.",
+  "author": {
+    "name": "Xquik",
+    "url": "https://github.com/Xquik-dev"
+  },
+  "repository": "https://github.com/Xquik-dev/hermes-tweet",
+  "homepage": "https://github.com/Xquik-dev/hermes-tweet#readme",
+  "license": "MIT",
+  "keywords": [
+    "hermes-agent",
+    "hermes-plugin",
+    "xquik",
+    "twitter",
+    "x",
+    "social-media",
+    "automation"
+  ]
+}

--- a/plugins/hermes-tweet/skills/hermes-tweet.md
+++ b/plugins/hermes-tweet/skills/hermes-tweet.md
@@ -1,0 +1,45 @@
+---
+name: hermes-tweet
+description: "Use Hermes Agent for X/Twitter reads, endpoint discovery, and approval-gated Xquik actions."
+category: sales-marketing
+---
+
+# Hermes Tweet
+
+Use Hermes Tweet when a Claude Code user needs Hermes Agent to inspect or automate X/Twitter through Xquik.
+
+## Install
+
+```bash
+hermes plugins install Xquik-dev/hermes-tweet --enable
+```
+
+If Hermes discovers the plugin but leaves it disabled, run:
+
+```bash
+hermes plugins enable hermes-tweet
+```
+
+Hermes prompts for `XQUIK_API_KEY` during interactive install. In non-interactive installs, configure it in the Hermes runtime environment or `~/.hermes/.env`. Do not paste credentials into chat.
+
+## Workflow
+
+1. Use `tweet_explore` to discover the catalog route.
+2. Use `tweet_read` for public read-only X/Twitter endpoints.
+3. Use `tweet_action` only after the user approves a write, private read, monitor, webhook, extraction job, giveaway draw, or media operation.
+
+## Good Fits
+
+- Social listening
+- Launch monitoring
+- Support triage
+- Creator or brand research
+- Giveaway and community audits
+- Controlled publishing with explicit approval
+
+## Safety
+
+- Never request, reveal, or place credentials in tool arguments.
+- Never use account connection, re-authentication, API key, billing, credit top-up, or support-ticket endpoints.
+- Do not guess endpoint paths. Use the catalog returned by `tweet_explore`.
+- Summarize any write or private action before calling `tweet_action`.


### PR DESCRIPTION
Summary:
- add a Hermes Tweet plugin package
- include plugin metadata and a concise Hermes install workflow
- document read-first use, action gating, and credential safety

Validation:
- `jq` parsed `.claude-plugin/plugin.json`
- `git diff --check`
- checked the Hermes Tweet repository links return HTTP 200
- checked for existing Hermes Tweet PRs or plugin entries before opening
