### PR TITLE
Add tlsradar plugin (resubmit of #207, MCP config included)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -25,6 +25,29 @@
   },
   "plugins": [
     {
+      "name": "tlsradar",
+      "description": "SSL/TLS certificate scanning, free Let's Encrypt issuance (private key stays local), and ongoing certificate-expiry monitoring — through a single remote MCP server. Free anonymous scans and cert issuance need no account; OAuth via /mcp unlocks ongoing monitoring.",
+      "version": "0.5.1",
+      "author": {
+        "name": "TLS Radar",
+        "url": "https://tlsradar.com"
+      },
+      "homepage": "https://tlsradar.com/cli",
+      "repository": "https://github.com/TLS-Radar/tlsradar-claude-plugin",
+      "license": "MIT",
+      "keywords": [
+        "ssl",
+        "tls",
+        "certificates",
+        "monitoring",
+        "letsencrypt",
+        "security",
+        "mcp"
+      ],
+      "category": "security",
+      "source": "./plugins/tlsradar"
+    },
+    {
       "name": "cashflow",
       "description": "Personal finance ledger for AI agents. Connect bank accounts via Plaid, query spending, track recurring bills, categorize transactions, and get financial recaps through MCP tools with OAuth authentication.",
       "version": "0.2.0",

--- a/plugins/tlsradar/.claude-plugin/plugin.json
+++ b/plugins/tlsradar/.claude-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "tlsradar",
+  "displayName": "TLS Radar",
+  "version": "0.5.1",
+  "description": "SSL/TLS certificate monitoring and free Let's Encrypt issuance inside Claude Code and Cowork, through a single MCP server. Free anonymous scans and cert issuance (private key stays local), plus ongoing monitoring after a one-time OAuth via /mcp.",
+  "author": {
+    "name": "TLS Radar",
+    "url": "https://tlsradar.com"
+  },
+  "license": "MIT",
+  "homepage": "https://tlsradar.com/cli",
+  "repository": "https://github.com/TLS-Radar/tlsradar-claude-plugin",
+  "keywords": [
+    "ssl",
+    "tls",
+    "certificates",
+    "monitoring",
+    "letsencrypt",
+    "security"
+  ]
+}

--- a/plugins/tlsradar/.mcp.json
+++ b/plugins/tlsradar/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "tlsradar": {
+      "type": "http",
+      "url": "${TLSRADAR_BASE_URL:-https://tlsradar.com}/api/v1/mcp"
+    }
+  }
+}

