### PR TITLE
marketing-optimizer: segment brand/non-brand and prospecting/retargeting before recommending budget shifts

### DIFF
--- a/plugins/claude-ops/agents/marketing-optimizer.md
+++ b/plugins/claude-ops/agents/marketing-optimizer.md
@@ -1,6 +1,6 @@
 ---
 name: marketing-optimizer
-description: Cross-platform ad budget optimization — reads Meta + Google Ads data, computes blended ROAS, and recommends specific budget shifts.
+description: Cross-platform ad budget optimization — reads Meta + Google Ads data, computes blended ROAS for top-line health plus segmented (brand/non-brand, prospecting/retargeting) ROAS, and recommends specific budget shifts.
 model: claude-sonnet-4-5
 effort: high
 maxTurns: 20
@@ -13,7 +13,7 @@ memory: project
 # Marketing Optimizer Agent
 
 **Model:** claude-sonnet-4-5
-**Purpose:** Cross-platform ad budget optimization — reads Meta + Google Ads data, computes blended ROAS, and recommends specific budget shifts.
+**Purpose:** Cross-platform ad budget optimization — reads Meta + Google Ads data, computes blended ROAS for top-line health plus segmented (brand/non-brand, prospecting/retargeting) ROAS, and recommends specific budget shifts.
 
 ---
 
@@ -61,13 +61,22 @@ curl -s "https://graph.facebook.com/v20.0/${META_ACCOUNT}/insights?fields=spend,
 # ORDER BY metrics.cost_micros DESC LIMIT 20
 ```
 
+### Segment before you optimize
+
+`blended_roas` is a top-line health number for the report — it is **not** the optimization target. Blending demand *capture* with demand *generation* flatters the account and starves growth. Before recommending any budget shift, split each platform:
+
+- **Google Ads — brand vs non-brand.** Brand campaigns (queries containing the company/product name) are demand capture — cheap by construction and largely non-incremental. Classify each campaign from `.campaign.name` (brand = name matches the advertiser's brand terms; ask the user for their brand terms if unknown, don't guess). Report brand ROAS separately, and **never** treat a low brand CPA / high brand ROAS as a win or a reason to scale. Drive targets and reallocation math off **non-brand ROAS**.
+- **Meta — retargeting vs prospecting.** Retargeting/remarketing ad sets (site visitors, cart abandoners, engager Custom Audiences) capture demand that would largely have converted anyway, so their ROAS is systematically inflated. Prospecting (cold / lookalike / broad) is the growth engine that refills the retargeting pool. Split ad sets by audience source, report each separately, and drive scaling decisions off **prospecting ROAS**.
+- **Retargeting/brand ROAS is only trustworthy with a holdout.** A high retargeting or brand ROAS proves incrementality only when measured with a lift test (Meta Conversion Lift, Google Conversion Lift / geo experiments, or a simple audience/geo holdout). Absent a holdout, flag these numbers as "capture, not proven lift" and do not recommend scaling on them.
+
 ### Analysis
 
-1. **Compute blended ROAS**: (Meta revenue + Google revenue) / (Meta spend + Google spend)
-2. **Compare platform ROAS**: Identify which platform has higher ROAS
-3. **Identify campaigns**: Find top 3 and bottom 3 campaigns by ROAS on each platform
-4. **Spot inefficiencies**: Campaigns with spend > $50 and ROAS < 1x
-5. **Budget shift math**: Calculate specific dollar amounts to reallocate
+1. **Compute blended ROAS** — reporting top-line only, **not** an optimization target: (Meta revenue + Google revenue) / (Meta spend + Google spend)
+2. **Compute segmented ROAS**: non-brand vs brand (Google), prospecting vs retargeting (Meta) — these drive every recommendation below
+3. **Compare platform ROAS**: Identify which platform has higher ROAS
+4. **Identify campaigns**: Find top 3 and bottom 3 campaigns by ROAS on each platform (evaluate on the segmented figure, not blended)
+5. **Spot inefficiencies**: Campaigns with spend > $50 and ROAS < 1x
+6. **Budget shift math**: Calculate specific dollar amounts to reallocate — grow non-brand/prospecting toward its target; never scale brand/retargeting on reported ROAS alone
 
 ### Output Format
 
@@ -80,8 +89,10 @@ Always output in this exact format:
 
 PERFORMANCE SUMMARY
  Meta Ads:    $[spend] spent | [ROAS]x ROAS | [N] purchases
+   Prospecting: [ROAS]x   Retargeting: [ROAS]x (capture — validate w/ holdout)
  Google Ads:  $[spend] spent | [ROAS]x ROAS | [N] conversions
- Blended:     $[total] spent | [ROAS]x ROAS | $[revenue] attributed
+   Non-brand:   [ROAS]x   Brand: [ROAS]x (capture — validate w/ holdout)
+ Blended:     $[total] spent | [ROAS]x ROAS | $[revenue] attributed (top-line only)
 
 HEALTH SCORE: [N]/100  ([Healthy/Warning/Critical])
  • ROAS:          [N pts] — [explanation]
@@ -134,3 +145,4 @@ Thresholds: ≥70 = Healthy, 40-69 = Warning, < 40 = Critical.
 - All budget numbers must be specific (not "increase by ~20%", but "increase by $15/day")
 - If data is missing for a platform, say so explicitly and compute with available data only
 - Recommendations must be ranked by expected revenue impact (highest first)
+- Base every scale-up on the segmented figure (non-brand for Google, prospecting for Meta), never on blended or on brand/retargeting ROAS — those capture demand that already exists and are only proven by a holdout/lift test. Flag any brand/retargeting scale-up as requiring an incrementality check first

--- a/plugins/claude-ops/skills/ops-marketing/SKILL.md
+++ b/plugins/claude-ops/skills/ops-marketing/SKILL.md
@@ -464,8 +464,12 @@ curl -s -X POST "https://graph.facebook.com/v20.0/${META_ACCOUNT}/adrules_librar
 ```
 
 For "Scale winners":
