### PR TITLE
Add animated-sketch-diagram skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -173,6 +173,36 @@
       "source": "./plugins/slopmop"
     },
     {
+      "name": "animated-sketch-diagram",
+      "description": "Creates hand-drawn animated technical diagrams as self-contained HTML and seamless-loop GIFs, with motion that follows branches, merges, and feedback loops in the system topology.",
+      "author": {
+        "name": "OLDyade",
+        "url": "https://github.com/OLDyade"
+      },
+      "homepage": "https://github.com/OLDyade/animated-sketch-diagram",
+      "repository": "https://github.com/OLDyade/animated-sketch-diagram",
+      "license": "MIT",
+      "keywords": [
+        "animated-diagram",
+        "architecture",
+        "hand-drawn",
+        "svg",
+        "gif",
+        "visualization",
+        "claude-code",
+        "agent-skill"
+      ],
+      "category": "creative",
+      "source": {
+        "source": "github",
+        "repo": "OLDyade/animated-sketch-diagram"
+      },
+      "strict": false,
+      "skills": [
+        "./"
+      ]
+    },
+    {
       "name": "archcore",
       "description": "Make your AI agent code with your project's architecture, rules, and decisions. Git-native context (folder conventions, ADRs, team standards) so new code lands in the right place and decisions persist across sessions and agents.",
       "version": "0.4.4",


### PR DESCRIPTION
## Summary

- Add `animated-sketch-diagram` to the Build with Claude marketplace.
- Use the upstream GitHub repository as the plugin source so its bundled fonts, SVG recipes, renderer, and examples stay versioned in one place.
- Register the repository-root `SKILL.md` with `strict: false`, matching Claude Code's external GitHub source format.

## Component details

- **Name:** `animated-sketch-diagram`
- **Type:** Skill
- **Category:** Creative
- **Source:** https://github.com/OLDyade/animated-sketch-diagram
- **License:** MIT

The skill creates hand-drawn animated technical diagrams as self-contained HTML and seamless-loop GIFs. Its motion follows the system topology, including branches, merges, and feedback loops, rather than adding decorative animation only.

## Validation

- `jq empty .claude-plugin/marketplace.json`
- `git diff --check`
- `npm test`
- Isolated install smoke test with a temporary home:
  - added the modified local `buildwithclaude` marketplace
  - installed `animated-sketch-diagram@buildwithclaude`
  - verified the plugin was enabled and its skill, references, renderer, examples, and bundled font assets were present in the plugin cache

`claude plugin validate .` still reports the same two pre-existing `plugins[3]` command-path errors on both this branch and an untouched `upstream/main` worktree; this change adds no new validator errors or warnings.
