### PR TITLE
Update search hydration: preserve plugin and skill identity

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "scripts": {
     "test": "npm run validate && npm run test:unit",
-    "test:unit": "node --test scripts/github-search-pagination.test.js && node --experimental-strip-types --test web-ui/lib/indexer/search-pagination.test.ts web-ui/lib/search/search-types.test.ts web-ui/lib/stories-server.test.ts",
+    "test:unit": "node --test scripts/github-search-pagination.test.js && node --experimental-strip-types --test web-ui/lib/indexer/search-pagination.test.ts web-ui/lib/search/search-types.test.ts web-ui/lib/search/search-hydration.test.ts web-ui/lib/stories-server.test.ts",
     "test:integration": "./tests/plugin-test-harness.sh",
     "validate": "node scripts/validate-all.js",
     "validate:subagents": "node scripts/validate-subagents.js",

--- a/web-ui/lib/search/search-hydrate.ts
+++ b/web-ui/lib/search/search-hydrate.ts
@@ -3,6 +3,7 @@ import { getDbPluginsBySlugs, getLocalBuildWithClaudePlugins } from '@/lib/plugi
 import { getMarketplacesByNamespaces } from '@/lib/marketplace-server'
 import type { UnifiedPlugin, PluginType } from '@/lib/plugin-types'
 import type { MarketplaceRegistry } from '@/lib/marketplace-types'
+import { hydrateHitsByTypeAndSlug } from './search-hydration'
 
 /**
  * Meilisearch-backed search for the plugins/skills pages: rank via Meilisearch,
@@ -29,20 +30,17 @@ export async function searchPluginsHydrated(opts: {
 
   const hits = res.items
   const dbList = await getDbPluginsBySlugs(hits.map((h) => h.slug))
-  const dbBySlug = new Map<string, UnifiedPlugin>()
-  for (const p of dbList) if (p.slug) dbBySlug.set(p.slug, p)
+  const dbByIdentity = new Set(dbList.map((p) => `${p.type}:${p.slug}`))
 
   // Hydrate local Build with Claude items only if some hits weren't in the DB.
-  const localByKey = new Map<string, UnifiedPlugin>()
-  if (hits.some((h) => !dbBySlug.has(h.slug))) {
-    for (const p of getLocalBuildWithClaudePlugins()) {
-      localByKey.set(`${p.type}:${p.slug ?? p.name}`, p)
-    }
-  }
+  const local = hits.some((h) => !dbByIdentity.has(`${h.type}:${h.slug}`))
+    ? getLocalBuildWithClaudePlugins().map((p) => ({ ...p, slug: p.slug ?? p.name }))
+    : []
 
-  const plugins = hits
-    .map((h) => dbBySlug.get(h.slug) ?? localByKey.get(`${h.type}:${h.slug}`))
-    .filter((p): p is UnifiedPlugin => Boolean(p))
+  const records = [...dbList, ...local].filter(
+    (p): p is UnifiedPlugin & { slug: string } => Boolean(p.slug),
+  )
+  const plugins = hydrateHitsByTypeAndSlug(hits, records)
 
   return { plugins, total: res.total, limit: res.limit, offset: res.offset, hasMore: res.hasMore }
 }

--- a/web-ui/lib/search/search-hydration.test.ts
+++ b/web-ui/lib/search/search-hydration.test.ts
@@ -1,0 +1,21 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { hydrateHitsByTypeAndSlug } from './search-hydration.ts'
+
+describe('hydrateHitsByTypeAndSlug', () => {
+  it('keeps plugin and skill records separate when they share a slug', () => {
+    const hits = [
+      { type: 'plugin', slug: 'shared' },
+      { type: 'skill', slug: 'shared' },
+    ]
+    const records = [
+      { type: 'skill', slug: 'shared', name: 'Shared skill' },
+      { type: 'plugin', slug: 'shared', name: 'Shared plugin' },
+    ]
+
+    assert.deepEqual(hydrateHitsByTypeAndSlug(hits, records), [
+      records[1],
+      records[0],
+    ])
+  })
+})

--- a/web-ui/lib/search/search-hydration.ts
+++ b/web-ui/lib/search/search-hydration.ts
@@ -1,0 +1,19 @@
+interface SearchIdentity {
+  type: string
+  slug: string
+}
+
+export function hydrateHitsByTypeAndSlug<T extends SearchIdentity>(
+  hits: readonly SearchIdentity[],
+  records: readonly T[],
+): T[] {
+  const byIdentity = new Map<string, T>()
+  for (const record of records) {
+    const key = `${record.type}:${record.slug}`
+    if (!byIdentity.has(key)) byIdentity.set(key, record)
+  }
+
+  return hits
+    .map((hit) => byIdentity.get(`${hit.type}:${hit.slug}`))
+    .filter((record): record is T => Boolean(record))
+}

--- a/web-ui/package.json
+++ b/web-ui/package.json
@@ -9,7 +9,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test:unit": "node --experimental-strip-types --test lib/indexer/search-pagination.test.ts lib/search/search-types.test.ts lib/stories-server.test.ts",
+    "test:unit": "node --experimental-strip-types --test lib/indexer/search-pagination.test.ts lib/search/search-hydration.test.ts lib/search/search-types.test.ts lib/stories-server.test.ts",
     "generate-registry": "node ../scripts/generate-registry.js",
     "index:skills": "node scripts/run-skills-index.js",
     "index:cron": "node scripts/run-indexer.js"


### PR DESCRIPTION
## Summary

Keeps plugin and skill search hits mapped to the correct record when they share a slug.

The current hydration path indexes database records by slug alone. If a plugin and a skill both use `shared`, the later database row can replace the earlier one and both ranked hits can render as the same component type. Hydration now uses the same `type + slug` identity as the search index and preserves Meilisearch result order.

## Component Details

- **Name**: Plugin and skill search hydration
- **Type**: Web UI search fix
- **Category**: Search results

## Testing

- [x] Ran validation (`npm test`)
- [x] Added a regression test with a plugin and skill sharing one slug
- [x] Ran TypeScript validation (`npm exec --workspace web-ui tsc -- --noEmit --allowImportingTsExtensions`)
- [x] Ran the production build (`npm run build --workspace web-ui`; 578 static pages generated)
- [x] No overlap with existing open issues or pull requests

## Examples

1. A `plugin:shared` hit hydrates to the plugin record.
2. A `skill:shared` hit hydrates to the skill record.
3. Records returned in database order are reordered to the original search ranking.

## Risk

The change only affects hydration of existing search results. It does not alter database records, index documents, or pagination metadata.
