### PR TITLE
Update story parsing: normalize YAML dates

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "scripts": {
     "test": "npm run validate && npm run test:unit",
-    "test:unit": "node --test scripts/github-search-pagination.test.js && node --experimental-strip-types --test web-ui/lib/indexer/search-pagination.test.ts web-ui/lib/search/search-types.test.ts",
+    "test:unit": "node --test scripts/github-search-pagination.test.js && node --experimental-strip-types --test web-ui/lib/indexer/search-pagination.test.ts web-ui/lib/search/search-types.test.ts web-ui/lib/stories-server.test.ts",
     "test:integration": "./tests/plugin-test-harness.sh",
     "validate": "node scripts/validate-all.js",
     "validate:subagents": "node scripts/validate-subagents.js",

--- a/web-ui/lib/stories-server.test.ts
+++ b/web-ui/lib/stories-server.test.ts
@@ -1,0 +1,18 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import matter from 'gray-matter'
+import { normalizeStoryDate } from './stories-server.ts'
+
+describe('normalizeStoryDate', () => {
+  it('formats an unquoted YAML date as a renderable string', () => {
+    const { data } = matter('---\ndate: 2026-08-18\n---')
+
+    assert.ok(data.date instanceof Date)
+    assert.equal(normalizeStoryDate(data.date), '2026-08-18')
+  })
+
+  it('preserves trimmed human-readable dates and rejects other values', () => {
+    assert.equal(normalizeStoryDate(' May 27, 2026 '), 'May 27, 2026')
+    assert.equal(normalizeStoryDate(20260818), '')
+  })
+})

--- a/web-ui/lib/stories-server.ts
+++ b/web-ui/lib/stories-server.ts
@@ -36,6 +36,14 @@ function optionalString(raw: unknown): string | undefined {
   return trimmed ? trimmed : undefined
 }
 
+export function normalizeStoryDate(raw: unknown): string {
+  if (typeof raw === 'string') return raw.trim()
+  if (raw instanceof Date && !Number.isNaN(raw.getTime())) {
+    return raw.toISOString().slice(0, 10)
+  }
+  return ''
+}
+
 /** A sanitized href, or undefined when missing / unsafe (so it renders as plain text). */
 function optionalHref(raw: unknown): string | undefined {
   if (typeof raw !== 'string' || !raw.trim()) return undefined
@@ -83,7 +91,7 @@ function parseStory(slug: string, raw: string, coverImage: string | undefined): 
     category,
     platforms: Array.isArray(data.platforms) ? data.platforms : [],
     cover,
-    date: data.date ?? '',
+    date: normalizeStoryDate(data.date),
     readTime: Number.isFinite(data.readTime) ? data.readTime : 5,
     featured: Boolean(data.featured),
     pinned: Boolean(data.pinned),

--- a/web-ui/package.json
+++ b/web-ui/package.json
@@ -9,7 +9,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test:unit": "node --experimental-strip-types --test lib/indexer/search-pagination.test.ts lib/search/search-types.test.ts",
+    "test:unit": "node --experimental-strip-types --test lib/indexer/search-pagination.test.ts lib/search/search-types.test.ts lib/stories-server.test.ts",
     "generate-registry": "node ../scripts/generate-registry.js",
     "index:skills": "node scripts/run-skills-index.js",
     "index:cron": "node scripts/run-indexer.js"


### PR DESCRIPTION
## Summary

Normalizes story frontmatter dates before they enter the `Story` model.

YAML parses an unquoted ISO date such as `2026-08-18` into a JavaScript `Date`, while the UI expects a string and renders it directly. The parser now preserves trimmed human-readable date strings, converts valid YAML `Date` values to `YYYY-MM-DD`, and falls back to an empty string for unsupported values.

## Component Details

- **Name**: Story date parsing
- **Type**: Web UI story fix
- **Category**: Community stories

## Testing

- [x] Ran validation (`npm test`)
- [x] Added regression coverage for YAML dates, human-readable strings, and unsupported values
- [x] Ran TypeScript validation (`npm exec --workspace web-ui tsc -- --noEmit --allowImportingTsExtensions`)
- [x] Ran the production build (`npm run build --workspace web-ui`; 578 static pages generated)
- [x] No overlap with existing open issues or pull requests

## Examples

1. `date: 2026-08-18` becomes the renderable string `2026-08-18`.
2. `date: May 27, 2026` remains `May 27, 2026`.
3. Non-string, non-date values safely become an empty date.

## Risk

Existing story dates keep their current display. Only unquoted ISO dates and invalid value types receive normalized fallback behavior.
