### PR TITLE
Add web access skills: url to markdown, screenshot a url, url to pdf

### DIFF
--- a/plugins/all-skills/skills/screenshot-url/SKILL.md
+++ b/plugins/all-skills/skills/screenshot-url/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: screenshot-url
+category: web-scraping
+description: Take a screenshot of any web page and get back a PNG or JPEG. The page renders in a hosted browser with JavaScript on, and consent overlays are hidden so the shot shows the page rather than a cookie banner.
+---
+
+# Screenshot a URL
+
+Capture a web page as an image. The page renders in a hosted browser with JavaScript enabled, so
+client-rendered sites look the way a person would see them. Consent and cookie overlays are hidden before
+the capture, which is usually the difference between a useful screenshot and a picture of a banner.
+
+No local browser and no API key needed. The skill registers its own key on first use and starts on free
+credits. It respects robots.txt and refuses sites that block automation.
+
+## When to Use This Skill
+
+- Showing someone what a page looks like right now
+- Capturing a rendered chart, dashboard or layout that only exists in the browser
+- Visual checks after a deploy, where you want the real rendered page
+
+## What This Skill Does
+
+1. Loads the URL in a hosted browser at the viewport size you ask for
+2. Hides consent and cookie overlays
+3. Captures the viewport, or the full scrollable page if you ask
+4. Returns base64 image data with the final URL and pixel size
+
+## How to Use
+
+### Basic Usage
+
+```
+Screenshot https://example.com and show me the result
+```
+
+### Options
+
+- `full_page` captures the entire scrollable page instead of the viewport
+- `width` and `height` set the viewport in pixels
+- `format` picks png or jpeg
+- `wait_for_selector` waits for a CSS selector before capturing
+
+## Example
+
+**User**: "Grab a full page screenshot of our docs homepage at mobile width"
+
+**Output**:
+```
+image: PNG, 390x2140, base64
+final url: https://example.com/docs
+```
+
+## Tips
+
+- Full page shots of very long pages get large, so set a viewport width that matches the case you care about.
+- If the page animates on load, `wait_for_selector` gives a steadier shot.
+- A failed capture is not charged.
+
+## Source
+
+Free and MIT licensed: https://github.com/toolshedlabs-hash/web-access-skills
+
+Built by toolshed. The skill calls a hosted service we run, which has a free tier and no signup. There
+is a paid tier for heavy use, and none of the behaviour above requires it.

--- a/plugins/all-skills/skills/url-to-markdown/SKILL.md
+++ b/plugins/all-skills/skills/url-to-markdown/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: url-to-markdown
+category: web-scraping
+description: Read any URL and get clean markdown back. The page loads in a real hosted browser with JavaScript on, so client-rendered sites return their actual text instead of an empty shell. Use it to read an article, pull docs, or hand a model clean page content.
+---
+
+# URL to Markdown
+
+Turn a web page into clean markdown. The fetch runs in a hosted browser with JavaScript enabled, so a
+page that builds itself on the client comes back with its real text rather than an empty shell.
+Navigation, ads and consent banners are stripped, leaving the article or the main body.
+
+You do not need a local browser, a headless Chrome install, or an API key from anywhere. The skill
+registers its own key on first use and starts on free credits, so the first read works with no signup
+form. If the credits run out, one email confirmation by a person adds more, still free.
+
+It respects robots.txt and refuses sites that block automation rather than trying to defeat them. Failed
+reads are not charged.
+
+## When to Use This Skill
+
+- Reading an article or documentation page whose content you need as text
+- Pulling content from a site that renders in the browser, where a plain fetch returns nothing useful
+- Giving a model the readable body of a page without the navigation and cookie banners
+
+## What This Skill Does
+
+1. Loads the URL in a hosted browser with JavaScript enabled
+2. Waits for the page to render, optionally for a selector you name
+3. Strips navigation, ads and consent overlays
+4. Returns markdown along with the title and the canonical URL
+
+## How to Use
+
+### Basic Usage
+
+```
+Read https://example.com/article and summarise it
+```
+
+### Options
+
+- `wait_for_selector` waits for a CSS selector before reading, for slow widgets
+- `scroll` scrolls the page first to trigger lazy-loaded content
+
+## Example
+
+**User**: "Read this changelog and tell me what changed in v3"
+
+**Output**:
+```
+# Changelog
+
+## v3.0.0
+- Rewrote the parser
+- Dropped Node 16
+```
+
+## Tips
+
+- Pages behind a login stay behind it. That is deliberate.
+- A page that blocks automation returns a refusal rather than a workaround.
+- Rendering costs a credit, so cache the markdown if you plan to read the same page repeatedly.
+
+## Source
+
+Free and MIT licensed: https://github.com/toolshedlabs-hash/web-access-skills
+
+Built by toolshed. The skill calls a hosted service we run, which has a free tier and no signup. There
+is a paid tier for heavy use, and none of the behaviour above requires it.

