### PR TITLE
Add MiniMax-H3 video v2 task commands

### DIFF
--- a/plugins/minimax-video/.claude-plugin/plugin.json
+++ b/plugins/minimax-video/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "minimax-video",
-  "version": "0.1.0",
-  "description": "Generate videos with MiniMax-Hailuo-2.3 from a text prompt or a first-frame image, poll generation status, and download the finished file across the global and China API endpoints.",
+  "version": "0.2.0",
+  "description": "Generate multimodal videos with MiniMax-H3 through the v2 API, manage tasks across global and China endpoints, and retain the existing v1 flows.",
   "author": {
     "name": "BuildWithClaude Community",
     "url": "https://github.com/davepoon/buildwithclaude"
@@ -10,10 +10,11 @@
   "license": "MIT",
   "keywords": [
     "minimax",
-    "hailuo",
+    "h3",
     "video-generation",
     "text-to-video",
     "image-to-video",
+    "reference-to-video",
     "slash-commands"
   ]
 }

--- a/plugins/minimax-video/README.md
+++ b/plugins/minimax-video/README.md
@@ -1,11 +1,21 @@
 # minimax-video
 
-Generate videos with **MiniMax-Hailuo-2.3** directly from Claude Code. This plugin
-adds slash commands that wrap the MiniMax video-generation REST API, covering the
-full asynchronous flow — create a task, poll its status, and download the result —
-across both the global and China API hosts.
+Generate multimodal videos with **MiniMax-H3** directly from Claude Code. This
+plugin provides a v2 flow for creation and task management across the global and
+China API hosts, while retaining the existing v1 commands for compatibility.
 
 ## Commands
+
+### H3 v2 commands
+
+| Command | Operation | Method and path |
+| --- | --- | --- |
+| /minimax-video:h3-create-video | Create a multimodal H3 task | POST /v2/video_generation |
+| /minimax-video:h3-query-video | Query one H3 task | GET /v2/query/video_generation/{task_id} |
+| /minimax-video:h3-list-videos | List and filter H3 tasks | GET /v2/query/video_generation |
+| /minimax-video:h3-delete-video | Cancel or delete an H3 task | DELETE /v2/video_generation/{task_id} |
+
+### Existing v1 commands
 
 | Command | Operation | Method & path |
 | --- | --- | --- |
@@ -24,7 +34,38 @@ across both the global and China API hosts.
 Each command takes an optional `--region global|cn` flag (default `global`) that
 selects the matching host.
 
-## Models
+## H3 v2 endpoints
+
+| Region | Base URL | Docs |
+| --- | --- | --- |
+| Global | https://api.minimax.io | https://platform.minimax.io/docs/api-reference/video-generation-v2-create |
+| China | https://api.minimaxi.com | https://platform.minimaxi.com/docs/api-reference/video-generation-v2-create |
+
+The H3 create command uses /v2/video_generation, query uses
+/v2/query/video_generation/{task_id}, list uses /v2/query/video_generation,
+and delete uses /v2/video_generation/{task_id}. The China request may include
+the regional <code>aigc_watermark</code> boolean; omit that field for the global endpoint.
+
+## H3 v2 input rules
+
+- <code>model</code> must be MiniMax-H3.
+- Every request must contain one non-empty <code>text</code> item, up to 7000 characters.
+- Supported content types are <code>text</code>, <code>image_url</code>, <code>video_url</code>, and <code>audio_url</code>.
+- Supported roles are <code>first_frame</code>, <code>last_frame</code>, <code>reference_image</code>,
+  <code>reference_video</code>, and <code>reference_audio</code>.
+- Frame roles and reference roles are mutually exclusive. A reference audio item
+  requires at least one reference image or reference video.
+- <code>resolution</code> must be 2K; <code>duration</code> must be an integer from 4 through 15.
+- The request body must not exceed 64 MB. Use public URLs or platform file URLs
+  for large media instead of embedding large Base64 payloads.
+- Text-only requests use a concrete ratio. Frame requests use adaptive; reference
+  requests may use adaptive or a supported concrete ratio.
+
+## H3 model
+
+The H3 v2 commands use MiniMax-H3 as the default and only supported v2 model.
+
+## Existing v1 models
 
 Default: `MiniMax-Hailuo-2.3`. Also accepted: `MiniMax-Hailuo-2.3-Fast`,
 `MiniMax-Hailuo-02`, `T2V-01-Director`, `T2V-01`, `I2V-01-Director`, `I2V-01-live`,