+
+> ⚠️ **Scope this to prospecting ad sets.** A bare `purchase_roas > 3` filter auto-scales *retargeting* ad sets too — whose ROAS is inflated by warm-audience demand capture (conversions that would have happened anyway), not incremental growth. Blanket-scaling them pours budget into demand you already own while starving prospecting, and the funnel contracts a month later. Add an ad-set-name/audience filter that excludes retargeting/remarketing (or restrict the rule to your prospecting ad sets), and confirm a winner's lift with a holdout before scaling on ROAS alone.
+
 ```bash
 # Increase budget 20% for ad sets with ROAS > 3x in last 7 days
+# NOTE: restrict to prospecting ad sets — see caveat above
 curl -s -X POST "https://graph.facebook.com/v20.0/${META_ACCOUNT}/adrules_library" \
   -H "Authorization: Bearer ${META_TOKEN}" \
   -H "Content-Type: application/json" \


### PR DESCRIPTION
## What
Makes the `marketing-optimizer` agent report blended ROAS as a top-line only and drive every budget recommendation off **segmented** ROAS — brand vs non-brand on Google, prospecting vs retargeting on Meta — and scopes the ops-marketing "Scale winners" auto-rule to prospecting.

## Why
The agent computes blended ROAS and recommends budget shifts off it, and the ops-marketing "Scale winners" rule auto-increases budget 20% for any ad set with `purchase_roas > 3`. Both blend demand *capture* with demand *generation*:

- **Brand search** and **retargeting** are demand you already own — someone searching your name, or a cart-abandoner who was going to come back. Last-click hands those the credit; their reported ROAS is inflated by conversions that would have happened anyway.
- Optimize (or auto-scale) on the blended/raw number and you pour budget into that cheap capture while starving **non-brand / prospecting** — the actual growth engine that refills the retargeting pool. A month later the funnel contracts.

I run a paid-search agency (Drak Marketing); this is the single most common way a "profitable"-looking account is actually treading water.

## The change (`plugins/claude-ops/`)
- `agents/marketing-optimizer.md`: new **"Segment before you optimize"** step; blended reframed as reporting-only; segmented reporting lines in the output format; a rule that scale-ups key on non-brand/prospecting and that brand/retargeting scale-ups need an incrementality (holdout / Conversion Lift) check first.
- `skills/ops-marketing/SKILL.md`: caveat on the "Scale winners" rule to scope it to prospecting ad sets (a bare `purchase_roas > 3` filter auto-scales retargeting).

Docs-only, no new dependencies, stays in the agent's existing voice.
