### PR TITLE
Update search object IDs: prevent sanitized slug collisions

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "scripts": {
     "test": "npm run validate && npm run test:unit",
-    "test:unit": "node --test scripts/github-search-pagination.test.js && node --experimental-strip-types --test web-ui/lib/indexer/search-pagination.test.ts",
+    "test:unit": "node --test scripts/github-search-pagination.test.js && node --experimental-strip-types --test web-ui/lib/indexer/search-pagination.test.ts web-ui/lib/search/search-types.test.ts",
     "test:integration": "./tests/plugin-test-harness.sh",
     "validate": "node scripts/validate-all.js",
     "validate:subagents": "node scripts/validate-subagents.js",

--- a/web-ui/lib/search/search-types.test.ts
+++ b/web-ui/lib/search/search-types.test.ts
@@ -16,8 +16,15 @@ describe('makeObjectID', () => {
   it('sanitizes characters Meilisearch forbids in primary keys', () => {
     // Only [a-zA-Z0-9_-] is allowed — colons, @, / etc. must be replaced.
     assert.match(makeObjectID('marketplace', '@owner/repo'), /^[a-zA-Z0-9_-]+$/)
-    assert.equal(makeObjectID('marketplace', '@owner/repo'), 'marketplace___owner_repo')
+    assert.match(makeObjectID('marketplace', '@owner/repo'), /^marketplace___owner_repo__[a-f0-9]{16}$/)
     assert.match(makeObjectID('skill', 'weird:slug.with/chars'), /^[a-zA-Z0-9_-]+$/)
+  })
+
+  it('does not collide when different slugs sanitize to the same text', () => {
+    assert.notEqual(
+      makeObjectID('marketplace', '@owner/foo/bar'),
+      makeObjectID('marketplace', '@owner/foo.bar'),
+    )
   })
 
   it('keeps ids stable + unique across types for the same slug', () => {

--- a/web-ui/lib/search/search-types.ts
+++ b/web-ui/lib/search/search-types.ts
@@ -1,4 +1,5 @@
 import type { Settings } from 'meilisearch'
+import { createHash } from 'node:crypto'
 
 /**
  * The seven content types BuildWithClaude indexes into Meilisearch. Values are
@@ -34,12 +35,15 @@ export function isSearchContentType(value: string): value is SearchContentType {
 /**
  * Build a Meilisearch primary key. Meilisearch only permits `[a-zA-Z0-9_-]` in
  * document ids, so the raw `${type}:${slug}` form (colon, and slugs like a
- * marketplace's `@owner/repo` namespace) must be sanitized. The `__` separator
- * is unambiguous because no content type contains an underscore.
+ * marketplace's `@owner/repo` namespace) must be sanitized. Slugs that require
+ * sanitizing get a stable digest suffix so distinct values cannot collapse.
  */
 export function makeObjectID(type: SearchContentType, slug: string): string {
   const safeSlug = slug.replace(/[^a-zA-Z0-9_-]+/g, '_')
-  return `${type}__${safeSlug}`
+  if (safeSlug === slug) return `${type}__${safeSlug}`
+
+  const digest = createHash('sha256').update(slug).digest('hex').slice(0, 16)
+  return `${type}__${safeSlug}__${digest}`
 }
 
 /**


### PR DESCRIPTION
## Summary

Prevents distinct search slugs from collapsing to the same Meilisearch primary key. Slugs that require sanitizing now retain the readable sanitized prefix and receive a deterministic SHA-256 suffix.

Previously, values such as `@owner/foo/bar` and `@owner/foo.bar` both became `marketplace___owner_foo_bar`, so one document could overwrite the other during indexing.

## Component Details

- **Name**: Search object ID generation
- **Type**: Web UI search fix
- **Category**: Search indexing

## Testing

- [x] Ran validation (`npm test`)
- [x] Added a regression test for colliding sanitized slugs
- [x] Ran TypeScript validation (`npm exec --workspace web-ui tsc -- --noEmit --allowImportingTsExtensions`)
- [x] Ran the production build (`npm run build --workspace web-ui`; 578 static pages generated)
- [x] No overlap with existing open issues or pull requests

## Examples

1. `@owner/foo/bar` and `@owner/foo.bar` now produce different object IDs.
2. Already-safe slugs such as `code-reviewer` retain their existing object ID.
3. All generated IDs still contain only Meilisearch-supported characters.

## Risk

Sanitized-slug documents receive new IDs on their next type or full reindex. The existing type reindex flow deletes the old type documents before adding the new set, so no separate migration is required.
