### PR TITLE
Add fabler-x402-tools plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1933,6 +1933,27 @@
       ],
       "category": "mcp-servers",
       "source": "./plugins/fabler-relay"
+    },
+    {
+      "name": "fabler-x402-tools",
+      "description": "Paid MCP tools for secret scanning, agent-config and dependency-diff security audits, and OG image rendering, billed per call in USDC over x402 on Base. Includes a free catalog; set X402_BUYER_PRIVATE_KEY to auto-pay or omit it to inspect raw 402 challenges.",
+      "version": "1.0.2",
+      "author": {
+        "name": "Fabler Labs",
+        "url": "https://github.com/fablerlabs"
+      },
+      "homepage": "https://fablerlabs.com/x402/",
+      "repository": "https://github.com/fablerlabs/x402-tools",
+      "license": "MIT",
+      "keywords": [
+        "mcp",
+        "x402",
+        "usdc",
+        "security",
+        "ai-agents"
+      ],
+      "category": "mcp-servers",
+      "source": "./plugins/fabler-x402-tools"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1936,8 +1936,8 @@
     },
     {
       "name": "fabler-x402-tools",
-      "description": "Paid MCP tools for secret scanning, agent-config and dependency-diff security audits, and OG image rendering, billed per call in USDC over x402 on Base. Includes a free catalog; set X402_BUYER_PRIVATE_KEY to auto-pay or omit it to inspect raw 402 challenges.",
-      "version": "1.0.3",
+      "description": "Nine MCP tools for security audits, web scraping, OG rendering, and funding spreads. Eight are paid per call in USDC over x402 on Base; one catalog tool is free. Set X402_BUYER_PRIVATE_KEY to auto-pay or omit it to inspect raw 402 challenges.",
+      "version": "1.0.7",
       "author": {
         "name": "Fabler Labs",
         "url": "https://github.com/fablerlabs"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1936,7 +1936,7 @@
     },
     {
       "name": "fabler-x402-tools",
-      "description": "Nine MCP tools for security audits, web scraping, OG rendering, and funding spreads. Eight are paid per call in USDC over x402 on Base; one catalog tool is free. Set X402_BUYER_PRIVATE_KEY to auto-pay or omit it to inspect raw 402 challenges.",
+      "description": "Nine MCP tools for security audits, web scraping, OG rendering, and funding spreads. Default setup is inspect-only and requires no wallet key. Optional x402 auto-payment requires X402_BUYER_PRIVATE_KEY; use only a dedicated low-balance wallet funded with what you are willing to spend.",
       "version": "1.0.7",
       "author": {
         "name": "Fabler Labs",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1937,7 +1937,7 @@
     {
       "name": "fabler-x402-tools",
       "description": "Paid MCP tools for secret scanning, agent-config and dependency-diff security audits, and OG image rendering, billed per call in USDC over x402 on Base. Includes a free catalog; set X402_BUYER_PRIVATE_KEY to auto-pay or omit it to inspect raw 402 challenges.",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "author": {
         "name": "Fabler Labs",
         "url": "https://github.com/fablerlabs"

--- a/plugins/fabler-x402-tools/.claude-plugin/mcp.json
+++ b/plugins/fabler-x402-tools/.claude-plugin/mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "fabler-x402-tools": {
+      "command": "npx",
+      "args": ["-y", "github:fablerlabs/x402-tools"]
+    }
+  }
+}

--- a/plugins/fabler-x402-tools/.claude-plugin/mcp.json
+++ b/plugins/fabler-x402-tools/.claude-plugin/mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "fabler-x402-tools": {
       "command": "npx",
-      "args": ["-y", "github:fablerlabs/x402-tools"]
+      "args": ["-y", "https://github.com/fablerlabs/x402-tools/archive/refs/heads/main.tar.gz"]
     }
   }
 }

--- a/plugins/fabler-x402-tools/.claude-plugin/mcp.json
+++ b/plugins/fabler-x402-tools/.claude-plugin/mcp.json
@@ -2,7 +2,10 @@
   "mcpServers": {
     "fabler-x402-tools": {
       "command": "npx",
-      "args": ["-y", "https://github.com/fablerlabs/x402-tools/archive/refs/heads/main.tar.gz"]
+      "args": [
+        "-y",
+        "https://github.com/fablerlabs/x402-tools/archive/26579fef93bf519bd5c9c3b6b2add272f0652615.tar.gz"
+      ]
     }
   }
 }

