### PR TITLE
Add agent-preflight command

### DIFF
--- a/plugins/commands-code-analysis-testing/.claude-plugin/plugin.json
+++ b/plugins/commands-code-analysis-testing/.claude-plugin/plugin.json
@@ -29,6 +29,7 @@
     "test-changelog-automation",
     "test-coverage",
     "testing_plan_integration",
-    "write-tests"
+    "write-tests",
+    "agent-preflight"
   ]
 }

--- a/plugins/commands-code-analysis-testing/commands/agent-preflight.md
+++ b/plugins/commands-code-analysis-testing/commands/agent-preflight.md
@@ -1,0 +1,64 @@
+---
+description: Preflight a repo before AI agents change files
+category: code-analysis-testing
+---
+
+# Agent Preflight
+
+Run this before letting Claude Code, Codex, Cursor, or another coding agent modify a real repository. The goal is to make the agent produce a short, reviewable safety receipt before any file-changing work starts.
+
+## Instructions
+
+1. **Identify the proposed agent task**
+   - Restate the requested change in one sentence.
+   - List the files, directories, commands, secrets, services, and package managers the agent is likely to touch.
+   - Flag any task that asks for credentials, payment details, KYC, production deploys, destructive commands, private prompt extraction, or unclear external network access.
+
+2. **Map the repository blast radius**
+   - Inspect the project layout, dependency manifests, test commands, CI config, lockfiles, and deployment files.
+   - Identify protected paths such as `.env*`, secrets, auth code, billing code, migration files, infra config, release scripts, and generated artifacts.
+   - Separate safe read-only exploration from write operations.
+
+3. **Score the change before editing**
+   - Mark the task `Green` when it is local, reversible, tested, and limited to low-risk files.
+   - Mark it `Yellow` when it touches dependencies, config, generated code, authentication-adjacent logic, or unclear test coverage.
+   - Mark it `Red` when it may expose secrets, change payment/auth/deployment behavior, delete data, or run untrusted code.
+
+4. **Create guardrails for the agent run**
+   - State the allowed files and commands.
+   - State the blocked files and commands.
+   - Require a branch or patch workflow for Yellow/Red work.
+   - Require tests, lint, or a dry-run command before reporting success.
+   - Require the agent to stop and ask before crossing any listed boundary.
+
+5. **Produce a preflight receipt**
+   - Output a concise Markdown receipt with: task summary, risk level, allowed scope, blocked scope, test plan, rollback plan, and exact stop conditions.
+   - Do not perform the actual implementation in the same response unless the user explicitly approves the receipt.
+
+## Receipt template
+
+```markdown
+# Agent preflight receipt
+
+Task: <one-sentence task>
+Risk: Green | Yellow | Red
+
+Allowed scope:
+- <files/directories/commands the agent may use>
+
+Blocked scope:
+- <files/directories/commands/secrets/payment/deploy actions the agent must not touch>
+
+Required verification:
+- <tests/lint/build/manual checks>
+
+Rollback plan:
+- <branch, patch, revert, backup, or restore step>
+
+Stop conditions:
+- <conditions requiring human approval before continuing>
+```
+
+## Optional reference
+
+For a copy-paste scanner pattern and example AI-agent repo-risk receipts, see the free repo: <https://github.com/el-zachariah/ai-agent-safety-starter-pack>.


### PR DESCRIPTION
## Description
Adds an `agent-preflight` Claude Code slash command to help users produce a short safety receipt before allowing coding agents to modify a real repository.

## Type
- **Type**: Command
- **Category**: code-analysis-testing

## Testing
- [x] Ran validation (`npm test`)
- [x] Tested functionality by checking the command frontmatter, category, and receipt workflow instructions

## Example usage
- `/agent-preflight` before asking Claude Code to refactor a repository
- `/agent-preflight` before running an agent-generated dependency or CI change
- `/agent-preflight` to generate an allowed-scope / blocked-scope receipt for review
