### PR TITLE
Add MCP project config export

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "scripts": {
     "test": "npm run validate && npm run test:unit",
-    "test:unit": "node --test scripts/github-search-pagination.test.js && node --experimental-strip-types --test web-ui/lib/indexer/search-pagination.test.ts web-ui/lib/search/search-types.test.ts web-ui/lib/search/search-hydration.test.ts web-ui/lib/stories-server.test.ts",
+    "test:unit": "node --test scripts/github-search-pagination.test.js && node --experimental-strip-types --test web-ui/lib/indexer/search-pagination.test.ts web-ui/lib/search/search-types.test.ts web-ui/lib/search/search-hydration.test.ts web-ui/lib/stories-server.test.ts web-ui/lib/mcp-project-config.test.ts",
     "test:integration": "./tests/plugin-test-harness.sh",
     "validate": "node scripts/validate-all.js",
     "validate:subagents": "node scripts/validate-subagents.js",

--- a/web-ui/components/mcp-card.tsx
+++ b/web-ui/components/mcp-card.tsx
@@ -147,6 +147,8 @@ export function MCPCard({ server }: MCPCardProps) {
         dockerMcpAvailable={server.docker_mcp_available || server.source_registry?.type === 'docker'}
         dockerMcpCommand={server.docker_mcp_command || `docker mcp server enable mcp/${server.name}`}
         environmentVariables={server.environment_variables}
+        packages={server.packages}
+        remotes={server.remotes}
       />
     </>
   )

--- a/web-ui/components/mcp-installation-modal.tsx
+++ b/web-ui/components/mcp-installation-modal.tsx
@@ -10,8 +10,16 @@ import {
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
-import { Copy, Check, Terminal, AlertCircle } from 'lucide-react'
-import { MCPEnvironmentVariable } from '@/lib/mcp-types'
+import { Copy, Check, Terminal, AlertCircle, FileJson } from 'lucide-react'
+import {
+  MCPEnvironmentVariable,
+  MCPPackage,
+  MCPRemote,
+} from '@/lib/mcp-types'
+import {
+  buildMCPProjectConfig,
+  serializeMCPProjectConfig,
+} from '@/lib/mcp-project-config'
 
 interface MCPInstallationModalProps {
   isOpen: boolean
@@ -22,6 +30,8 @@ interface MCPInstallationModalProps {
   dockerMcpAvailable?: boolean
   dockerMcpCommand?: string
   environmentVariables?: MCPEnvironmentVariable[]
+  packages?: MCPPackage[]
+  remotes?: MCPRemote[]
 }
 
 export function MCPInstallationModal({
@@ -33,9 +43,12 @@ export function MCPInstallationModal({
   dockerMcpAvailable,
   dockerMcpCommand,
   environmentVariables,
+  packages,
+  remotes,
 }: MCPInstallationModalProps) {
   const [copiedClaude, setCopiedClaude] = useState(false)
   const [copiedDocker, setCopiedDocker] = useState(false)
+  const [copiedProjectConfig, setCopiedProjectConfig] = useState(false)
 
   // Use provided command or fall back to a generic message
   const claudeCommand = claudeMcpAddCommand || `claude mcp add ${serverName}`
@@ -43,6 +56,15 @@ export function MCPInstallationModal({
 
   const hasEnvVars = environmentVariables && environmentVariables.length > 0
   const hasClaudeCommand = !!claudeMcpAddCommand
+  const projectConfig = buildMCPProjectConfig({
+    serverName,
+    packages,
+    remotes,
+    environmentVariables,
+  })
+  const projectConfigText = projectConfig
+    ? serializeMCPProjectConfig(projectConfig)
+    : null
 
   const handleCopyClaude = async () => {
     await navigator.clipboard.writeText(claudeCommand)
@@ -56,10 +78,30 @@ export function MCPInstallationModal({
     setTimeout(() => setCopiedDocker(false), 2000)
   }
 
+  const handleCopyProjectConfig = async () => {
+    if (!projectConfigText) return
+    await navigator.clipboard.writeText(projectConfigText)
+    setCopiedProjectConfig(true)
+    setTimeout(() => setCopiedProjectConfig(false), 2000)
+  }
+
   // Determine which tabs to show
   const showClaudeTab = hasClaudeCommand
   const showDockerTab = dockerMcpAvailable
-  const defaultTab = showClaudeTab ? 'claude' : showDockerTab ? 'docker' : 'claude'
+  const showProjectConfigTab = !!projectConfigText
+  const visibleTabCount = [showClaudeTab, showDockerTab, showProjectConfigTab].filter(Boolean).length
+  const tabsGridClass = visibleTabCount === 3
+    ? 'grid-cols-3'
+    : visibleTabCount === 2
+      ? 'grid-cols-2'
+      : 'grid-cols-1'
+  const defaultTab = showClaudeTab
+    ? 'claude'
+    : showDockerTab
+      ? 'docker'
+      : showProjectConfigTab
+        ? 'project-config'
+        : 'claude'
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
@@ -72,7 +114,7 @@ export function MCPInstallationModal({
         </DialogHeader>
 
         <Tabs defaultValue={defaultTab} className="flex-1 flex flex-col">
-          <TabsList className={`grid w-full ${showClaudeTab && showDockerTab ? 'grid-cols-2' : 'grid-cols-1'}`}>
+          <TabsList className={`grid w-full ${tabsGridClass}`}>
             {showClaudeTab && (
               <TabsTrigger value="claude" className="flex items-center gap-2">
                 <Terminal className="h-4 w-4" />
@@ -83,6 +125,12 @@ export function MCPInstallationModal({
               <TabsTrigger value="docker" className="flex items-center gap-2">
                 <Terminal className="h-4 w-4" />
                 Docker MCP {!showClaudeTab && '(Recommended)'}
+              </TabsTrigger>
+            )}
+            {showProjectConfigTab && (
+              <TabsTrigger value="project-config" className="flex items-center gap-2">
+                <FileJson className="h-4 w-4" />
+                Project config
               </TabsTrigger>
             )}
           </TabsList>
@@ -193,6 +241,46 @@ export function MCPInstallationModal({
                   <ul className="list-disc list-inside space-y-1 ml-2 text-muted-foreground">
                     <li>Docker Desktop must be installed and running</li>
                     <li>Docker MCP Toolkit must be enabled</li>
+                  </ul>
+                </div>
+              </div>
+            </TabsContent>
+          )}
+
+          {showProjectConfigTab && projectConfigText && (
+            <TabsContent value="project-config" className="flex-1 overflow-auto space-y-4">
+              <div className="space-y-3">
+                <p className="text-sm text-muted-foreground">
+                  Copy this project-scoped <code className="bg-muted px-1 rounded">.mcp.json</code> entry.
+                  Required values remain placeholders for you to fill locally.
+                </p>
+
+                <div className="relative rounded-lg bg-muted p-3">
+                  <pre className="max-h-72 overflow-auto whitespace-pre-wrap break-words pr-12 font-mono text-sm">
+                    {projectConfigText}
+                  </pre>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    className="absolute right-2 top-2"
+                    onClick={handleCopyProjectConfig}
+                    title="Copy project MCP configuration"
+                    aria-label="Copy project MCP configuration"
+                  >
+                    {copiedProjectConfig ? (
+                      <Check className="h-4 w-4 text-green-600" />
+                    ) : (
+                      <Copy className="h-4 w-4" />
+                    )}
+                  </Button>
+                </div>
+
+                <div className="space-y-2 text-xs text-muted-foreground">
+                  <p>This configuration will:</p>
+                  <ul className="list-disc list-inside space-y-1 ml-2">
+                    <li>Keep the server scoped to the current project</li>
+                    <li>Use the catalog&apos;s structured transport and package metadata</li>
+                    <li>Leave required environment values for local configuration</li>
                   </ul>
                 </div>
               </div>

--- a/web-ui/lib/mcp-project-config.test.ts
+++ b/web-ui/lib/mcp-project-config.test.ts
@@ -1,0 +1,108 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  buildMCPProjectConfig,
+  serializeMCPProjectConfig,
+  type MCPProjectConfig,
+  type MCPProjectConfigInput,
+} from './mcp-project-config.ts'
+
+describe('buildMCPProjectConfig', () => {
+  it('prefers a valid remote and normalizes streamable HTTP', () => {
+    const input: MCPProjectConfigInput = {
+      serverName: 'github',
+      packages: [{ registryType: 'npm', identifier: '@scope/github-mcp', transport: 'stdio' }],
+      remotes: [{ type: 'streamable-http', url: 'https://mcp.example.com' }],
+    }
+
+    assert.deepEqual(buildMCPProjectConfig(input), {
+      mcpServers: {
+        github: { type: 'http', url: 'https://mcp.example.com' },
+      },
+    })
+  })
+
+  it('builds an npm stdio package with required environment placeholders', () => {
+    const input: MCPProjectConfigInput = {
+      serverName: 'local-search',
+      packages: [{ registryType: 'npm', identifier: '@scope/search-mcp', transport: 'stdio' }],
+      environmentVariables: [
+        { name: 'SEARCH_API_KEY', required: true },
+        { name: 'OPTIONAL_REGION', required: false },
+      ],
+    }
+
+    assert.deepEqual(buildMCPProjectConfig(input), {
+      mcpServers: {
+        'local-search': {
+          command: 'npx',
+          args: ['-y', '@scope/search-mcp'],
+          env: { SEARCH_API_KEY: '${SEARCH_API_KEY}' },
+        },
+      },
+    })
+  })
+
+  it('builds an OCI stdio package when no remote or npm package is usable', () => {
+    const input: MCPProjectConfigInput = {
+      serverName: 'docker-tools',
+      packages: [
+        { registryType: 'npm', identifier: '', transport: 'stdio' },
+        { registryType: 'oci', identifier: 'ghcr.io/acme/tools:1.2.0', transport: 'stdio' },
+      ],
+    }
+
+    assert.deepEqual(buildMCPProjectConfig(input), {
+      mcpServers: {
+        'docker-tools': {
+          command: 'docker',
+          args: ['run', '--rm', '-i', 'ghcr.io/acme/tools:1.2.0'],
+        },
+      },
+    })
+  })
+
+  it('normalizes SSE remotes and rejects unsupported or incomplete records', () => {
+    assert.deepEqual(buildMCPProjectConfig({
+      serverName: 'events',
+      remotes: [{ type: 'sse', url: 'https://mcp.example.com/events' }],
+    }), {
+      mcpServers: {
+        events: { type: 'sse', url: 'https://mcp.example.com/events' },
+      },
+    })
+
+    assert.equal(buildMCPProjectConfig({
+      serverName: 'unsupported',
+      packages: [{ registryType: 'npm', identifier: '@scope/tool', transport: 'http' }],
+      remotes: [{ type: 'http', url: 'not-a-url' }],
+    }), null)
+  })
+
+  it('deduplicates required environment placeholders and ignores optional values', () => {
+    const config = buildMCPProjectConfig({
+      serverName: 'dedupe',
+      packages: [{ registryType: 'npm', identifier: 'dedupe-mcp', transport: 'stdio' }],
+      environmentVariables: [
+        { name: 'TOKEN', required: true },
+        { name: 'TOKEN', required: true },
+        { name: 'OPTIONAL', required: false },
+        { name: ' ', required: true },
+      ],
+    })
+
+    const localConfig = config as MCPProjectConfig & {
+      mcpServers: { dedupe: { env?: Record<string, string> } }
+    }
+    assert.deepEqual(localConfig.mcpServers.dedupe.env, { TOKEN: '${TOKEN}' })
+  })
+
+  it('serializes a stable two-space JSON document with a trailing newline', () => {
+    const config = buildMCPProjectConfig({
+      serverName: 'github',
+      remotes: [{ type: 'http', url: 'https://mcp.example.com' }],
+    })
+
+    assert.equal(serializeMCPProjectConfig(config!), '{\n  "mcpServers": {\n    "github": {\n      "type": "http",\n      "url": "https://mcp.example.com"\n    }\n  }\n}\n')
+  })
+})

--- a/web-ui/lib/mcp-project-config.ts
+++ b/web-ui/lib/mcp-project-config.ts
@@ -1,0 +1,116 @@
+import type {
+  MCPEnvironmentVariable,
+  MCPPackage,
+  MCPRemote,
+} from './mcp-types.ts'
+
+type RemoteProjectConfig = {
+  type: 'http' | 'sse'
+  url: string
+}
+
+type LocalProjectConfig = {
+  command: 'npx' | 'docker'
+  args: string[]
+  env?: Record<string, string>
+}
+
+export interface MCPProjectConfig {
+  mcpServers: Record<string, RemoteProjectConfig | LocalProjectConfig>
+}
+
+export interface MCPProjectConfigInput {
+  serverName: string
+  packages?: MCPPackage[]
+  remotes?: MCPRemote[]
+  environmentVariables?: MCPEnvironmentVariable[]
+}
+
+const ENVIRONMENT_VARIABLE_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/
+
+function normalizeRemote(remote: MCPRemote): RemoteProjectConfig | null {
+  const url = remote.url.trim()
+
+  try {
+    const parsed = new URL(url)
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null
+  } catch {
+    return null
+  }
+
+  if (remote.type === 'sse') return { type: 'sse', url }
+  if (remote.type === 'http' || remote.type === 'streamable-http') {
+    return { type: 'http', url }
+  }
+
+  return null
+}
+
+function isUsableIdentifier(identifier: string): boolean {
+  return identifier.trim().length > 0 && !/\s/.test(identifier)
+}
+
+function requiredEnvironment(
+  environmentVariables: MCPEnvironmentVariable[],
+): Record<string, string> | undefined {
+  const entries = environmentVariables
+    .filter(({ name, required }) => required === true && ENVIRONMENT_VARIABLE_NAME.test(name.trim()))
+    .map(({ name }) => {
+      const normalizedName = name.trim()
+      return [normalizedName, `\${${normalizedName}}`] as const
+    })
+
+  if (entries.length === 0) return undefined
+  return Object.fromEntries(entries)
+}
+
+function localEntry(
+  packages: MCPPackage[],
+  environmentVariables: MCPEnvironmentVariable[],
+): LocalProjectConfig | null {
+  const npmPackage = packages.find((item) => (
+    item.registryType === 'npm'
+    && item.transport === 'stdio'
+    && isUsableIdentifier(item.identifier)
+  ))
+  const ociPackage = packages.find((item) => (
+    item.registryType === 'oci'
+    && item.transport === 'stdio'
+    && isUsableIdentifier(item.identifier)
+  ))
+  const selectedPackage = npmPackage || ociPackage
+
+  if (!selectedPackage) return null
+
+  const identifier = selectedPackage.identifier.trim()
+  const entry: LocalProjectConfig = selectedPackage.registryType === 'npm'
+    ? { command: 'npx', args: ['-y', identifier] }
+    : { command: 'docker', args: ['run', '--rm', '-i', identifier] }
+  const env = requiredEnvironment(environmentVariables)
+
+  return env ? { ...entry, env } : entry
+}
+
+export function buildMCPProjectConfig({
+  serverName,
+  packages = [],
+  remotes = [],
+  environmentVariables = [],
+}: MCPProjectConfigInput): MCPProjectConfig | null {
+  const normalizedName = serverName.trim()
+  if (!normalizedName || /[\u0000-\u001f]/.test(normalizedName)) return null
+
+  const entry = remotes.map(normalizeRemote).find((item) => item !== null)
+    || localEntry(packages, environmentVariables)
+  if (!entry) return null
+
+  return {
+    mcpServers: {
+      [normalizedName]: entry,
+    },
+  }
+}
+
+export function serializeMCPProjectConfig(config: MCPProjectConfig): string {
+  return `${JSON.stringify(config, null, 2)}\n`
+}

--- a/web-ui/package.json
+++ b/web-ui/package.json
@@ -9,7 +9,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test:unit": "node --experimental-strip-types --test lib/indexer/search-pagination.test.ts lib/search/search-hydration.test.ts lib/search/search-types.test.ts lib/stories-server.test.ts",
+    "test:unit": "node --experimental-strip-types --test lib/indexer/search-pagination.test.ts lib/search/search-hydration.test.ts lib/search/search-types.test.ts lib/stories-server.test.ts lib/mcp-project-config.test.ts",
     "generate-registry": "node ../scripts/generate-registry.js",
     "index:skills": "node scripts/run-skills-index.js",
     "index:cron": "node scripts/run-indexer.js"


### PR DESCRIPTION
## Summary

Adds a project-scoped `.mcp.json` export to the existing MCP installation dialog.

The new `Project config` tab is shown only when structured registry metadata can produce a supported configuration. Remote HTTP/SSE endpoints are preferred, followed by npm stdio packages and OCI stdio packages. Required environment variables remain local placeholders; the exporter never reads secrets or parses shell commands.

## Component Details

- **Name**: MCP project config export
- **Type**: Web UI feature
- **Category**: MCP servers

## Testing

- [x] Ran validation and unit tests (`npm test`; 20 tests passed)
- [x] Added focused tests for remote, npm, OCI, precedence, environment placeholders, unsupported inputs, and stable JSON serialization
- [x] Ran TypeScript validation (`npm exec --workspace web-ui tsc -- --noEmit --allowImportingTsExtensions`)
- [x] Ran the production build (`npm run build --workspace web-ui`; 578 static pages generated)
- [x] Tested the dialog at desktop and 390x844 mobile viewports with no overflow or console errors
- [x] No overlap with existing open issues or pull requests

## Examples

1. A Streamable HTTP endpoint exports as a project MCP server with `type: "http"` and its registry URL.
2. An npm stdio package exports as `npx -y <identifier>` with required environment values such as `${API_KEY}` left as placeholders.
3. Unsupported or incomplete metadata does not show the project-config tab instead of guessing a command.

## Risk

The feature consumes only existing structured `packages`, `remotes`, and `environment_variables` fields. It does not change the database schema, existing Claude CLI/Docker installation paths, or any user files. The local in-app browser did not grant Clipboard API write permission, so clipboard contents could not be inspected there; the same browser API and feedback pattern already used by the existing install buttons is retained.
