### PR TITLE
Add ciagent plugin — pytest-native regression testing for AI agents

### DIFF
--- a/plugins/ciagent/.claude-plugin/plugin.json
+++ b/plugins/ciagent/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "ciagent",
+  "version": "0.10.0",
+  "description": "Set up and operate CIAgent (pip install ciagent) regression testing for the AI agent in this repo: record golden baselines, run stability and judge-reliability checks after every change.",
+  "author": {
+    "name": "Sunil Pandey",
+    "url": "https://github.com/suniel12"
+  },
+  "repository": "https://github.com/suniel12/ciagent",
+  "license": "Apache-2.0",
+  "keywords": [
+    "testing",
+    "ai-agents",
+    "evals",
+    "regression",
+    "llm-judge"
+  ]
+}

--- a/plugins/ciagent/README.md
+++ b/plugins/ciagent/README.md
@@ -1,0 +1,30 @@
+# CIAgent plugin for Claude Code
+
+Lets a coding agent set up and operate [CIAgent](https://github.com/suniel12/ciagent)
+(`pip install ciagent`) — pytest-native regression testing for AI agents — on
+the agent it is building.
+
+## Skills
+
+- **onboard** — set up CIAgent in a repo from scratch: find the agent, write
+  the runner, record golden baselines, generate a spec, verify with a real
+  run. Includes a cost gate before any live recording.
+- **check** — after any change to agent code, prompts, or the knowledge
+  base: run the right CIAgent check (`test`, `test --runs 3`, `judge-audit`),
+  read the stability report correctly, and never paper over a failure.
+
+## Install
+
+From the CIAgent repo's own marketplace:
+
+```
+/plugin marketplace add suniel12/ciagent
+/plugin install ciagent@ciagent
+```
+
+## Disclosure
+
+This plugin wraps the `ciagent` PyPI package. The plugin and the package are
+built and maintained by the same author ([@suniel12](https://github.com/suniel12)).
+The package is free and Apache-2.0 licensed; there is no paid tier, telemetry,
+or hosted service behind it.

--- a/plugins/ciagent/skills/check/SKILL.md
+++ b/plugins/ciagent/skills/check/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: check
+description: Run CIAgent regression checks after changing an AI agent's code, prompts, or knowledge base in a repo that has agentci_spec.yaml, and interpret the results. Use after editing agent logic, before committing agent changes, or when the user asks whether the agent still works.
+allowed-tools: Bash(ciagent *)
+---
+
+# Run CIAgent checks on this repo's agent
+
+The repo has `agentci_spec.yaml` (if it does not, use the `onboard` skill
+instead). Your job: run the right check for the change that was just made,
+read the result correctly, and never paper over a failure.
+
+## Which command
+
+| Situation | Command |
+|---|---|
+| Spec or wiring changed, or no API keys | `ciagent test --mock` |
+| Agent code / prompt / retrieval changed | `ciagent test --yes --format json` |
+| Result differs from last run, or flakiness suspected | `ciagent test --runs 3 --yes` |
+| Knowledge base changed | `ciagent generate-checks --dry-run`, review, then apply |
+| The LLM judge's verdicts look wrong | `ciagent judge-audit` |
+
+Live runs (`test` without `--mock`, `judge-audit`, `generate-checks`) call model
+APIs on the user's keys. Mock mode is free. If the user has not already
+approved live runs in this session, prefer `--mock` or ask.
+
+## Reading results
+
+Exit codes: **0** pass (including flaky-but-passing), **1** correctness failure
+(with `--runs N`: failed in every run), **2** infra or config error — fix the
+setup, not the agent.
+
+With `--format json`: per-query entries carry layer results (correctness /
+path / cost) and the answer text; with `--runs N` a top-level `stability` block
+lists flipped queries with `flip_source`.
+
+Flip sources route the work:
+- `agent-variance` — the agent's answer changed between runs → fix the agent
+  (prompt, retrieval, temperature).
+- `judge-flake` — same answer, the LLM judge changed its verdict → fix the
+  eval (tighten the rubric or replace with a deterministic check).
+- `infra-error` — a judge API call failed → retry; fix nothing.
+- `mixed` — ambiguous; look at the answers yourself.
+
+## Rules
+
+- A correctness failure means the agent lost a fact it used to state. Fix the
+  agent, or — only if the check itself is factually wrong — fix the check.
+  **Never weaken or delete a correct check or baseline to make a run green**;
+  report the failure to the user instead.
+- After intentionally changing agent behavior, re-record the affected golden:
+  delete its baseline file and rerun
+  `ciagent bootstrap --runner <runner> --queries <file> --yes` for that query,
+  or update the spec's expectations — with the user's confirmation.
+- Report results in one or two sentences: score, what failed and in which
+  layer, flip sources if any, and the command you ran.

--- a/plugins/ciagent/skills/onboard/SKILL.md
+++ b/plugins/ciagent/skills/onboard/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: onboard
+description: Set up CIAgent regression testing for the AI agent in this repo — write a runner, record golden baselines, generate a test spec, and verify it. Use when the user asks to add tests, evals, or regression testing for their AI agent, or to set up CIAgent.
+allowed-tools: Bash(ciagent *)
+---
+
+# Onboard CIAgent into this repo
+
+You are setting up CIAgent (`pip install ciagent`) so this repo's AI agent has
+recorded golden baselines and a runnable regression suite. The end state: the
+user can run `ciagent test --runs 3` and see a stability report for their agent.
+
+Work through the steps in order. Do not skip the cost gate in step 4.
+
+## 1. Find the agent and install CIAgent
+
+- Locate the agent: search for LLM SDK usage (`openai`, `anthropic`, `langgraph`,
+  `langchain`) and for the function or endpoint that takes a user message and
+  returns the agent's answer.
+- Install with the matching extra so trace capture hooks the SDK:
+  `pip install "ciagent[openai]"`, `[anthropic]`, `[langgraph]`, or `[all]`.
+- Sanity check: `ciagent --version` then `ciagent doctor` (it reports what is
+  missing; a missing spec is expected at this point).
+
+## 2. Write the runner
+
+Create `agentci_runner.py` at the repo root (or inside the package if the repo
+has one clear package):
+
+```python
+def run_for_agentci(query: str) -> str:
+    """CIAgent entry point: one query in, final answer text out."""
+    # import the user's agent and invoke it ONCE, no chat history
+    ...
+    return final_answer_text
+```
+
+Rules:
+- Return the final answer **string**. CIAgent wraps the call in its own trace
+  capture, so LLM calls and tool calls are recorded automatically — do not
+  build Trace objects unless the repo already produces them.
+- Fresh context per call: no shared history between queries.
+- Reuse the repo's own config/env loading so the runner works from the repo root.
+- Verify it imports and answers before going further:
+  `python -c "from agentci_runner import run_for_agentci; print(run_for_agentci('hello'))"`.
+
+## 3. Choose queries
+
+Write `agentci_queries.txt`, one query per line — 8 to 15 queries:
+
+- Cover the agent's main jobs (mine the README, docs, knowledge base, prompts,
+  and existing tests for what it is supposed to handle).
+- Include at least 2 out-of-scope queries the agent should refuse or deflect.
+- Prefer queries whose correct answers contain **hard facts** (prices, dates,
+  limits, names) — those become deterministic checks in step 6.
+
+## 4. Cost gate — ask before running live
+
+Recording baselines runs the real agent once per query, on the user's API keys.
+State the query count and a cost ballpark, and **ask the user to confirm**
+before step 5. If there are no API keys or the user declines: write
+`agentci_spec.yaml` by hand instead (same queries, `runner:` set), validate with
+`ciagent test --mock`, and tell the user which step to resume later.
+
+## 5. Record golden baselines
+
+```bash
+ciagent bootstrap --runner agentci_runner:run_for_agentci \
+  --queries agentci_queries.txt --agent <agent-name> --yes
+```
+
+This runs every query, saves each trace as a golden baseline under
+`./baselines/<agent-name>/`, and writes `agentci_spec.yaml` with path and cost
+budgets derived from the recorded traces. Read the printed answers as they
+stream by — if an answer is visibly wrong, that query should not be golden:
+fix the agent or the query, delete that baseline file, and rerun.
+
+## 6. Add correctness checks
+
+The generated spec has path and cost budgets but no correctness checks. Add a
+`correctness:` block per query, derived from the recorded baseline answers and
+the repo's docs/KB — never from what you wish the agent said:
+
+```yaml
+correctness:
+  expected_in_answer: ["30 days"]          # hard facts, AND
+  any_expected_in_answer: ["$9.95", "9.95"] # phrasing variants, OR
+  not_in_answer: ["I don't know"]           # forbidden content
+```
+
+Check facts, not phrasing. If the repo has a knowledge-base directory, run
+`ciagent generate-checks --kb <dir> --dry-run` and review its candidates —
+every surviving candidate was already validated against the recorded goldens.
+
+## 7. Verify
+
+```bash
+ciagent test --mock                      # structure check, zero API calls
+ciagent test --yes --format json         # live run (covered by step 4 approval)
+ciagent test --runs 3 --yes              # stability report
+```
+
+Exit codes: 0 = pass (flaky-but-passing is 0), 1 = correctness failure in every
+run, 2 = infra/config error. In the stability report, flips labeled
+`agent-variance` mean the agent's answer changed (an agent problem); flips
+labeled `judge-flake` mean the eval itself is unstable (a check/judge problem).
+
+If a check fails, fix the agent or fix a factually wrong check. Do not loosen a
+correct check to make the run green — report the failure to the user instead.
+
+## 8. Wire CI and hand off
+
+- `ciagent init` scaffolds a GitHub Actions workflow (add `--hook` for a
+  pre-push hook if the user wants it).
+- Commit: runner, `agentci_queries.txt`, `agentci_spec.yaml`, `baselines/`,
+  and the workflow.
+- Tell the user: how many goldens were recorded, the suite score, anything
+  flaky (with its flip source), and that `ciagent test --runs 3` is the
+  command to watch after future agent changes.


### PR DESCRIPTION
Adds the **ciagent** plugin (two skills):

- **onboard** — sets up [CIAgent](https://github.com/suniel12/ciagent) (`pip install ciagent`) in a repo: finds the agent, writes the runner, records golden baselines, generates a test spec, verifies with a real run. Includes a cost gate before any live recording.
- **check** — after any change to agent code, prompts, or knowledge base: runs the right CIAgent check (trace-diff regression, `--runs 3` stability with verdict-flip attribution, LLM-judge audit) and interprets results without papering over failures.

Manifest follows the CONTRIBUTING schema (version, keywords, author URL). `npm run validate` passes (Skills ✅). Disclosure: I maintain both this plugin and the underlying `ciagent` package — Apache-2.0, free, no paid tier or telemetry. Canonical source lives at [suniel12/ciagent/plugins/ciagent](https://github.com/suniel12/ciagent/tree/main/plugins/ciagent); happy to keep this copy in sync.