### PR TITLE
Add markitdown-hook hook

### DIFF
--- a/plugins/all-hooks/hooks/markitdown-hook.md
+++ b/plugins/all-hooks/hooks/markitdown-hook.md
@@ -1,0 +1,92 @@
+---
+name: markitdown-hook
+description: Converts PDFs and Office documents referenced in your prompt to markdown and injects a pointer instead of the content, so a 200-page PDF costs almost nothing until Claude needs it. Grades every conversion so image-only PDFs are reported honestly instead of silently arriving empty.
+category: development
+event: UserPromptSubmit
+matcher: "*"
+language: python
+version: 1.1.0
+---
+
+# markitdown-hook
+
+Cheap, honest document ingestion for Claude Code. Spots PDF and Office document
+paths mentioned in a prompt, converts them with
+[markitdown](https://github.com/microsoft/markitdown), and injects a **pointer**
+into the context instead of the file's contents — a 200-page PDF costs almost
+nothing in tokens until Claude actually reads the cached markdown.
+
+The reason this exists: markitdown exits `0` even when it extracts nothing. An
+image-only PDF (a scan, a screenshot saved as PDF) has no text layer, so a naive
+pipe-through silently reports success on an empty conversion and the model then
+confidently tells the user the document is blank. This hook grades every
+conversion — for PDFs, by characters-per-page — and when a conversion recovers
+nothing it says so explicitly and tells Claude to read the original file
+natively with vision instead.
+
+## Event Configuration
+
+- **Event Type**: `UserPromptSubmit`
+- **Tool Matcher**: `*`
+- **Category**: development
+
+## Requirements
+
+- Python 3.10+
+- `pip install "markitdown[all]"` (quote the brackets — `zsh`, the default shell
+  on macOS, treats them as a glob and the install fails without quotes)
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|--------------|
+| `MARKITDOWN_BIN` | auto-detect | Explicit markitdown path, for virtualenvs |
+| `MARKITDOWN_HOOK_MIN_CHARS_PER_PAGE` | `100` | PDF density threshold below which a conversion is rejected as image-based |
+| `MARKITDOWN_HOOK_CACHE` | `~/.claude/markitdown-cache` | Where conversions are cached |
+| `MARKITDOWN_HOOK_EXTS` | 12 formats | Comma-separated extensions to handle |
+| `MARKITDOWN_HOOK_TIMEOUT` | `100` | Per-file conversion budget, seconds |
+| `MARKITDOWN_HOOK_CACHE_DAYS` | `30` | Prune conversions unused this long |
+| `MARKITDOWN_HOOK_MAX_FILES` | `12` | Cap on documents per prompt |
+
+When installed as a Claude Code plugin, these are exposed as plugin options
+(`python_bin`, `markitdown_bin`, `min_chars_per_page`) instead — plugin options
+win over the environment variables when both are set.
+
+## Usage
+
+As a Claude Code plugin (recommended):
+
+```bash
+claude plugin marketplace add AndrewAvery7/claude-markitdown-hook
+claude plugin install markitdown-hook@claude-markitdown-hook --config python_bin=python
+```
+
+Or manually, add to `~/.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python \"/absolute/path/to/markitdown_hook.py\"",
+            "timeout": 120,
+            "statusMessage": "Converting referenced documents with markitdown..."
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Keep the explicit `timeout` — `UserPromptSubmit` lowers the default for command
+hooks to 30 seconds, below the hook's own 100-second per-file budget, so a slow
+conversion would be killed part-way.
+
+## Source
+
+Full source, docs, and test suite:
+[AndrewAvery7/claude-markitdown-hook](https://github.com/AndrewAvery7/claude-markitdown-hook).


### PR DESCRIPTION
## Summary
Adds `markitdown-hook`, a `UserPromptSubmit` hook that converts PDFs and Office
documents referenced in a prompt to markdown via markitdown, injecting a
pointer instead of the raw content so large documents cost almost nothing in
tokens until Claude actually needs them. Every conversion is graded (by
characters-per-page for PDFs) so an image-only PDF is reported honestly
instead of silently arriving empty.

## Component Details
- **Name**: markitdown-hook
- **Type**: Hook
- **Category**: development

## Testing
- [x] Ran validation (`npm run validate:hooks` — 34 hooks, 0 errors, 0 warnings)
- [x] Tested functionality (in production use in the linked repo, which has its own CI/test suite)
- [x] No overlap with existing components

## Examples
1. `Summarize report.pdf` — hook converts it once, Claude gets a pointer to
   cached markdown instead of re-rendering pages as images every turn.
2. A scanned/image-only PDF — hook reports "NO USABLE TEXT extracted" instead
   of writing an empty file, so Claude reads the original with vision instead
   of claiming the document is blank.
3. A `.docx`/`.pptx`/`.xlsx` file Claude can't read natively — converted to
   markdown first.

Full source, docs, and CI: https://github.com/AndrewAvery7/claude-markitdown-hook