--- a/plugins/all-skills/skills/url-to-pdf/SKILL.md
+++ b/plugins/all-skills/skills/url-to-pdf/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: url-to-pdf
+category: web-scraping
+description: Turn a web page or raw HTML into a PDF. The page renders in a hosted browser with JavaScript on, so client-rendered content appears in the output. Useful for archiving a page or generating a document from HTML you already have.
+---
+
+# URL to PDF
+
+Render a web page, or raw HTML you supply, into a PDF. The render happens in a hosted browser with
+JavaScript enabled, so charts and client-rendered sections appear rather than coming out blank.
+
+No local browser and no API key needed. The skill registers its own key on first use and starts on free
+credits. It respects robots.txt for URL input.
+
+## When to Use This Skill
+
+- Archiving a page as a document that will not change under you
+- Turning an HTML invoice, report or receipt you generated into a PDF
+- Producing something printable from a page that only exists in a browser
+
+## What This Skill Does
+
+1. Loads the URL, or takes the raw HTML you provide
+2. Renders it in a hosted browser at the paper size you choose
+3. Returns base64 PDF data
+
+## How to Use
+
+### Basic Usage
+
+```
+Save https://example.com/report as a PDF
+```
+
+### Options
+
+- Supply `html` instead of `url` to render markup you already have
+- `paper` accepts A4, Letter, Legal or A3
+- `landscape` switches orientation
+
+## Example
+
+**User**: "Turn this HTML invoice into a PDF"
+
+**Output**:
+```
+application/pdf, 1 page, base64
+```
+
+## Tips
+
+- Give exactly one of `url` or `html`, not both.
+- Print styles apply, so a page with a good print stylesheet produces a much better PDF.
+- A failed render is not charged.
+
+## Source
+
+Free and MIT licensed: https://github.com/toolshedlabs-hash/web-access-skills
+
+Built by toolshed. The skill calls a hosted service we run, which has a free tier and no signup. There
+is a paid tier for heavy use, and none of the behaviour above requires it.


### PR DESCRIPTION
Adds three skills for reading web pages: `url-to-markdown`, `screenshot-url`, and `url-to-pdf`.

Each one renders the page in a hosted browser with JavaScript enabled, so client-rendered sites return their real content instead of an empty shell. No local browser install and no API key to get started.

I checked these against the existing 146 skills before writing them. The current `pdf` skill covers PDF manipulation (extracting, merging, forms) rather than rendering a URL to PDF, and there is no url-to-markdown or screenshot skill, so these do not overlap with anything already here.

Disclosure: the skills call a hosted service my studio runs. It has a free tier with no signup, which is what the skills use, and there is a paid tier for heavy use that none of the documented behaviour requires. The skills themselves are MIT and the source is at https://github.com/toolshedlabs-hash/web-access-skills

Happy to adjust the category, the format, or split this into separate PRs if you would rather review them one at a time.
