### PR TITLE
Add Codex Orchestrator plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1842,6 +1842,33 @@
         "source": "github",
         "repo": "tonmoy007/forge-plugins"
       }
+    },
+    {
+      "name": "codex-orchestrator",
+      "description": "Orchestrate OpenAI Codex from Claude through supervised checkpoint slices, server-enforced quality gates, persistent plans and hypotheses, worktree isolation, and per-task model and effort control.",
+      "version": "1.5.2",
+      "author": {
+        "name": "Tom Werner",
+        "url": "https://github.com/tomtastisch"
+      },
+      "homepage": "https://github.com/tomtastisch/codex-orchestrator",
+      "repository": "https://github.com/tomtastisch/codex-orchestrator",
+      "license": "MIT",
+      "keywords": [
+        "claude-code",
+        "codex",
+        "mcp",
+        "orchestration",
+        "multi-agent",
+        "checkpoint",
+        "worktrees",
+        "quality-gates"
+      ],
+      "category": "orchestration",
+      "source": {
+        "source": "github",
+        "repo": "tomtastisch/codex-orchestrator"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary
Add Codex Orchestrator as an external GitHub plugin source. The plugin lets Claude Code supervise the local OpenAI Codex CLI through bounded checkpoint slices, persistent plans and hypotheses, worktree isolation, and server-enforced quality gates.

## Component Details
- Name: `codex-orchestrator`
- Type: Plugin
- Category: `orchestration`
- Version: `1.5.2`
- Source: `tomtastisch/codex-orchestrator`

## Testing
- [x] Marketplace JSON parses successfully
- [x] Exactly one `codex-orchestrator` entry exists
- [x] No existing Build with Claude entry or open duplicate PR was found
- [x] The source repository passes its full CI, MCPB verification, and strict Claude plugin validation
- [ ] Upstream validation (`npm test`) — delegated to this repository's PR checks

## Examples
1. Run `/codex-orchestrator:codex-orchestrator` to split a repository change into supervised implementation clusters and delegate bounded slices to Codex.
2. Resume a durable orchestration plan after a Claude session restart and inspect its state with `/codex-orchestrator:orchestrator-status`.
3. Enforce declared checks and Claude review before a Codex task can be accepted or merged.

The contribution is metadata-only and keeps the upstream repository as the canonical install source.