--- a/plugins/tlsradar/LICENSE
+++ b/plugins/tlsradar/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 TLS Radar
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/tlsradar/README.md
+++ b/plugins/tlsradar/README.md
@@ -1,0 +1,154 @@
+# TLS Radar plugin for Claude Code & Cowork
+
+[![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
+[![Claude Code plugin](https://img.shields.io/badge/Claude%20Code-plugin-7c3aed)](https://github.com/TLS-Radar/tlsradar-claude-plugin)
+[![smithery badge](https://smithery.ai/badge/slmusayev/tls-radar)](https://smithery.ai/servers/slmusayev/tls-radar)
+
+Run SSL/TLS scans, issue free Let's Encrypt certificates, and manage cert monitoring from inside Claude Code or Claude Cowork - through a single MCP server, with nothing to configure.
+
+Independent monitoring from a vendor that doesn't sell certificates - built for the 90-day-cert era, where manual renewal tracking is already finished.
+
+![Installing the plugin and issuing a free cert with /tls-cert](https://raw.githubusercontent.com/TLS-Radar/tlsradar-claude-plugin/main/docs/demo.gif)
+
+```
+# Public - no account, no setup
+/tls-scan example.com                       # free SSL/TLS scan
+/tls-cert mydomain.dev                      # free 90-day Let's Encrypt cert (private key stays local)
+/tls-renew mydomain.dev                     # renew a cert
+
+# Connect once for monitoring (OAuth via /mcp)
+/mcp                                        # built-in Claude Code OAuth flow
+/tls-monitor add api.foo.io                 # one or many: /tls-monitor add a.com b.com c.com
+/tls-monitor list
+/tls-monitor remove api.foo.io
+/tls-diagnose                               # health check (use when something's off)
+/tls-upgrade                                # open pricing page
+```
+
+> **See real output before installing:** [sample scan report](https://tlsradar.com/scan/7yeRj83mGGhcuhe5rSbXZg)
+
+Other actions - "what's expiring soon," "scan history for X," "what plan am I on," "export/import my monitors," "invite a teammate" - just ask in plain language; the plugin's skill routes them to the right tool. No slash command needed.
+
+## How it works
+
+Claude Code's MCP client talks to **one** remote server:
+
+- `tlsradar.com/api/v1/mcp`
+
+Certificate issuance is **proxied through that server** to the Let's Encrypt backend (Beacon), so there's a single connection and a single auth model - no second server, no token to paste into your shell.
+
+- **Public tools** (`scan`, `create_certificate`, `check_certificate_propagation`, `finalize_certificate`, `get_certificate_status`, `renew_certificate`) work with no account.
+- **Authenticated tools** (monitoring, plan info, export/import, team) use Claude Code's built-in OAuth 2.0 + PKCE. Run `/mcp` once, pick the `tlsradar` server, approve in the browser; the token is managed by Claude Code.
+
+When you run `/mcp`, Claude Code fetches `tlsradar.com/.well-known/oauth-authorization-server` (RFC 8414), dynamically registers as a public client (RFC 7591), opens the browser for consent (PKCE / RFC 7636), and includes the token on subsequent requests automatically.
+
+### Certificates keep your private key local
+
+`/tls-cert` generates the key + CSR on **your** machine with `openssl` and sends only the CSR. The private key never leaves your computer and no passphrase is ever typed into the chat. If you want a `.p12` bundle (e.g. for Windows/Java import), the plugin packages it locally too.
+
+You choose how to prove control of the domain, and the plugin remembers your choice (in `~/.config/tlsradar/config.json`):
+
+- **`dns-01`** - you add a TXT record by hand (works anywhere).
+- **`dns-01-cloudflare` / `dns-01-route53`** - the plugin sets the TXT record for you via the provider API, reading your token from the local environment (`CLOUDFLARE_API_TOKEN`, or your configured `aws` CLI). Those credentials stay on your machine - they're never sent to TLS Radar or Beacon.
+- **`http-01`** - serve a file on `http://yourdomain` (port 80); issues the apex only.
+
+When a cert is issued, TLS Radar emails you about ongoing monitoring - the cert → monitoring handoff is fully automatic and server-side.
+
+### Works in Claude Code and Cowork
+
+This is a standard plugin, so it runs in both **Claude Code** and **Claude Cowork**. Scanning, certificate issuance, and monitoring all work in either client: the tools come from one MCP server, and the certificate flow runs `openssl` plus a bundled helper script locally (both clients can run local commands and the bundled script via `${CLAUDE_PLUGIN_ROOT}`). Connecting for monitoring uses your client's built-in OAuth - `/mcp` in Claude Code, or the equivalent connect step in Cowork.
+
+### Use in Claude.ai (custom connector)
+
+You don't need Claude Code to scan and monitor from Claude. TLS Radar is a standard **remote** MCP server, so you can add it as a **custom connector** in the Claude.ai apps (web, desktop, mobile) on any plan - Free included (Free allows one connector).
+
+1. Open **Settings → Connectors** (Team/Enterprise: **Organization settings → Connectors**, Owner only).
+2. Click **Add custom connector**.
+3. Paste the connector URL: `https://tlsradar.com/api/v1/mcp/connect`
+4. Save, then **sign in to TLS Radar** when the OAuth prompt appears (the connector is an authenticated surface - sign-in connects your account once, then scanning and monitoring both work).
+
+Then just ask in plain language - "scan example.com", "what certs are expiring soon", "monitor api.foo.io". There are no slash commands in Claude.ai; the tool descriptions route your request.
+
+> **No account? Use Claude Code instead.** The anonymous, no-signup scanning and free cert issuance live in the Claude Code plugin (below), which talks to the public `…/api/v1/mcp` endpoint. The Claude.ai connector requires a one-time sign-in because hosted connectors must authenticate.
+
+> **Certificate issuance stays a Claude Code / Cowork feature.** `/tls-cert` generates your private key locally with `openssl`, which the Claude.ai apps can't do (no local shell). In a connector you get scanning and monitoring; to issue a Let's Encrypt cert with the key staying on your machine, use the plugin in Claude Code/Cowork, or the web form at [beacon.tlsradar.com](https://beacon.tlsradar.com).
+
+## Install
+
+In Claude Code, add the marketplace and install - two commands, no clone, no paths:
+
+```
+/plugin marketplace add TLS-Radar/tlsradar-claude-plugin
+/plugin install tlsradar@tlsradar
+```
+
+(Or browse it in the `/plugin` menu after adding the marketplace.) In **Claude Cowork**, add it from the plugin catalog (search "TLS Radar"). That's it - scanning and cert issuance work immediately. Run `/mcp` (or Cowork's connect step) when you want monitoring.
+
+<details>
+<summary>Manual install (no marketplace)</summary>
+
+```bash
+git clone https://github.com/TLS-Radar/tlsradar-claude-plugin ~/.claude/plugins/tlsradar
+```
+</details>
+
+## Free plan limits
+
+- **1 monitor** included free
+- **1 alert per month**, delivered at 7 days before expiry
+- Unlimited free scans (rate-limited)
+- Free Let's Encrypt issuance
+- REST API access on every plan, including Free
+
+When you hit the monitor limit, the tool's response includes the recommended upgrade and a pricing URL.
+
+## Configuration
+
+Nothing is required. Optional environment variables:
+
+- `TLSRADAR_BASE_URL` - override the TLS Radar URL (default `https://tlsradar.com`). Useful for staging/self-host.
+
+**Anonymous usage id.** On first run the plugin mints a random id at `~/.config/tlsradar/install_id` and the scan/cert commands pass it (as a `client_id` argument) so anonymous usage can be attributed to one install. It identifies an install, not a person. The plugin **does not modify your shell config and sends no tracking header** - the id travels only as that argument, read from the local file.
+
+  **To opt out:** `rm ~/.config/tlsradar/install_id`. With the file gone, no id is sent.
+
+## Privacy & security
+
+- This plugin ships **no tokens or credentials** - there's nothing secret in this repo. See [`SECURITY.md`](./SECURITY.md).
+- The OAuth token is managed by Claude Code's MCP client, not by this plugin.
+- Certificate private keys are generated locally and never sent to any server.
+- DNS-provider credentials (`CLOUDFLARE_API_TOKEN`, AWS CLI) are read from your local environment and never sent to TLS Radar or Beacon.
+- An anonymous install id is sent for usage attribution, passed as a tool argument read from `~/.config/tlsradar/install_id` (see Configuration to opt out). The plugin modifies no shell files and sends no tracking header. It identifies an install, not a person.
+- To revoke access: `https://tlsradar.com/oauth/authorized_applications` or remove the MCP server in `/mcp`.
+- Access tokens expire in 2 hours; refresh tokens rotate on use, capped at 90 days.
+
+## Layout
+
+```
+.
+├── README.md                        # this file
+├── CLAUDE.md                        # architecture / funnel / contracts (humans + AI agents)
+├── CONTRIBUTING.md                  # dev loop + how to add commands
+├── CHANGELOG.md                     # version history
+├── SECURITY.md                      # reporting + why the plugin holds no secrets
+├── LICENSE                          # MIT
+├── .claude-plugin/plugin.json       # plugin manifest
+├── .claude-plugin/marketplace.json  # self-hosting marketplace entry
+├── .mcp.json                        # MCP server config (one remote URL)
+├── commands/                        # slash commands (how to add one: CONTRIBUTING.md)
+├── skills/                          # NL skill router (with its own README)
+├── hooks/hooks.json                 # one-time SessionStart welcome (print only)
+├── tools/manifest.json              # single source of truth for tool names
+├── scripts/                         # CI guards + tested DNS-provider helper
+└── evals/                           # tool-routing evals (prompt → expected tool)
+```
+
+## Contributing
+
+Start with [`CONTRIBUTING.md`](./CONTRIBUTING.md) for the dev loop (all checks are offline and run with `python3`). For architecture, the funnel, contract pitfalls, and the release process, read [`CLAUDE.md`](./CLAUDE.md) - useful for both humans and AI agents. Changes are tracked in [`CHANGELOG.md`](./CHANGELOG.md).
+
+Security reports: **security@tlsradar.com** (never a public issue) - see [`SECURITY.md`](./SECURITY.md).
+
+## License
+
+[MIT](./LICENSE) © TLS Radar

--- a/plugins/tlsradar/commands/tls-cert.md
+++ b/plugins/tlsradar/commands/tls-cert.md
@@ -1,0 +1,100 @@
+---
+description: Issue a free 90-day Let's Encrypt certificate
+argument-hint: <domain>
+allowed-tools: Bash(openssl*), Bash(python3 *dns_provider.py*), Bash(mkdir -p *tlsradar*), Read, Write
+---
+
+Issue a free SSL/TLS certificate from Let's Encrypt for `$ARGUMENTS`, entirely through the TLS Radar MCP server's certificate tools. The private key is generated **locally** and never leaves the machine.
+
+## 1. Choose the validation (challenge) method
+
+Read `${HOME}/.config/tlsradar/config.json` (it may not exist). Its shape:
+
+```json
+{ "default_challenge": "dns-01-cloudflare",
+  "per_domain": { "example.com": "http-01" } }
+```
+
+Pick the method in this order: a `per_domain` entry for `$ARGUMENTS` → else `default_challenge` → else **ask the user**, offering:
+
+| Method | How it's proven | Best when |
+|---|---|---|
+| `dns-01` (manual TXT) | You show a TXT record; the user adds it by hand | Any domain; no API token |
+| `dns-01-cloudflare` | Claude sets the TXT record via the Cloudflare API (`$CLOUDFLARE_API_TOKEN`) | Domain on Cloudflare - fully automated |
+| `dns-01-route53` | Claude sets the TXT record via the AWS CLI (`aws` configured) | Domain on Route 53 - fully automated |
+| `http-01` | Serve a file on `http://$ARGUMENTS` port 80 | You control the web server; issues the apex only (no www) |
+
+When the user picks one, ask "save as the default?" - if yes, write it back to `default_challenge` (or `per_domain["$ARGUMENTS"]` if they say "just for this domain"), preserving the rest of the file. Create `~/.config/tlsradar` first if needed.
+
+The Beacon `challenge` value is `http-01` for `http-01`, otherwise `dns-01` (all three dns-01 variants differ only in *how the plugin sets the TXT record*).
+
+## 2. Start the order
+
+You'll need the user's email. When you ask for it (or before using one from context), tell them plainly what it's for: **the Let's Encrypt order, and a one-time follow-up email from TLS Radar about monitoring this certificate's expiry. No marketing unless they opt in.** Only set `marketing_consent: true` if they explicitly ask for it (default is off - keep it off).
+
+Read `${HOME}/.config/tlsradar/install_id` if it exists. Call `tlsradar.create_certificate` with `domain=$ARGUMENTS`, `email`, `challenge` (`dns-01` or `http-01`), and `client_id` = that install id (for anonymous funnel attribution; omit if the file is absent). It returns `order_id`, either `dns_records` or `http_files`, a `resume_token`, and an `install_id`.
+
+**Keep two things from the response for later:** the `resume_token` (lets you finalize even if the order is interrupted for a day) and the `install_id` - if `~/.config/tlsradar/install_id` didn't exist, write the returned `install_id` there so future calls are attributed to the same install.
+
+**If any certificate-tool call returns `structuredContent.degraded: true`** (the certificate backend is briefly unavailable - server-side and transient), don't treat it as a hard failure or retry in a loop: relay the friendly message, note that `/tls-scan` still works, and suggest trying again in a minute. This can happen at any step below.
+
+## 3. Put the challenge in place
+
+**dns-01 (manual):** show the TXT record(s) from `dns_records`; the user publishes them.
+
+**dns-01-cloudflare / dns-01-route53:** for each record in `dns_records`, run the bundled helper - it handles zone lookup, the Cloudflare API call / Route 53 change-batch, and Route 53's TXT double-quoting (all tested, so the model doesn't hand-build the request):
+
+```
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/dns_provider.py" set \
+  --provider <cloudflare|route53> --name "<record.name>" --value "<record.value>"
+```
+
+Credentials are read from the local environment by the helper (`CLOUDFLARE_API_TOKEN`, or the configured `aws` CLI) and never sent to TLS Radar or Beacon. If zone auto-detection is wrong, pass `--zone <id>`.
+
+**http-01:** each `http_files` entry must be served at `http://<domain><path>` with the exact `content` body on port 80. If the user gives you a webroot, write the file to `<webroot><path>`; otherwise show them the path + content to place themselves.
+
+## 4. Wait for propagation
+
+Poll `tlsradar.check_certificate_propagation` with `order_id` until `all_found` is `true`. Don't finalize before it's green.
+
+## 5. Generate a CSR locally, then finalize
+
+Generate the key + CSR on the user's machine. **The SAN set depends on the method:** `dns-01*` issues `{$ARGUMENTS, www.$ARGUMENTS}`; `http-01` issues `$ARGUMENTS` only.
+
+```
+mkdir -p "${HOME}/.config/tlsradar/certs"
+# dns-01 variants (apex + www):
+openssl req -new -newkey rsa:2048 -nodes \
+  -keyout "${HOME}/.config/tlsradar/certs/$ARGUMENTS.key" \
+  -out "${HOME}/.config/tlsradar/certs/$ARGUMENTS.csr" \
+  -subj "/CN=$ARGUMENTS" -addext "subjectAltName=DNS:$ARGUMENTS,DNS:www.$ARGUMENTS"
+# http-01 (apex only): drop the ,DNS:www.$ARGUMENTS from subjectAltName
+```
+
+Read the `.csr` and call `tlsradar.finalize_certificate` with `order_id` + `csr_pem` (and the `resume_token` from step 2 - harmless normally, and the only way to finish if Beacon purged the order after a long gap). It validates, waits briefly, and issues, returning `fullchain_pem`. If it replies "still validating," re-run `tlsradar.check_certificate_propagation`, then `tlsradar.finalize_certificate` again - **safe to retry** (a completed order returns the same chain, never re-issues).
+
+## 6. Save the certificate
+
+Write `fullchain_pem` to `${HOME}/.config/tlsradar/certs/$ARGUMENTS.fullchain.pem` (next to the `.key`). Tell the user both paths.
+
+If they want a PKCS#12 (Windows/Java), package it **locally** - key and passphrase stay on their machine (openssl prompts for the export password; never ask for it in chat):
+
+```
+openssl pkcs12 -export \
+  -inkey "${HOME}/.config/tlsradar/certs/$ARGUMENTS.key" \
+  -in "${HOME}/.config/tlsradar/certs/$ARGUMENTS.fullchain.pem" \
+  -out "${HOME}/.config/tlsradar/certs/$ARGUMENTS.p12"
+```
+
+If they want the files in their project dir, have them `.gitignore` `*.key *.p12 *.csr` first.
+
+## After issuance
+
+The cert → monitoring handoff is automatic and server-side. `finalize_certificate`'s response carries a `handoff` object - relay `structuredContent.handoff.message` to the user and **don't** add the monitor manually.
+
+## Cleanup & notes
+
+- After a successful dns-01-provider issuance, offer to delete the `_acme-challenge` TXT record you created - same helper, `delete` action: `python3 "${CLAUDE_PLUGIN_ROOT}/scripts/dns_provider.py" delete --provider <cloudflare|route53> --name "<record.name>" --value "<record.value>"`.
+- Provider credentials (`$CLOUDFLARE_API_TOKEN`, AWS creds) are read locally by the helper and never sent to TLS Radar or Beacon.
+- Don't ask the user for any private-key or p12 passphrase in chat.
+- Don't push `/tls-monitor add` afterward - the handoff covers it.

--- a/plugins/tlsradar/commands/tls-diagnose.md
+++ b/plugins/tlsradar/commands/tls-diagnose.md
@@ -1,0 +1,50 @@
+---
+description: Verify the TLS Radar plugin's connection and configuration
+---
+
+Run a health check on the plugin's MCP backend and report the status. This is for users who installed the plugin and something isn't working - give them a concrete picture instead of "it just doesn't work."
+
+The plugin talks to a single MCP server (`tlsradar`); certificate issuance is proxied through it to Beacon, so there's no second connection or token to check.
+
+## What to check, in order
+
+### 1. TLS Radar reachability (public tools)
+
+Call `tlsradar.scan_domain` with `domain=example.com` to verify the public MCP endpoint responds.
+
+- **Success:** "✓ TLS Radar MCP is reachable (public tools work)"
+- **Connection error:** "✗ Can't reach tlsradar.com - check the TLSRADAR_BASE_URL environment variable and your network"
+
+### 2. TLS Radar authentication
+
+Call `tlsradar.get_account` (requires auth).
+
+- **Success:** "✓ Authenticated as `<email>` (`<plan>` plan, `<used>/<limit>` monitors used)"
+- **401 / unauthorized:** "✗ Not connected. Run `/mcp`, pick the `tlsradar` server, and approve OAuth in your browser. (Scanning and cert issuance still work without this.)"
+- **Other error:** report it verbatim.
+
+### 3. Certificate issuance path (proxy → Beacon)
+
+Call `tlsradar.get_certificate_status` with a deliberately non-existent `order_id` like `health-check-probe`. This proxies through to Beacon without creating anything.
+
+- **Returns an "order not found" (or similar) error WITHOUT `structuredContent.degraded`:** "✓ Certificate issuance is reachable" (Beacon answered - it just doesn't know that order)
+- **Returns `structuredContent.degraded: true` (the proxy's graceful-degradation response):** "⚠ The certificate backend is briefly unavailable - `/tls-cert` will fail right now. This is server-side and transient; try again in a minute."
+- **Connection error:** covered by check 1 (same server).
+
+### 4. Environment
+
+Report:
+- `TLSRADAR_BASE_URL`: its value or "(default: https://tlsradar.com)"
+- `~/.config/tlsradar/install_id` (the anonymous usage id the scan/cert commands pass as `client_id`): "present (anonymous usage id active)" if the file exists, else "(absent - attribution off; harmless)". The id lives only in this file - the plugin uses no env var or header for it.
+
+## Output format
+
+Render as a checklist with ✓/✗/⚠ markers. If everything is green, end with: "All systems go. You can run any of the `/tls-*` commands."
+
+If anything is red or yellow, end with: "Run the specific command that's failing for a detailed error, or open an issue at https://github.com/TLS-Radar/tlsradar-claude-plugin/issues"
+
+## Things this command should NOT do
+
+- Don't try to fix problems - only report them.
+- Don't expose any bearer tokens or auth headers in the output.
+- Don't make more than 3 MCP calls total.

--- a/plugins/tlsradar/commands/tls-monitor.md
+++ b/plugins/tlsradar/commands/tls-monitor.md
@@ -1,0 +1,38 @@
+---
+description: Manage ongoing certificate monitoring (list, add, remove)
+argument-hint: list | add <domain> [domain ...] | remove <domain>
+---
+
+Manage TLS Radar monitors. Parse `$ARGUMENTS`:
+
+## `list` (default if no args)
+
+Call `tlsradar.list_monitors`. Show domain, expiry days, last-scan timestamp. Sort by days-until-expiry ascending so the most urgent surfaces first.
+
+If the user is at the plan's monitor cap (used == limit from `list_monitors` meta), mention casually: "You're at your `<plan>` plan's `<limit>` monitor cap. `/tls-upgrade` to lift it."
+
+## `add <domain> [more domains...]`
+
+Decide between single-add and bulk-add based on argument count:
+
+- **One domain:** call `tlsradar.add_monitor` with `domain`
+- **Two or more:** call `tlsradar.add_monitors` with `domains: [d1, d2, ...]`. The bulk variant returns per-domain status, so you can render "added 8/10, 2 hit the limit."
+
+New monitors land on the **first active scan_group of your current team**. If you've never created one, TLS Radar bootstraps one for you the first time you add a monitor. Use the web dashboard to organize hosts into named scan_groups; the plugin doesn't ask which group to use.
+
+If either returns `domains_limit_reached`:
+- Lead with the `recommended_upgrade` (typically Starter)
+- Offer `/tls-upgrade` to open the pricing page
+- Offer `/tls-monitor remove <existing>` to free a slot
+
+If a domain was successfully added, mention briefly that the first scan is queued and the user will be notified before the cert expires (free plan: 7-day warning; paid plans: 30-day warning).
+
+## `remove <domain>`
+
+Call `tlsradar.remove_monitor` with `domain`. Confirm with the user before calling if removing would drop their monitor count to 0 - getting back to 1 just means re-adding, but a user might not realize they're about to lose their only monitor.
+
+## Things this command should NOT do
+
+- Don't loop: if `add_monitors` hits the limit halfway through, surface the result once; don't keep retrying.
+- Don't assume the user wants to remove all monitors when they say "remove all" - confirm explicitly and only after they re-affirm.
+- Don't auto-suggest team-scoping operations - if the user wants to invite a teammate, that's the `tlsradar.invite_team_member` tool (no slash command), reached by natural language.

--- a/plugins/tlsradar/commands/tls-renew.md
+++ b/plugins/tlsradar/commands/tls-renew.md
@@ -1,0 +1,26 @@
+---
+description: Renew a Let's Encrypt certificate before it expires
+argument-hint: <domain>
+allowed-tools: Bash(openssl*), Bash(open*), Write
+---
+
+Renew the Let's Encrypt certificate for `$ARGUMENTS`. Renewal issues a fresh 90-day cert for the same domain; the user's monitoring picks up the new cert on the next scan.
+
+## Flow
+
+`tlsradar.renew_certificate` clones an existing order by its **`order_id`**, and orders are purged ~24h after creation - so months later at renewal time there's usually no order to clone. Two cases:
+
+- **No `order_id` (the normal case):** just run a fresh issuance - it *is* the renewal. Follow `/tls-cert` exactly: `tlsradar.create_certificate(domain=$ARGUMENTS, email=…)` → publish TXT → `tlsradar.check_certificate_propagation` until green → generate a CSR locally → `tlsradar.finalize_certificate(order_id, csr_pem)`.
+- **User still has a recent `order_id`:** call `tlsradar.renew_certificate` with it to get a fresh order + new TXT records, then continue from the propagation step as above.
+
+Either way the private key is generated locally (CSR path) and the monitoring handoff fires automatically when the cert completes - you do not register anything.
+
+## When to suggest this proactively
+
+If the user runs an expiry check and any entry shows < 30 days remaining, suggest `/tls-renew <domain>`. Don't auto-renew without asking - renewal involves DNS changes the user controls.
+
+## Things this command should NOT do
+
+- Don't renew an unrelated domain just because it's expiring - only act on `$ARGUMENTS`.
+- Don't call `tlsradar.renew_certificate` with a domain - it takes an `order_id`. Without one, use `tlsradar.create_certificate`.
+- Don't tell the user to manually update monitoring afterward - the cert change is picked up on the next scheduled scan.

--- a/plugins/tlsradar/commands/tls-scan.md
+++ b/plugins/tlsradar/commands/tls-scan.md
@@ -1,0 +1,15 @@
+---
+description: Run a free SSL/TLS scan on a domain (no account required)
+argument-hint: <domain>
+allowed-tools: Read, Write
+---
+
+Run a free, anonymous SSL/TLS scan against `$ARGUMENTS` by calling the `tlsradar.scan_domain` MCP tool.
+
+If `${HOME}/.config/tlsradar/install_id` exists, read it and pass its contents as `client_id` (anonymous funnel attribution; just omit it if the file is absent). If the response includes an `install_id` and the file didn't exist, write it there so future calls share the same id.
+
+If the user did not pass a domain, ask for one before calling the tool. Do not invent a domain.
+
+After the scan completes, summarize the result in plain text: the issuer, expiration date, and any flagged issues. Include the shareable report URL from the response.
+
+If the response shows the certificate expiring within 30 days, suggest the user run `/tls-monitor add <domain>` to add it to ongoing monitoring with renewal alerts.

--- a/plugins/tlsradar/commands/tls-upgrade.md
+++ b/plugins/tlsradar/commands/tls-upgrade.md
@@ -1,0 +1,34 @@
+---
+description: Open TLS Radar pricing or upgrade your plan
+argument-hint: "[plan: starter | pro | business]"
+allowed-tools: Bash(open*)
+---
+
+Open TLS Radar's pricing page in the user's browser. This is the explicit funnel command - users who want more monitors, Slack alerts, or vulnerability scanning use this to compare and choose.
+
+## Behavior
+
+If `$ARGUMENTS` is a known plan tier (`starter`, `pro`, or `business`), open that tier's page directly:
+- `open 'https://tlsradar.com/pricing?source=plugin&utm_content=cli_upgrade&plan=<tier>'`
+
+If `$ARGUMENTS` is empty or anything else, open the main pricing page:
+- `open 'https://tlsradar.com/pricing?source=plugin&utm_content=cli_upgrade'`
+
+After opening, briefly orient the user on the tiers. **Do not quote exact prices or feature counts from memory** - they change, and stale numbers read as false advertising. If the user is already connected, prefer live values from `tlsradar.get_account` (but don't trigger an auth prompt just for this). Otherwise keep it general and let the page you just opened carry the current, exact numbers:
+
+- **Starter** (plans start around $10/mo) - the usual first upgrade: more monitors, more frequent checks, and vulnerability scanning.
+- **Pro** - for larger portfolios: many more monitors and advanced analytics.
+- **Business** - teams and high scale: Slack & webhook alerts, custom schedules, revocation monitoring.
+
+Point the user to the open pricing page for the exact prices, monitor counts, and alert quotas. End with a one-liner about what stays the same on every plan: REST API, Claude Code plugin, and email notifications.
+
+## Why this command exists
+
+Most upgrade prompts in the plugin are reactive - when a user hits a limit, the 402 response includes upgrade options. This command is the proactive path: a user who just wants to evaluate plans without hitting an error.
+
+## Things this command should NOT do
+
+- Don't try to charge the user or collect payment info - that's the web app's job.
+- Don't push a specific tier unless the user named it. Lead with the user's likely next-tier (Starter for free users, Pro for Starter, etc.) but don't insist.
+- Don't recite exact prices/quotas from memory - they go stale. Use live `tlsradar.get_account` data or defer to the pricing page.
+- Don't run `tlsradar.get_account` if it would prompt for auth - the goal here is friction-free upgrade browsing.

--- a/plugins/tlsradar/hooks/hooks.json
+++ b/plugins/tlsradar/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "! test -f ${HOME}/.config/tlsradar/welcomed.rev2",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "mkdir -p \"${HOME}/.config/tlsradar\" && printf '\\n👋 TLS Radar plugin ready - nothing to configure, and it never touches your shell config.\\n\\n  /tls-scan <domain>     free SSL/TLS scan, no account\\n  /tls-cert <domain>     free Let'\\''s Encrypt cert (private key stays local)\\n  /mcp                    connect for monitoring (OAuth)\\n  /tls-monitor add ...    ongoing monitoring (after /mcp)\\n  /tls-diagnose           health check\\n\\nDocs: https://tlsradar.com/cli\\n\\n' && touch \"${HOME}/.config/tlsradar/welcomed.rev2\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/tlsradar/scripts/dns_provider.py
+++ b/plugins/tlsradar/scripts/dns_provider.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Set/delete the dns-01 challenge TXT record via a DNS provider's API.
+
+Why this exists: the provider automation (Cloudflare zone lookup, Route 53's
+change-batch with its TXT double-quoting gotcha, extracting the registrable
+root) is the most failure-prone part of issuance, and it used to live as shell
+snippets inside a prompt - untested. This moves it into one tested place. The
+prompt just calls:
+
+    dns_provider.py set    --provider cloudflare --name _acme-challenge.example.com --value <txt>
+    dns_provider.py delete --provider route53    --name _acme-challenge.example.com --value <txt>
+
+Credentials stay LOCAL and are read from the environment, never passed as args
+and never sent anywhere but the provider:
+  - cloudflare: CLOUDFLARE_API_TOKEN
+  - route53:    the standard AWS env/profile the `aws` CLI already uses
+
+The risky, gotcha-prone bits (root extraction, payload shapes, TXT quoting) are
+pure functions covered by scripts/dns_provider_test.py. The network/CLI calls
+are thin wrappers around them.
+
+Exit 0 on success; non-zero with a message on failure.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+
+CF_API = "https://api.cloudflare.com/client/v4"
+
+
+# --- pure helpers (tested) ---------------------------------------------------
+
+def registrable_root(name: str) -> str:
+    """Best-effort registrable domain for a challenge name.
+
+    Challenge names look like `_acme-challenge.sub.example.com`. We want the
+    zone to query the provider for. This uses a small public-suffix-aware-ish
+    heuristic: two labels normally, three when the second-to-last label is a
+    known two-level TLD (co.uk, com.au, ...). Not a full PSL, but covers the
+    common cases; callers can override with --zone for anything exotic.
+    """
+    # DNS is case-insensitive and providers return zone names lowercased, so
+    # fold here - otherwise a mixed-case challenge name would never match a zone.
+    labels = name.rstrip(".").lower().split(".")
+    if len(labels) <= 2:
+        return ".".join(labels)
+    two_level = {"co.uk", "com.au", "co.nz", "co.jp", "com.br", "co.za", "org.uk", "ac.uk"}
+    last_two = ".".join(labels[-2:])
+    if last_two in two_level and len(labels) >= 3:
+        return ".".join(labels[-3:])
+    return last_two
+
+
+def cloudflare_record_payload(name: str, value: str) -> dict:
+    """Body for POST /zones/{id}/dns_records."""
+    return {"type": "TXT", "name": name, "content": value, "ttl": 60}
+
+
+def route53_change_batch(name: str, value: str, action: str) -> dict:
+    """Route 53 TXT values MUST be enclosed in double quotes inside the record.
+
+    This quoting is the classic footgun; encode it once, here.
+    """
+    quoted = '"' + value.replace('"', '\\"') + '"'
+    return {
+        "Changes": [{
+            "Action": action,  # UPSERT or DELETE
+            "ResourceRecordSet": {
+                "Name": name,
+                "Type": "TXT",
+                "TTL": 60,
+                "ResourceRecords": [{"Value": quoted}],
+            },
+        }]
+    }
+
+
+# --- provider calls (thin wrappers) -----------------------------------------
+
+def _cf_request(method: str, path: str, token: str, body: dict | None = None) -> dict:
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(CF_API + path, data=data, method=method)
+    req.add_header("Authorization", f"Bearer {token}")
+    req.add_header("Content-Type", "application/json")
+    with urllib.request.urlopen(req, timeout=15) as resp:
+        return json.loads(resp.read().decode())
+
+
+def cloudflare(action: str, name: str, value: str, zone: str | None) -> None:
+    token = os.environ.get("CLOUDFLARE_API_TOKEN")
+    if not token:
+        raise SystemExit("CLOUDFLARE_API_TOKEN is not set")
+    root = zone or registrable_root(name)
+    zones = _cf_request("GET", f"/zones?name={root}", token)
+    results = zones.get("result") or []
+    if not results:
+        raise SystemExit(f"Cloudflare: no zone found for {root} (try --zone)")
+    zone_id = results[0]["id"]
+
+    if action == "set":
+        out = _cf_request("POST", f"/zones/{zone_id}/dns_records", token, cloudflare_record_payload(name, value))
+        if not out.get("success"):
+            raise SystemExit(f"Cloudflare set failed: {out.get('errors')}")
+    else:  # delete: find the matching record then remove it
+        recs = _cf_request("GET", f"/zones/{zone_id}/dns_records?type=TXT&name={name}", token)
+        for rec in recs.get("result") or []:
+            if rec.get("content") == value:
+                _cf_request("DELETE", f"/zones/{zone_id}/dns_records/{rec['id']}", token)
+
+
+def route53(action: str, name: str, value: str, zone: str | None) -> None:
+    zone_id = zone or _route53_zone_id(registrable_root(name))
+    batch = route53_change_batch(name, value, "UPSERT" if action == "set" else "DELETE")
+    _aws("route53", "change-resource-record-sets",
+         "--hosted-zone-id", zone_id, "--change-batch", json.dumps(batch))
+
+
+def route53_zone_id_from_list(zones: list, root: str) -> str | None:
+    """Return the hosted-zone id only if the first zone EXACTLY matches root.
+
+    list-hosted-zones-by-name returns zones lexicographically >= the query, so
+    the first result is NOT guaranteed to be `root` - if no exact zone exists
+    it's the next one. Picking it blindly would write the challenge record into
+    the wrong zone. Returns None when there's no exact match.
+    """
+    if zones and zones[0].get("Name", "").rstrip(".") == root:
+        return zones[0]["Id"].split("/")[-1]
+    return None
+
+
+def _route53_zone_id(root: str) -> str:
+    out = _aws("route53", "list-hosted-zones-by-name", "--dns-name", root, "--max-items", "1")
+    zone_id = route53_zone_id_from_list(json.loads(out).get("HostedZones") or [], root)
+    if zone_id is None:
+        raise SystemExit(f"Route 53: no hosted zone exactly matching {root} (pass --zone <id>)")
+    return zone_id
+
+
+def _aws(*args: str) -> str:
+    try:
+        return subprocess.run(["aws", *args], check=True, capture_output=True, text=True).stdout
+    except FileNotFoundError:
+        raise SystemExit("the `aws` CLI is not installed")
+    except subprocess.CalledProcessError as e:
+        raise SystemExit(f"aws {' '.join(args[:2])} failed: {e.stderr.strip()}")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("action", choices=["set", "delete"])
+    ap.add_argument("--provider", required=True, choices=["cloudflare", "route53"])
+    ap.add_argument("--name", required=True, help="full record name, e.g. _acme-challenge.example.com")
+    ap.add_argument("--value", required=True, help="the TXT value from cert_create")
+    ap.add_argument("--zone", help="override the zone/hosted-zone id if root detection is wrong")
+    args = ap.parse_args()
+
+    try:
+        (cloudflare if args.provider == "cloudflare" else route53)(args.action, args.name, args.value, args.zone)
+    except urllib.error.URLError as e:
+        print(f"network error talking to {args.provider}: {e}", file=sys.stderr)
+        return 1
+    print(f"{args.action} ok ({args.provider}): {args.name}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/tlsradar/skills/README.md
+++ b/plugins/tlsradar/skills/README.md
@@ -1,0 +1,50 @@
+# Skills
+
+Skills are Claude's natural-language router. When the user says "is my cert expiring," there's no `/expiring` command in their head - but Claude reads `certificate-monitoring/SKILL.md`, sees the trigger phrases, and picks `tlsradar.expiring`.
+
+Read `../CLAUDE.md` first for full context.
+
+## Skill vs slash command
+
+| Skill | Slash command |
+|---|---|
+| Triggered by Claude noticing relevant user intent | Explicitly invoked by the user |
+| One file per knowledge domain | One file per action |
+| Routes between tools/commands | Calls a specific tool |
+| Loaded into context automatically when relevant | Loaded when typed |
+
+Slash commands are user-controlled. Skills are Claude-controlled. Both can co-exist for the same operation - `/tls-monitor list` is user-explicit; "what am I monitoring?" hits the skill and routes to the same tool.
+
+## Format
+
+```
+skills/<skill-name>/
+└── SKILL.md
+```
+
+The directory layout matters: Claude Code's plugin loader looks for `SKILL.md` inside per-skill subdirectories. Don't put the markdown at the root of `skills/`.
+
+Frontmatter:
+
+```yaml
+---
+name: certificate-monitoring
+description: One paragraph explaining WHEN this skill should activate.
+  Include trigger phrases the user might say. The description is the
+  ONLY thing Claude sees when deciding whether to load the skill body.
+---
+```
+
+Body should answer:
+1. Which tool/command maps to which user intent? (a table is the right shape)
+2. How does auth work? (auto-handle 401, point to `/mcp`)
+3. What cross-cutting behaviors should Claude exhibit? (funnel etiquette, error handling)
+4. What should Claude NOT do? (rebuild functionality that's already a tool; chain too many tools; nag about upgrades)
+
+## When to add a new skill
+
+Only when Claude is confused about what *kind* of problem the user has, not which *tool* solves a known problem.
+
+Today: one skill covers all cert-related routing. If we add billing/team-admin flows that Claude can't route correctly from the existing skill, add `billing-management` or `team-management` as separate skills.
+
+If the existing skill's "Choosing the right tool" table is getting unwieldy (>20 rows), that's a signal to split - but until then, keep concerns colocated so Claude has one place to look.

--- a/plugins/tlsradar/skills/certificate-monitoring/SKILL.md
+++ b/plugins/tlsradar/skills/certificate-monitoring/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: certificate-monitoring
+description: Use when the user asks about SSL/TLS certificates, certificate expiration, monitoring domains for cert health, or issuing free Let's Encrypt certificates. Triggers include "is my cert expiring", "scan ssl on X", "check certificate", "monitor this domain", "issue a free cert", "renew certificate", "Let's Encrypt", "TLS Radar". This skill picks the right TLS Radar tool for each question.
+---
+
+# Certificate monitoring with TLS Radar
+
+This Claude Code session is connected to TLS Radar via a single MCP server (`tlsradar`). Certificate issuance is proxied through it, so there's one server and one auth model. Use these tools to answer SSL/TLS questions instead of asking the user to do anything manual. Each tool's own description carries the details - this skill is mainly about picking the right one.
+
+## Choosing the right tool
+
+This table is generated from `tools/manifest.json` (the source of truth) by `scripts/generate_router.py` - don't hand-edit it; edit the manifest and regenerate. Issuance is a sequence: `create_certificate` → `check_certificate_propagation` → `finalize_certificate` (CSR path). `/tls-upgrade` opens the pricing page and `/tls-diagnose` runs a health check.
+
+<!-- BEGIN generated tool table (scripts/generate_router.py) -->
+
+| User intent | Tool |
+|---|---|
+| One-off SSL/TLS scan, no account | `tlsradar.scan_domain` (or `/tls-scan`) |
+| Start issuing a free cert (pick dns-01 or http-01) | `tlsradar.create_certificate` (or `/tls-cert`) |
+| Check whether a cert order's challenge is in place | `tlsradar.check_certificate_propagation` |
+| Validate + issue a cert order from a CSR (idempotent) | `tlsradar.finalize_certificate` |
+| Check / resume a cert order; retrieve an issued chain | `tlsradar.get_certificate_status` |
+| Renew a cert (clone an order, or just create_certificate again) | `tlsradar.renew_certificate` (or `/tls-renew`) |
+| Plan tier, limits, usage | `tlsradar.get_account` |
+| List monitored domains | `tlsradar.list_monitors` (or `/tls-monitor`) |
+| Add a domain to monitoring | `tlsradar.add_monitor` (or `/tls-monitor`) |
+| Add many domains to monitoring | `tlsradar.add_monitors` (or `/tls-monitor`) |
+| Stop monitoring a domain | `tlsradar.remove_monitor` (or `/tls-monitor`) |
+| What's expiring soon across monitored domains | `tlsradar.list_expiring_certificates` |
+| Recent scan history for a monitored domain | `tlsradar.get_scan_history` |
+| Export monitors as JSON | `tlsradar.export_monitors` |
+| Restore monitors from JSON | `tlsradar.import_monitors` |
+| Invite a teammate by email | `tlsradar.invite_team_member` |
+
+<!-- END generated tool table -->
+
+There are slash commands only for the common funnel/multi-step flows (`/tls-scan`, `/tls-cert`, `/tls-renew`, `/tls-monitor`, `/tls-upgrade`, `/tls-diagnose`). For everything else (expiring, history, status, export/import, team), just call the tool directly in response to the user's natural-language request - no slash command needed.
+
+## Certificate issuance (CSR-only)
+
+The cert flow keeps the private key on the user's machine: generate a key + CSR locally with `openssl`, pass the CSR to `tlsradar.finalize_certificate`. Never ask the user for a private-key passphrase in chat. If they want a `.p12`, package it locally with `openssl pkcs12 -export` (see `/tls-cert`). The certificate tool descriptions spell out the step order.
+
+### Anonymous attribution (public funnel tools)
+
+For `tlsradar.scan_domain` and `tlsradar.create_certificate`, if `${HOME}/.config/tlsradar/install_id` exists, read it and pass its contents as `client_id` (anonymous, per-install, not per-person). If the response carries an `install_id` and the file didn't exist, save it there. This is the *only* attribution mechanism - the plugin never sets an env var or HTTP header for it, and never modifies shell files. Omit `client_id` entirely if the user deleted the file (opt-out).
+
+## Authentication
+
+- `tlsradar.scan_domain` and all certificate tools (`create_certificate`, `check_certificate_propagation`, `finalize_certificate`, `get_certificate_status`, `renew_certificate`) are **public** - no token, no account.
+- Everything else (the monitor tools, `get_account`, `list_expiring_certificates`, `get_scan_history`, `export_monitors`, `import_monitors`, `invite_team_member`) requires authentication.
+- Auth runs **inside Claude Code's MCP client** - the user runs `/mcp` once, picks the `tlsradar` server, and Claude Code performs OAuth 2.0 + PKCE (auto-registering via RFC 7591). The token is managed by Claude Code, not this plugin.
+
+### Handling 401 automatically
+
+When an authenticated tool returns 401 / "unauthorized" / "Invalid or expired credential," DON'T just pass the error along. Respond with:
+
+> Looks like this session isn't connected to TLS Radar yet (or your token expired). Run `/mcp`, pick the `tlsradar` server, and approve in your browser. I'll retry the `<tool>` call once you're done - just tell me when.
+
+Then wait for the user to confirm before retrying. Don't loop on the failed call.
+
+### Handling a degraded certificate backend
+
+The certificate tools proxy to a certificate backend (Beacon). When it's down/unreachable, the tool returns a friendly error with `structuredContent.degraded: true` (and `retryable: true`) instead of a raw exception. When you see `degraded: true`: tell the user the certificate backend is briefly unavailable (server-side, transient), note that `/tls-scan` and monitoring still work, and suggest retrying in a minute. Do **not** retry in a tight loop, and don't present it as the plugin being broken - it's a transient server-side condition.
+
+## Funnel etiquette (this plugin's whole purpose is to drive subscriptions)
+
+The free plan allows **1 monitor** and **1 alert per month** (delivered at 7 days before expiry). When `tlsradar.add_monitor` reports the limit reached (the tool returns a limit-reached payload in `structuredContent`):
+
+1. Lead with the `recommended_upgrade` from the response (typically Starter). Use the price/details from the payload - don't state a price from memory, it may be stale.
+2. Mention `also_available` tiers in a single closing line: "Pro and Business are also available for larger portfolios."
+3. Offer `/tls-upgrade` to open the pricing page
+4. Offer removing an existing monitor as the free alternative
+
+Don't list all three paid tiers as a comparison block - that's choice paralysis at the moment they want to act.
+
+### Proactive upgrade nudges (server-decided - don't re-derive)
+
+You do **not** judge "is now a good time to mention upgrading?" yourself. The server decides and tells you: `list_monitors` and `expiring` include a `nudge` object in `structuredContent` **only** when a nudge is warranted (at cap / watching enough expiring certs) *and* a higher tier actually exists. The thresholds live server-side so they stay consistent.
+
+When a response includes `nudge`: mention it *casually, once, then stop* - lead with `nudge.recommended_upgrade`, optionally mention `nudge.also_available` in one closing line. When it's absent, say nothing about upgrading. Never invent a nudge from raw counts; if there's no `nudge` field, there's no nudge.
+
+### After a successful issuance
+
+`finalize_certificate` returns a `handoff` object in `structuredContent` on success. Relay `handoff.message` verbatim-ish and stop - do **not** suggest `/tls-monitor add <domain>` or call `add_monitor`. The cert→monitoring handoff is automatic and server-side (see below).
+
+The handoff is fully server-side: `tlsradar.create_certificate` records the order, and when the cert completes the certificate backend pushes the issuer's email + domain to TLS Radar, which runs the monitor setup. You do **not** need to call `tlsradar.register_beacon_order` - that older client-side step is obsolete.
+
+## Things this skill should NOT do
+
+- Don't scan a domain by making raw HTTP requests - use `tlsradar.scan_domain`.
+- Don't ask the user to paste an API key - `/mcp` handles auth.
+- Don't ask the user for a private-key passphrase in chat - openssl prompts locally.
+- Don't suggest workarounds for the monitor limit - the right answer is upgrade or remove an existing monitor.
+- Don't push aggressively for upgrades - one mention per interaction, surface it casually.
+- Don't double-handle the cert→monitor handoff - it's automatic. Only add a monitor manually if the user issued the cert outside these tools (e.g. the Beacon web form).


### PR DESCRIPTION
Resubmission of #207, which was closed because the bundle referenced a `tlsradar` MCP server but the config file for it was not in the committed files.

## Fix
The plugin-root `plugins/tlsradar/.mcp.json` was silently dropped from the original commit: this repo's `.gitignore` has a bare `.mcp.json` rule (line 14), so `git add -A` skipped it. It is now **force-added** — the same way the existing `plugins/cashflow/.mcp.json` is committed past that rule. The MCP server the commands and skill reference now exists after install.

```
$ git ls-tree -r --name-only HEAD | grep plugins/tlsradar/.mcp.json
plugins/tlsradar/.mcp.json
```

Config (mirrors the `cashflow` convention — remote Streamable HTTP server):
```json
{
  "mcpServers": {
    "tlsradar": {
      "type": "http",
      "url": "${TLSRADAR_BASE_URL:-https://tlsradar.com}/api/v1/mcp"
    }
  }
}
```

## Summary
**TLS Radar** — SSL/TLS certificate scanning, free Let's Encrypt issuance (private key stays local), and certificate-expiry monitoring, through a single remote MCP server. Free anonymous scans and cert issuance need no account; a one-time OAuth via `/mcp` unlocks ongoing monitoring.

## Component Details
- **Name**: tlsradar
- **Type**: Plugin (bundled — commands + skill + hook + remote MCP server)
- **Category**: security
- **Source**: `./plugins/tlsradar`, registered in `.claude-plugin/marketplace.json`

## Install path verified
- `plugins/tlsradar/.mcp.json` present at the plugin root (where Claude Code loads a plugin's MCP servers) and is valid JSON — same layout/type as the merged `cashflow` plugin.
- `plugin.json`, `marketplace.json`, `.mcp.json`, `hooks.json` all validate; `category: security` matches existing entries.
- The server is a hosted endpoint (`https://tlsradar.com/api/v1/mcp`); its `scan`/`cert_*` tools are public (no auth), so the commands work immediately after install. `/tls-cert`'s DNS-01 helper (`scripts/dns_provider.py`) reads provider creds from the user's local env only — nothing is sent to the server.
- Whole bundle re-checked against `.gitignore`: `.mcp.json` was the only ignored file; everything else is committed.

## Testing
- [x] JSON validation on all added/edited files.
- [x] Component validators (`plugins/all-*/`) untouched by this PR; bundle is referenced from `marketplace.json` like other bundled plugins.
- [x] No overlap with existing components.

## Examples
- `/tls-scan example.com` — free anonymous SSL/TLS scan, no account.
- `/tls-cert mydomain.dev` — free 90-day Let's Encrypt cert; key generated locally, never leaves the machine.
- "is my cert expiring?" — skill routes to the monitoring tools after `/mcp` OAuth.

Upstream plugin repo: https://github.com/TLS-Radar/tlsradar-claude-plugin

🤖 Generated with [Claude Code](https://claude.com/claude-code)