@@ -40,6 +81,17 @@ export MINIMAX_API_KEY="your-key"
 
 Every request sends `Authorization: Bearer $MINIMAX_API_KEY`. A response is
 successful when `base_resp.status_code` is `0`.
+
+The base_resp status check above applies to the existing v1 responses. H3 v2
+creation succeeds when the response contains task_id; use the H3 query command
+to read task status and output.
+
+## H3 v2 flow
+
+1. /minimax-video:h3-create-video "a neon koi in a rainy alley" returns a task_id.
+2. /minimax-video:h3-query-video task_id polls until the task succeeds and returns task.content.url.
+3. /minimax-video:download-video task.content.url ./clip.mp4 downloads the time-limited H3 result URL.
+4. Use /minimax-video:h3-list-videos to review recent tasks or /minimax-video:h3-delete-video to cancel or remove one.
 
 ## Typical flow
 

--- a/plugins/minimax-video/commands/download-video.md
+++ b/plugins/minimax-video/commands/download-video.md
@@ -1,28 +1,42 @@
 ---
-description: Retrieve the download URL for a finished MiniMax video by file id and save the file.
+description: Download an H3 result URL or resolve a v1 file id and save the video.
 category: integration-sync
-argument-hint: <file_id> [output_path] [--region global|cn]
+argument-hint: <file_id_or_url> [output_path] [--region global|cn]
 allowed-tools: Bash
 ---
 
-# Download Video (MiniMax-Hailuo)
+# Download Video
 
-Resolve a finished video's `file_id` (returned by `/minimax-video:query-video`) into
-a download URL and save the file locally.
+Download a finished video from either the time-limited `task.content.url`
+returned by the H3 query command or the `file_id` returned by the v1 query
+command.
 
 ## Instructions
 
-1. Read the `file_id` from `$ARGUMENTS` (required); an optional second token is the
-   output path (default `./minimax-video.mp4`).
-2. Choose the endpoint host by region:
+1. Read the required `file_id_or_url` from `$ARGUMENTS`; an optional
+   second token is the output path (default `./minimax-video.mp4`).
+2. If the value starts with `http://` or `https://`, download it
+   directly with `curl -fsSL -L`. Do not send the API key to the result URL.
+   H3 result URLs are time-limited, so download promptly and query again if one
+   has expired.
+3. Otherwise, treat the value as a v1 `file_id` and choose the endpoint host:
    - `global` (default): `https://api.minimax.io/v1/files/retrieve`
    - `cn`: `https://api.minimaxi.com/v1/files/retrieve`
-3. Authenticate with a Bearer token from the `MINIMAX_API_KEY` environment variable.
-4. GET the file metadata with the `file_id` query parameter, read the download URL
-   from `file.download_url`, then fetch that URL to the output path.
-5. Check `base_resp.status_code == 0` before downloading.
+4. For a v1 file id, authenticate with a Bearer token from
+   `MINIMAX_API_KEY`, GET the metadata using the `file_id` query
+   parameter, and check `base_resp.status_code == 0`.
+5. Read `file.download_url` from the v1 metadata response and download it
+   without forwarding the API key.
 
 ## Request
