### PR TITLE
Add context-memory plugin

### DIFF
--- a/plugins/context-memory/.claude-plugin/plugin.json
+++ b/plugins/context-memory/.claude-plugin/plugin.json
@@ -1,0 +1,23 @@
+{
+  "name": "context-memory",
+  "version": "0.13.1",
+  "description": "Persistent knowledge base for Claude Code. Auto-captures the decisions, gotchas, and dead ends from your sessions and recalls the relevant ones at session start and on every prompt, ranked by proven usefulness. Ships an MCP server plus session-recall and capture hooks.",
+  "author": {
+    "name": "Slova Applications",
+    "url": "https://github.com/SlovaApplications"
+  },
+  "homepage": "https://context-memory.slova.app",
+  "repository": "https://github.com/SlovaApplications/claude-plugins",
+  "license": "MIT",
+  "keywords": [
+    "memory",
+    "context",
+    "knowledge-base",
+    "mcp",
+    "claude-code",
+    "recall",
+    "session-memory",
+    "context-engineering",
+    "hooks"
+  ]
+}

--- a/plugins/context-memory/README.md
+++ b/plugins/context-memory/README.md
@@ -1,0 +1,36 @@
+# context-memory
+
+Persistent memory for your coding agent. Claude Code is brilliant but amnesiac: every session starts cold, re-learns your codebase's quirks, re-litigates settled decisions, and re-walks ruled-out dead ends. context-memory captures those decisions, gotchas, and dead ends automatically as you work and surfaces the relevant ones at session start and on every prompt.
+
+- **Auto-capture** — an end-of-turn hook nudges the agent to save what was genuinely learned (a decision, a gotcha, a dead end), so knowledge lands in the store instead of evaporating between sessions.
+- **Auto-recall** — a `SessionStart` hook injects this repo's "where you left off" plus durable project facts, and a pre-fetch hook searches your store on every prompt and injects the top hits, scoped to your current repo.
+- **Ranked by proven usefulness** — recall is re-ranked by what has actually been used, not just semantic similarity, so load-bearing knowledge rises.
+- **Topics** — related contexts get compiled into durable, editable syntheses instead of staying scattered.
+- **Auditable** — supersede and retract semantics keep a tombstoned history rather than silently overwriting.
+
+Unlike a hand-maintained `CLAUDE.md`, it is auto-captured, auto-recalled, and ranked (no drift). Unlike RAG, it stores derived decisions and facts (recall), not document chunks (retrieval).
+
+## Install
+
+Requires a free API key. Sign up at <https://context-memory.slova.app/signup/>, then export the key and add the marketplace:
+
+```bash
+export CONTEXT_MEMORY_API_KEY="cm_..."
+```
+
+```
+/plugin marketplace add SlovaApplications/claude-plugins
+/plugin install context-memory@slova
+```
+
+Full setup guide: <https://context-memory.slova.app/get-started/>
+
+## Privacy
+
+The plugin is a client for a hosted backend. On each prompt it sends the first 500 bytes of your prompt to the search API; memories you save are stored under your account. Your Claude Code transcripts stay local. All requests use HTTPS. See the plugin repo's README for full details.
+
+## Links
+
+- Homepage: <https://context-memory.slova.app>
+- Source and full docs: <https://github.com/SlovaApplications/claude-plugins>
+- License: MIT


### PR DESCRIPTION
## Summary
Adds **context-memory**, a persistent-memory plugin for Claude Code. It auto-captures the decisions, gotchas, and dead ends from your sessions and recalls the relevant ones at session start and on every prompt, ranked by proven usefulness. It ships an MCP server plus session-recall and capture hooks. Source lives at [SlovaApplications/claude-plugins](https://github.com/SlovaApplications/claude-plugins) and installs as `context-memory@slova`.

Follows the archcore / claude-snapshot precedent: a metadata listing (`.claude-plugin/plugin.json` + `README.md`) that points at the plugin's own repository, rather than vendoring the hooks/MCP config.

## Component Details
- **Name**: context-memory
- **Type**: Plugin
- **Repository**: https://github.com/SlovaApplications/claude-plugins
- **Homepage**: https://context-memory.slova.app
- **License**: MIT

## Testing
- [x] Ran validation (`npm run validate`) - all validators pass
- [x] `plugin.json` is valid JSON and follows the manifest format in CONTRIBUTING.md
- [x] No overlap with existing components (no prior context-memory entry)

## Notes
- How it differs from similar tools: versus a hand-maintained `CLAUDE.md` it is auto-captured, auto-recalled, and usefulness-ranked (no drift); versus RAG it stores derived decisions and facts (recall), not document chunks (retrieval).
- Requires a free API key (documented in the README); the plugin is MIT and open source.