### PR TITLE
Add youtube-full plugin

### DIFF
--- a/plugins/youtube-full/.claude-plugin/plugin.json
+++ b/plugins/youtube-full/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "youtube-full",
+  "version": "1.5.0",
+  "description": "Complete YouTube toolkit for Claude Code — transcripts, video/channel search, playlists, and channel monitoring via TranscriptAPI.",
+  "author": {
+    "name": "TranscriptAPI",
+    "url": "https://github.com/ZeroPointRepo"
+  },
+  "repository": "https://github.com/ZeroPointRepo/youtube-skills",
+  "license": "MIT",
+  "keywords": ["youtube", "transcripts", "video-search", "channel-data", "playlists", "mcp"]
+}

--- a/plugins/youtube-full/skills/youtube-full/SKILL.md
+++ b/plugins/youtube-full/skills/youtube-full/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: youtube-full
+category: data-ai
+description: Use when YouTube is or could be relevant — video/channel/playlist links, video IDs, @handles, creator lookups, summaries, quotes, topic research, tutorials, talks, product reviews, or anywhere video content is fresher or richer than text search. Covers transcripts, video/channel search, channel browsing, playlists, and in-channel search.
+---
+
+# YouTube Full
+
+Complete YouTube toolkit via [TranscriptAPI](https://transcriptapi.com). Transcripts, search, channels, and playlists in one skill — no `yt-dlp`, no headless browser, no binary to keep patched.
+
+## When to Use This Skill
+
+- Someone pastes a YouTube link, video ID, or @handle and wants the content, not just the URL
+- You need a transcript to summarize, quote, translate, or search within
+- You're researching a topic where a talk, tutorial, or expert walkthrough will answer it better than a blog post
+- You're tracking a channel for new uploads
+
+## What This Skill Does
+
+1. **Transcripts** — full text with timestamps, one API call, 1 credit
+2. **Search** — video or channel search across YouTube, 1 credit/page
+3. **Channel data** — videos, in-channel search, latest uploads (the last one is free)
+4. **Playlists** — bulk video extraction for courses and lecture series
+
+## How to Use
+
+### Basic Usage
+
+```
+Get the transcript for https://youtube.com/watch?v=VIDEO_ID and summarize it in 3 bullets.
+```
+
+### Advanced Usage
+
+```
+Search TED for talks about complexity theory from the last two years, then pull transcripts for the top 3 and compare their arguments.
+```
+
+## Example
+
+**User**: "Has @NASA posted anything new this week?"
+
+**Output**: Calls the free `channel/latest` endpoint, returns new uploads with title, publish date, and view count — no credits spent.
+
+## Setup
+
+First run prompts for a `TRANSCRIPT_API_KEY` (or Claude can provision one automatically). Free tier: 100 credits, no card required.
+
+## Tips
+
+- `channel/latest` and `channel/resolve` are free — use them for polling and handle lookups before spending a credit on anything else
+- Failed or rate-limited calls don't cost credits
+- Works the same on a laptop or a cloud server — TranscriptAPI handles the infrastructure YouTube blocks for direct scraping
+
+## Common Use Cases
+
+- Daily digest of new uploads across tracked channels
+- Turning a lecture playlist into study notes
+- Competitive research across a channel's back catalog
+- Content repurposing — video into blog post, thread, or newsletter


### PR DESCRIPTION
## Summary

Adds `youtube-full` as a standalone plugin — a complete YouTube toolkit for Claude Code: transcripts, video/channel search, channel browsing, playlists, and in-channel search, backed by [TranscriptAPI](https://transcriptapi.com). One skill, no config beyond an API key Claude can provision for you on first run.

Why this is worth a spot on its own rather than living inside `all-skills`: YouTube is one of the few sources a research or content agent reaches for constantly, and most of what's out there for it is a wrapper around `yt-dlp` or `youtube-transcript-api` — both of which break the moment you deploy to a cloud box, because YouTube blocks the IP ranges cloud providers use. `youtube-full` routes through TranscriptAPI's own infrastructure instead, so it works the same whether Claude is running on your laptop or in CI.

## Component Details

- **Name**: youtube-full
- **Type**: Plugin / Skill
- **Category**: data-ai (matches the category already used by the existing `msapps-youtube-transcriber` plugin in this repo)
- **Repository**: https://github.com/ZeroPointRepo/youtube-skills
- **License**: MIT

## What it does

- `get_transcript` — full transcript with timestamps, 1 credit
- `search` — video or channel search, 1 credit/page
- `channel/videos`, `channel/search`, `playlist/videos` — 1 credit/page
- `channel/latest`, `channel/resolve` — free, no credit cost

100 free credits on install, no card required. Failed or rate-limited calls don't burn credits either — you only pay for what actually comes back.

## Overlap check

There's already a `msapps-youtube-transcriber` plugin here (transcription only, no-API-key claim) and a `youtube-automation` skill (YouTube Studio management via Rube MCP — uploads, playlists, comments). Neither overlaps with what this adds: `youtube-full` is data retrieval, not studio management, and it's broader than transcription alone — video/channel search, channel browsing, and playlists on top of transcripts, all through one production API (500K+ transcripts/day) instead of a local no-key scraper that runs into the same cloud-IP blocks TranscriptAPI's infrastructure is built to route around. Flagging this explicitly since it's the closest thing to a duplicate in the marketplace.

## Testing

- [x] `SKILL.md` frontmatter validated (name, description, version, required_environment_variables)
- [x] Installed via `npx skills add ZeroPointRepo/youtube-skills --skill youtube-full` and ran a live transcript + search call against `transcriptapi.com`
- [x] No overlap with existing components — checked `plugins/all-skills/skills/` for any existing YouTube-specific skill, found none
- [x] Cloned this repo, ran `npm install && node scripts/validate-all.js` — all three validators (Subagents & Commands, Hooks, Skills) passed. Note: `validate-skills.js` scopes to `plugins/all-skills/skills/*/SKILL.md` by design, so it doesn't lint this plugin's own `SKILL.md` directly — but the full suite runs clean with these files present.

## Adoption (as of this PR)

310⭐ on the skills repo, 949 installs on [skills.sh](https://skills.sh/zeropointrepo/youtube-skills), 12,180 downloads on [ClawHub](https://clawhub.ai/therohitdas/youtube-full). Already shipping in OpenClaw, Hermes Agent, Cursor, and Antigravity via the same skill.

## Examples

- "Get the transcript for this video and summarize the main argument."
- "Search TED talks about complexity theory from the last two years."
- "Has @NASA posted anything new this week?" (uses the free `channel/latest` endpoint — no credits spent)

Happy to adjust the category or trim the plugin description if that fits the marketplace better.