+
+For an H3 result URL:
+
+~~~bash
+curl -fsSL -L -o "./minimax-video.mp4" "$RESULT_URL"
+~~~
+
+For a v1 file id:
 
 ```bash
 # region=global -> https://api.minimax.io ; region=cn -> https://api.minimaxi.com

--- a/plugins/minimax-video/commands/h3-create-video.md
+++ b/plugins/minimax-video/commands/h3-create-video.md
@@ -1,0 +1,126 @@
+---
+description: Create a MiniMax-H3 multimodal video task with validated v2 inputs.
+category: integration-sync
+argument-hint: <prompt> [media and options] [--region global|cn]
+allowed-tools: Bash
+---
+
+# Create H3 Video
+
+Create an asynchronous MiniMax-H3 video-generation task from text and optional
+image, video, or audio inputs. Read the user's prompt and options from
+<code>$ARGUMENTS</code>, then build the v2 JSON request described below.
+
+## Supported options
+
+- <code>--first-frame URL</code> and <code>--last-frame URL</code> create frame
+  inputs.
+- <code>--reference-image URL</code>, <code>--reference-video URL</code>, and
+  <code>--reference-audio URL</code> may be repeated to create reference inputs.
+- <code>--duration N</code>, <code>--resolution 2K</code>, and
+  <code>--ratio VALUE</code> control the generated output.
+- <code>--callback-url URL</code> adds a callback.
+- <code>--region global|cn</code> selects the endpoint. The
+  <code>--aigc-watermark true|false</code> option is valid only with cn.
+
+## Build the content array
+
+Every request must contain exactly one non-empty text item. Add media items only
+when the user supplies them:
+
+~~~json
+{
+  "type": "text",
+  "text": "Describe the desired video here."
+}
+~~~
+
+Use these shapes for media items:
+
+~~~json
+{
+  "type": "image_url",
+  "image_url": { "url": "https://example.com/first-frame.jpg" },
+  "role": "first_frame"
+}
+~~~
+
+~~~json
+{
+  "type": "video_url",
+  "video_url": { "url": "https://example.com/reference.mp4" },
+  "role": "reference_video"
+}
+~~~
+
+~~~json
+{
+  "type": "audio_url",
+  "audio_url": { "url": "https://example.com/reference.mp3" },
+  "role": "reference_audio"
+}
+~~~
+
+Supported media types are <code>image_url</code>, <code>video_url</code>, and
+<code>audio_url</code>. Supported roles are <code>first_frame</code>,
+<code>last_frame</code>, <code>reference_image</code>,
+<code>reference_video</code>, and <code>reference_audio</code>. A single
+unlabelled image is treated as a first frame; label both images when using first
+and last frames.
+
+## Validate before the request
+
+Stop with a concise validation error and do not call the API when any rule fails:
+
+1. Set <code>model</code> to MiniMax-H3 and require one non-empty text item of at
+   most 7000 characters.
+2. Set <code>resolution</code> to exactly 2K. Reject every other resolution.
+3. Require <code>duration</code> to be an integer from 4 through 15 inclusive.
+   Reject missing, fractional, or out-of-range values.
+4. Do not mix <code>first_frame</code> or <code>last_frame</code> with any
+   <code>reference_image</code>, <code>reference_video</code>, or
+   <code>reference_audio</code> role.
+5. Reject a <code>last_frame</code> item unless the request also contains a
+   <code>first_frame</code> item.
+6. A <code>reference_audio</code> item requires at least one
+   <code>reference_image</code> or <code>reference_video</code> item. Audio
+   cannot be the only reference input.
+7. Keep the complete request body at or below 64 MB. Prefer public or platform
+   file URLs over large Base64 data when possible.
+8. For text-only content, require a concrete <code>ratio</code> from 21:9, 16:9,
+   4:3, 1:1, 3:4, or 9:16. For frame content, use adaptive. For reference
+   content, use adaptive or one of the concrete ratios.
+
+The optional <code>callback_url</code> may be included after validation. Select
+the host from <code>--region</code>: global uses https://api.minimax.io; cn uses
+https://api.minimaxi.com. Include the optional <code>aigc_watermark</code>
+boolean only for cn requests.
+
+## Request
+
+~~~bash
+# Set BASE_URL from --region before running this request.
+curl -fsS -X POST "$BASE_URL/v2/video_generation" \
+  -H "Authorization: Bearer $MINIMAX_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "MiniMax-H3",
+    "content": [
+      {
+        "type": "text",
+        "text": "A quiet mountain train crosses a bridge at sunrise."
+      }
+    ],
+    "resolution": "2K",
+    "duration": 5,
+    "ratio": "16:9"
+  }'
+~~~
+
+For China, add <code>"aigc_watermark": true</code> or
+<code>"aigc_watermark": false</code> to the request body. Do not send that field
+to the global endpoint.
+
+On success, report the returned <code>task_id</code> and continue with
+/minimax-video:h3-query-video task_id. A successful v2 create response is
+identified by <code>task_id</code>; task status is returned by the query command.

--- a/plugins/minimax-video/commands/h3-delete-video.md
+++ b/plugins/minimax-video/commands/h3-delete-video.md
@@ -1,0 +1,40 @@
+---
+description: Cancel a queued MiniMax-H3 task or delete a terminal task record.
+category: integration-sync
+argument-hint: <task_id> [--region global|cn]
+allowed-tools: Bash
+---
+
+# Delete H3 Video Task
+
+Cancel or delete one MiniMax-H3 v2 task by its <code>task_id</code>.
+
+## Instructions
+
+1. Read the required <code>task_id</code> from <code>$ARGUMENTS</code> and select
+   the host from <code>--region</code>: global uses https://api.minimax.io; cn
+   uses https://api.minimaxi.com.
+2. Send an authenticated DELETE request to /v2/video_generation/{task_id}.
+3. A queued task is cancelled. A succeeded, failed, or expired task record is
+   deleted. Requests for running or cancelled tasks are rejected by the API;
+   report that response without retrying a different operation.
+4. Report <code>task_id</code>, <code>action</code>, and the resulting
+   <code>status</code> from the response.
+
+## Request
+
+~~~bash
+# Set BASE_URL from --region before running this request.
+curl -fsS -X DELETE "$BASE_URL/v2/video_generation/$TASK_ID" \
+  -H "Authorization: Bearer $MINIMAX_API_KEY"
+~~~
+
+## Response
+
+~~~json
+{
+  "task_id": "424010985738629",
+  "action": "cancel",
+  "status": "cancelled"
+}
+~~~

--- a/plugins/minimax-video/commands/h3-list-videos.md
+++ b/plugins/minimax-video/commands/h3-list-videos.md
@@ -1,0 +1,63 @@
+---
+description: List and filter recent MiniMax-H3 video-generation tasks.
+category: integration-sync
+argument-hint: "[--page-num N] [--page-size N] [filters] [--region global|cn]"
+allowed-tools: Bash
+---
+
+# List H3 Videos
+
+List MiniMax-H3 v2 tasks from the recent task window and apply any filters the
+user provides.
+
+## Supported options
+
+- <code>--page-num N</code> and <code>--page-size N</code> control pagination.
+  Page numbers start at 1.
+- <code>--status</code> accepts queued, running, succeeded, failed, cancelled, or
+  expired.
+- <code>--task-id ID</code> may be repeated and maps to
+  <code>filter.task_ids</code>.
+- <code>--model MiniMax-H3</code> maps to <code>filter.model</code>.
+- <code>--task-type TYPE</code> maps to <code>filter.task_type</code>.
+- <code>--region global|cn</code> selects https://api.minimax.io or
+  https://api.minimaxi.com.
+
+Use <code>--data-urlencode</code> for every supplied filter. Do not include empty
+filters. The API only lists tasks from its recent task window; report
+<code>items</code> and <code>total</code> from the response.
+
+## Request
+
+~~~bash
+# Set BASE_URL from --region before running this request.
+curl -fsS -G "$BASE_URL/v2/query/video_generation" \
+  -H "Authorization: Bearer $MINIMAX_API_KEY" \
+  --data-urlencode "page_num=1" \
+  --data-urlencode "page_size=20" \
+  --data-urlencode "filter.model=MiniMax-H3" \
+  --data-urlencode "filter.status=succeeded"
+~~~
+
+For repeated task ids, send one <code>filter.task_ids</code> parameter per id.
+Report each matching task's id, status, duration, resolution, ratio, usage, task
+type, modality, and result URL when present.
+
+## Response
+
+~~~json
+{
+  "items": [
+    {
+      "id": "424010985738629",
+      "model": "MiniMax-H3",
+      "status": "succeeded",
+      "content": { "url": "https://example.com/video.mp4" },
+      "resolution": "2K",
+      "duration": 5,
+      "ratio": "16:9"
+    }
+  ],
+  "total": 1
+}
+~~~

--- a/plugins/minimax-video/commands/h3-query-video.md
+++ b/plugins/minimax-video/commands/h3-query-video.md
@@ -1,0 +1,62 @@
+---
+description: Query a MiniMax-H3 video task and report its status and result URL.
+category: integration-sync
+argument-hint: <task_id> [--region global|cn]
+allowed-tools: Bash
+---
+
+# Query H3 Video
+
+Query one MiniMax-H3 v2 task by its <code>task_id</code> and report the task
+state, output metadata, usage, and result URL when available.
+
+## Instructions
+
+1. Read the required <code>task_id</code> from <code>$ARGUMENTS</code> and select
+   the host from <code>--region</code>: global uses https://api.minimax.io; cn
+   uses https://api.minimaxi.com.
+2. Send an authenticated GET request to
+   /v2/query/video_generation/{task_id}. The task id is a path segment, not a
+   query parameter.
+3. Report <code>task.id</code>, <code>task.model</code>,
+   <code>task.status</code>, <code>task.error</code> when present,
+   <code>task.resolution</code>, <code>task.duration</code>,
+   <code>task.ratio</code>, <code>task.task_type</code>, and the
+   <code>task.modality</code> and <code>task.usage</code> fields when present.
+4. When <code>task.status</code> is succeeded, extract
+   <code>task.content.url</code> and pass that time-limited URL to
+   /minimax-video:download-video. Download it promptly; query again when the URL
+   has expired.
+5. Treat queued, running, failed, cancelled, and expired as distinct states. Do
+   not report a task as complete unless its status is succeeded.
+
+## Request
+
+~~~bash
+# Set BASE_URL from --region before running this request.
+curl -fsS "$BASE_URL/v2/query/video_generation/$TASK_ID" \
+  -H "Authorization: Bearer $MINIMAX_API_KEY"
+~~~
+
+## Response
+
+~~~json
+{
+  "task": {
+    "id": "424010985738629",
+    "model": "MiniMax-H3",
+    "status": "succeeded",
+    "content": { "url": "https://example.com/video.mp4" },
+    "resolution": "2K",
+    "duration": 5,
+    "usage": {
+      "total_seconds": 5,
+      "input_seconds": 0,
+      "output_seconds": 5,
+      "image_count": 0
+    },
+    "ratio": "16:9",
+    "task_type": "generation"
+  }
+}
+~~~

--- a/plugins/minimax-video/commands/image-to-video.md
+++ b/plugins/minimax-video/commands/image-to-video.md
@@ -7,6 +7,9 @@ allowed-tools: Bash
 
 # Image to Video (MiniMax-Hailuo)
 
+This command uses the existing v1 API. Use /minimax-video:h3-create-video for
+MiniMax-H3 v2 generation and frame or reference roles.
+
 Animate a still image with the MiniMax video-generation endpoint. The image is
 supplied as the `first_frame_image` (a public URL or a `data:` base64 string) and
 becomes the opening frame of the clip. Returns the `task_id` for polling.

--- a/plugins/minimax-video/commands/query-video.md
+++ b/plugins/minimax-video/commands/query-video.md
@@ -7,6 +7,9 @@ allowed-tools: Bash
 
 # Query Video Generation (MiniMax-Hailuo)
 
+This command uses the existing v1 API. Use /minimax-video:h3-query-video for
+MiniMax-H3 v2 task responses and time-limited result URLs.
+
 Check the status of a previously submitted video-generation task. When the task
 finishes, the response carries the `file_id` needed to download the video.
 

--- a/plugins/minimax-video/commands/text-to-video.md
+++ b/plugins/minimax-video/commands/text-to-video.md
@@ -7,6 +7,9 @@ allowed-tools: Bash
 
 # Text to Video (MiniMax-Hailuo)
 
+This command uses the existing v1 API. Use /minimax-video:h3-create-video for
+MiniMax-H3 v2 generation and multimodal content roles.
+
 Submit a text prompt to the MiniMax video-generation endpoint and return the
 `task_id` that identifies the asynchronous job. Follow up with `/minimax-video:query-video`
 to poll status and `/minimax-video:download-video` to fetch the result.


### PR DESCRIPTION
Reason: The MiniMax video plugin needs the MiniMax-H3 v2 create, query, list, and delete flow with validated multimodal inputs.

## Summary

- Add dedicated MiniMax-H3 v2 commands for task creation, single-task query, filtered task listing, and cancel/delete operations across the global and China endpoints.
- Validate required text, content roles, frame/reference exclusivity, reference-audio dependencies, 2K resolution, integer durations from 4 through 15 seconds, request size, ratios, and the China-only watermark field.
- Allow the download command to consume the time-limited result URL returned by the v2 query response while retaining the existing v1 file-id flow.
- Update the plugin manifest and documentation for the expanded command set.

## Checks

- <code>npm run validate</code>
- <code>npm run test:unit</code>
- Focused Node validation for MiniMax command frontmatter and H3 v2 contract fields
- <code>git diff --check</code>
- Configured diff secret scan