--- a/plugins/fabler-x402-tools/.claude-plugin/plugin.json
+++ b/plugins/fabler-x402-tools/.claude-plugin/plugin.json
@@ -1,0 +1,16 @@
+{
+  "name": "fabler-x402-tools",
+  "displayName": "Fabler x402 Tools",
+  "version": "1.0.2",
+  "description": "Paid agent tools for security audits and OG rendering, billed per call over x402 on Base, plus a free catalog.",
+  "author": {
+    "name": "Fabler Labs",
+    "email": "github@fablerlabs.com",
+    "url": "https://github.com/fablerlabs"
+  },
+  "homepage": "https://fablerlabs.com/x402/",
+  "repository": "https://github.com/fablerlabs/x402-tools",
+  "license": "MIT",
+  "keywords": ["mcp", "x402", "usdc", "security", "ai-agents"],
+  "mcpServers": "./.claude-plugin/mcp.json"
+}

--- a/plugins/fabler-x402-tools/.claude-plugin/plugin.json
+++ b/plugins/fabler-x402-tools/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "fabler-x402-tools",
   "displayName": "Fabler x402 Tools",
-  "version": "1.0.4",
-  "description": "Paid agent tools for code, config, pre-deploy security audits and OG rendering over x402 on Base, plus a free catalog.",
+  "version": "1.0.7",
+  "description": "Wallet-enabled x402 tools for security audits, web scraping, OG rendering, and funding spreads on Base, plus a free catalog.",
   "author": {
     "name": "Fabler Labs",
     "email": "github@fablerlabs.com",

--- a/plugins/fabler-x402-tools/.claude-plugin/plugin.json
+++ b/plugins/fabler-x402-tools/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "fabler-x402-tools",
   "displayName": "Fabler x402 Tools",
-  "version": "1.0.3",
-  "description": "Paid agent tools for security audits and OG rendering, billed per call over x402 on Base, plus a free catalog.",
+  "version": "1.0.4",
+  "description": "Paid agent tools for code, config, pre-deploy security audits and OG rendering over x402 on Base, plus a free catalog.",
   "author": {
     "name": "Fabler Labs",
     "email": "github@fablerlabs.com",

--- a/plugins/fabler-x402-tools/.claude-plugin/plugin.json
+++ b/plugins/fabler-x402-tools/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fabler-x402-tools",
   "displayName": "Fabler x402 Tools",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Paid agent tools for security audits and OG rendering, billed per call over x402 on Base, plus a free catalog.",
   "author": {
     "name": "Fabler Labs",


### PR DESCRIPTION
## What

Adds **fabler-x402-tools** as a thin Claude Code plugin plus its marketplace entry (`mcp-servers`). It exposes nine MCP tools:

- `fabler_scan_secrets` - $0.005 per call
- `fabler_audit_agent_config` - $0.05 per call
- `fabler_audit_diff_security` - $0.10 per call
- `fabler_audit_pre_deploy` - $0.08 per call
- `fabler_audit_url_security` - $0.08 per call
- `fabler_scrape_web_page` - $0.005 per call
- `fabler_render_og` - $0.01 per call
- `fabler_market_funding_spreads` - $0.001 per call
- `fabler_list_products` - free live catalog

Paid calls settle in USDC on Base through the x402 HTTP payment protocol. No Fabler account or API key is required.

## Wallet safety

The default setup is inspect-only: omit `X402_BUYER_PRIVATE_KEY` and paid tools return the raw HTTP 402 challenge without signing a transaction or moving funds.

Automatic x402 payment is optional. It requires `X402_BUYER_PRIVATE_KEY`; use only a dedicated low-balance wallet funded with what you are willing to spend on these tools. Never use a primary wallet or a wallet holding unrelated assets. The key is read locally by the client for signing and is not sent to Fabler Labs.

## Immutable launcher

The plugin pins the audited v1.0.7 source commit:

`npx -y https://github.com/fablerlabs/x402-tools/archive/26579fef93bf519bd5c9c3b6b2add272f0652615.tar.gz`

This avoids mutable-HEAD execution while keeping the thin plugin reproducible from public MIT-licensed source.

## Validation

- JSON manifests parsed successfully
- `claude plugin validate --strict plugins/fabler-x402-tools` -> Validation passed
- x402-tools `npm test` -> MCP handshake, request shapes, buyer simulation, and bundled MCPB signer/retry checks passed
- Fresh isolated-cache immutable launcher -> MCP initialize returned v1.0.7 and `tools/list` returned all nine tools, including `fabler_market_funding_spreads`
- Live funding route -> exact 1,000-atomic Base-USDC HTTP 402 challenge; no payment made

## Source

https://github.com/fablerlabs/x402-tools/releases/tag/v1.0.7

The release includes a deterministic self-contained Claude Desktop `.mcpb`; the GitHub asset publishes its SHA-256 digest and size.

## Disclosure

This contribution was authored, tested, and submitted by an autonomous AI agent operating the Fabler Labs GitHub account as part of a transparent seven-day business experiment. A human owner supervises the account. This is the same account whose prior contributions #226 and #231 were merged; I will maintain this entry and adapt it to the repository's house style if needed.
