### PR TITLE
Add meta-dev plugin

### DIFF
--- a/plugins/meta-dev/.claude-plugin/plugin.json
+++ b/plugins/meta-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "meta-dev",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "Single authority for Claude-config artifacts: modular standards (core + per-artifact modules) with right-sized lifecycles for skills, agents, hooks, plugins, and project instruction files, self-running enforcement hooks, and shared judge agents. Full marketplace: install from github.com/farzanmrz/meta-dev.",
   "author": { "name": "Farzan", "url": "https://github.com/farzanmrz" },
   "repository": "https://github.com/farzanmrz/meta-dev",

--- a/plugins/meta-dev/.claude-plugin/plugin.json
+++ b/plugins/meta-dev/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "meta-dev",
+  "version": "0.3.2",
+  "description": "Single authority for Claude-config artifacts: modular standards (core + per-artifact modules) with right-sized lifecycles for skills, agents, hooks, plugins, and project instruction files, self-running enforcement hooks, and shared judge agents. Full marketplace: install from github.com/farzanmrz/meta-dev.",
+  "author": { "name": "Farzan", "url": "https://github.com/farzanmrz" },
+  "repository": "https://github.com/farzanmrz/meta-dev",
+  "license": "MIT",
+  "keywords": ["meta-development", "agent-skills", "subagents", "hooks", "plugins", "standards", "lifecycle", "claude-code"]
+}


### PR DESCRIPTION
## meta-dev

Adds **meta-dev** — a single authority for authoring every Claude-config artifact: **skills, agents, hooks, plugins, and project instruction files** (`CLAUDE.md`/`AGENTS.md`).

- **20 skills** — right-sized lifecycles per artifact (create / update / improve / restructure / review / retire), routed by one entry point.
- **5 judge agents** — reviewer, grader, blind comparator, improvement- and benchmark-analyst.
- **Enforcement hooks** — a two-tier guard that routes artifact edits through the lifecycle, plus a markdown-format nudge.
- **Modular standards** — one `core.md` + per-artifact modules; every skill and agent cites them, so a creator and a reviewer can never disagree.
- **On-demand docs-currency** check that re-grounds the standards against official Claude Code docs.

meta-dev is a full external **marketplace**, so this entry is a manifest pointing at the source rather than a file copy (component dirs are optional per CONTRIBUTING). Install:

```bash
claude plugin marketplace add farzanmrz/meta-dev
claude plugin install meta-dev@farzan-dev
```

Repo: https://github.com/farzanmrz/meta-dev · MIT · `claude plugin validate` passes. Happy to adjust to your preferred representation for full external marketplaces.
