### PR TITLE
Update kegg-mcp-server: v0.4.0 (repairs broken uvx install)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1744,7 +1744,7 @@
     {
       "name": "kegg-mcp-server",
       "description": "Query the KEGG bioinformatics database — pathways, genes, compounds, drugs, enzymes, diseases, reactions, and more via 34 read-only MCP tools. No API key required.",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "author": {
         "name": "Lucas Servi",
         "url": "https://github.com/Lucas-Servi"

--- a/plugins/kegg-mcp-server/.claude-plugin/plugin.json
+++ b/plugins/kegg-mcp-server/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kegg-mcp-server",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Query the KEGG bioinformatics database — pathways, genes, compounds, drugs, enzymes, diseases, reactions, and more via 34 MCP tools. No API key required.",
   "author": {
     "name": "Lucas Servi",


### PR DESCRIPTION
## Summary

Bumps the `kegg-mcp-server` plugin and its marketplace registry entry from **0.3.0 → 0.4.0**.

This is a **repair release, not a feature release**. The upstream PyPI package declared an unbounded `mcp>=1.20`. When the MCP Python SDK **2.0** shipped (2026-07-28) it removed `mcp.server.fastmcp`, so `uvx kegg-mcp-server` began resolving an SDK the published code cannot import and the server failed at startup for anyone installing the plugin fresh. v0.4.0 migrates to `mcp.server.mcpserver.MCPServer` and pins `mcp>=2,<3`.

`0.4.0` is live on PyPI, so `uvx kegg-mcp-server` resolves it with no further action.

**The plugin payload is unchanged** — same 34 read-only tools, 9 resource templates, 4 prompts, 3 commands, 1 agent, 1 skill. The diff is two version strings.

## Component Details

- **Name**: kegg-mcp-server
- **Type**: Plugin (MCP server + commands + agent + skill)
- **Category**: mcp-servers

## Testing

- [x] Ran validation (`npm test`) — all validations passed, 3/3 unit tests
- [x] Ran `npm run validate` separately — skill + hook + registry validation clean
- [x] Tested functionality — drove the plugin's own `.mcp.json` command (`uvx kegg-mcp-server`) over stdio from a **cold `uv` cache**: initialize → protocol `2025-11-25`, `tools/list` = 34, `resources/templates/list` = 9, `prompts/list` = 4, plus a live `search_pathways` call against `rest.kegg.jp` returning `200`
- [x] Confirmed the published wheel imports on both ends of the project's CI matrix (Python 3.11 and 3.14) with mcp 2.0.0
- [x] No overlap with existing components — this updates an existing plugin

## Examples

**1. Pathway lookup**
> "What genes are in the human glycolysis pathway?"

Uses `search_pathways` → `get_pathway_genes`, returning the `hsa00010` gene set.

**2. Drug investigation** (`/kegg-drug`)
> "/kegg-drug metformin"

Walks targets → pathways → classification via `search_drugs`, `get_drug_info`, `get_drug_interactions`.

**3. Cross-species metabolic comparison**
> "Compare the TCA cycle between human and E. coli"

The `kegg-analysis` skill orchestrates `get_pathway_info` / `get_pathway_reactions` across `hsa` and `eco`.