### PR TITLE
Add checkpointed-agent-loop skill

### DIFF
--- a/plugins/all-skills/skills/checkpointed-agent-loop/SKILL.md
+++ b/plugins/all-skills/skills/checkpointed-agent-loop/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: checkpointed-agent-loop
+category: ai-agents
+description: "Run long or failure-prone Claude Code tasks as bounded, resumable loops with a durable state machine, attempt budget, and verification evidence checkpoint."
+license: MIT
+---
+
+# Checkpointed Agent Loop
+
+Use this skill when a task can be interrupted, needs bounded retries, or must prove verification before it is called complete. It adds a small local checkpoint file around ordinary Claude Code work so a new context can resume from explicit state instead of reconstructing progress from chat.
+
+The included Node.js utility stores state and evidence. It does **not** execute commands, call a model, spawn agents, access secrets, or contact a network service. Claude Code remains responsible for each actual tool call and for deciding whether a human approval is required.
+
+## When to Use This Skill
+
+- A migration, refactor, test repair, or investigation may span multiple sessions.
+- A bounded retry loop is safer than repeatedly improvising from conversation history.
+- A task needs a durable next action and a record of which verification actually ran.
+- You need to stop at an external dependency or a human decision without claiming success.
+
+Do not use it for a one-line edit or a workflow that already has its own durable runner.
+
+## State Model
+
+The checkpoint uses these states and only these transitions:
+
+```text
+planned -> running
+running -> verifying | failed | blocked
+verifying -> succeeded | running | failed | blocked
+```
+
+`succeeded`, `failed`, and `blocked` are terminal. Entering `running` consumes one attempt, and the finite `maxAttempts` value cannot be exceeded. A transition to `succeeded` is rejected until the checkpoint contains at least one passing evidence record from `verifying`.
+
+## Setup
+
+Choose a project-local path that is not committed with application code, for example `.agent/checkpoints/data-migration.json`. Keep objectives, reasons, and evidence free of API keys, tokens, passwords, personal data, and raw secret-bearing logs.
+
+Set the helper path for the commands below:
+
+```bash
+SKILL_DIR="<absolute path to the installed checkpointed-agent-loop skill>"
+CHECKPOINT=".agent/checkpoints/task.json"
+```
+
+Initialize with a finite budget:
+
+```bash
+node "$SKILL_DIR/scripts/checkpoint-loop.mjs" init \
+  --file "$CHECKPOINT" \
+  --task "data-migration" \
+  --objective "Migrate the user table without losing records" \
+  --max-attempts 3 \
+  --next-action "Inspect the current migration and test fixture"
+```
+
+## Operating Protocol
+
+### 1. Start one bounded attempt
+
+Before making the change, persist the next action and enter `running`:
+
+```bash
+node "$SKILL_DIR/scripts/checkpoint-loop.mjs" transition \
+  --file "$CHECKPOINT" \
+  --to running
+```
+
+Use Claude Code-native tools for exactly the bounded action described by `nextAction`. Do not turn one attempt into an unbounded plan.
+
+### 2. Enter verification
+
+After the action, move to verification before deciding the outcome:
+
+```bash
+node "$SKILL_DIR/scripts/checkpoint-loop.mjs" transition \
+  --file "$CHECKPOINT" \
+  --to verifying
+```
+
+Run the relevant check yourself. The helper records a check name and outcome; it never runs that check for you:
+
+```bash
+node "$SKILL_DIR/scripts/checkpoint-loop.mjs" evidence \
+  --file "$CHECKPOINT" \
+  --check "npm test -- workspace migration" \
+  --outcome passed \
+  --artifact "artifacts/migration-test.txt"
+```
+
+Only cite an artifact that exists and is safe to share. A failed check can be recorded with `--outcome failed`; do not convert it to a passing record by rewriting the expected value.
+
+### 3. Finish, retry, or escalate
+
+If verification is genuinely passing:
+
+```bash
+node "$SKILL_DIR/scripts/checkpoint-loop.mjs" transition \
+  --file "$CHECKPOINT" \
+  --to succeeded
+```
+
+If the change needs another bounded attempt, provide a concrete next action and reason:
+
+```bash
+node "$SKILL_DIR/scripts/checkpoint-loop.mjs" transition \
+  --file "$CHECKPOINT" \
+  --to running \
+  --next-action "Fix the null-row fixture and rerun the focused test" \
+  --reason "Verification found a reproducible null-row failure"
+```
+
+Use `failed` for a terminal technical failure. Use `blocked` only when progress needs an external dependency or human decision:
+
+```bash
+node "$SKILL_DIR/scripts/checkpoint-loop.mjs" transition \
+  --file "$CHECKPOINT" \
+  --to blocked \
+  --reason "Waiting for the database owner to approve the production window"
+```
+
+### 4. Resume after interruption
+
+Read the checkpoint before doing any work in a new session:
+
+```bash
+node "$SKILL_DIR/scripts/checkpoint-loop.mjs" status \
+  --file "$CHECKPOINT" \
+  --format summary
+```
+
+For machine-readable recovery, omit `--format summary`. Continue from `nextAction`, inspect the history and evidence, and never repeat a completed attempt merely because the old conversation is unavailable.
+
+## Safety Rules
+
+- Use a positive, finite attempt budget. A loop without a ceiling is not a recoverable loop.
+- Never mark `succeeded` without passing verification evidence in the checkpoint.
+- Do not place secrets or full sensitive logs in the checkpoint; store only a safe check name and sanitized artifact path.
+- The helper does not run evidence commands. Execute checks with normal approval and tool policy, then record their observed result.
+- Destructive actions, external writes, payments, deployments, and permission changes still require the normal human approval boundary.
+- Treat a malformed or manually edited checkpoint as invalid and stop for review; do not guess its missing state.
+
+## Examples
+
+### Interrupted migration
+
+An agent initializes `data-migration` with three attempts, enters `running`, updates the migration, and is interrupted before verification. The next session runs `status`, sees `running` and the saved `nextAction`, performs only that action, then records the actual test result before moving to `succeeded` or a bounded retry.
+
+### Attempt ceiling reached
+
+An agent records a failed verification, transitions back to `running` with `maxAttempts: 2`, and fails the same focused check on the second attempt. A third transition into `running` is rejected with `attempt budget exhausted`; the agent must report the failure or escalate rather than silently looping forever.
+
+## Verification
+
+The script has a local Node test suite covering legal transitions, terminal immutability, attempt limits, evidence rules, malformed input, atomic persistence, and rejected-operation preservation:
+
+```bash
+node --test "$SKILL_DIR/scripts/checkpoint-loop.test.mjs"
+```
+
+The repository validator checks the frontmatter and directory/name contract:
+
+```bash
+node scripts/validate-skills.js
+```

--- a/plugins/all-skills/skills/checkpointed-agent-loop/scripts/checkpoint-loop.mjs
+++ b/plugins/all-skills/skills/checkpointed-agent-loop/scripts/checkpoint-loop.mjs
@@ -1,0 +1,279 @@
+#!/usr/bin/env node
+
+import { mkdir, readFile, rename, unlink, writeFile } from 'node:fs/promises'
+import { dirname, basename, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const STATES = new Set(['planned', 'running', 'verifying', 'succeeded', 'failed', 'blocked'])
+const TERMINAL_STATES = new Set(['succeeded', 'failed', 'blocked'])
+const TRANSITIONS = {
+  planned: new Set(['running']),
+  running: new Set(['verifying', 'failed', 'blocked']),
+  verifying: new Set(['succeeded', 'running', 'failed', 'blocked']),
+}
+
+function nonEmptyString(value, field) {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new Error(`${field} must be a non-empty string`)
+  }
+  return value.trim()
+}
+
+function isoTimestamp(value, field) {
+  const normalized = nonEmptyString(value, field)
+  if (Number.isNaN(Date.parse(normalized))) throw new Error(`${field} must be an ISO timestamp`)
+  return normalized
+}
+
+function positiveInteger(value, field) {
+  if (!Number.isInteger(value) || value < 1) throw new Error(`${field} must be a positive integer`)
+  return value
+}
+
+function validateHistory(history) {
+  if (!Array.isArray(history)) throw new Error('history must be an array')
+  return history.map((entry, index) => {
+    if (!entry || typeof entry !== 'object') throw new Error(`history[${index}] must be an object`)
+    if (!STATES.has(entry.from) || !STATES.has(entry.to)) {
+      throw new Error(`history[${index}] contains an invalid state`)
+    }
+    const result = {
+      from: entry.from,
+      to: entry.to,
+      at: isoTimestamp(entry.at, `history[${index}].at`),
+    }
+    if (entry.reason !== undefined) result.reason = nonEmptyString(entry.reason, `history[${index}].reason`)
+    return result
+  })
+}
+
+function validateEvidence(evidence) {
+  if (!Array.isArray(evidence)) throw new Error('evidence must be an array')
+  return evidence.map((entry, index) => {
+    if (!entry || typeof entry !== 'object') throw new Error(`evidence[${index}] must be an object`)
+    if (entry.outcome !== 'passed' && entry.outcome !== 'failed') {
+      throw new Error(`evidence[${index}].outcome must be passed or failed`)
+    }
+    const result = {
+      check: nonEmptyString(entry.check, `evidence[${index}].check`),
+      outcome: entry.outcome,
+      at: isoTimestamp(entry.at, `evidence[${index}].at`),
+    }
+    if (entry.artifact !== undefined) {
+      result.artifact = nonEmptyString(entry.artifact, `evidence[${index}].artifact`)
+    }
+    return result
+  })
+}
+
+export function parseCheckpoint(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('checkpoint must be an object')
+  }
+  if (value.schemaVersion !== 1) throw new Error('schemaVersion must be 1')
+
+  const taskId = nonEmptyString(value.taskId, 'taskId')
+  const objective = nonEmptyString(value.objective, 'objective')
+  if (!STATES.has(value.state)) throw new Error(`state is invalid: ${value.state}`)
+
+  const attempts = value.attempts
+  if (!Number.isInteger(attempts) || attempts < 0) throw new Error('attempts must be a non-negative integer')
+  const maxAttempts = positiveInteger(value.maxAttempts, 'maxAttempts')
+  if (attempts > maxAttempts) throw new Error('attempts cannot exceed maxAttempts')
+
+  const checkpoint = {
+    schemaVersion: 1,
+    taskId,
+    objective,
+    state: value.state,
+    attempts,
+    maxAttempts,
+    nextAction: nonEmptyString(value.nextAction, 'nextAction'),
+    createdAt: isoTimestamp(value.createdAt, 'createdAt'),
+    updatedAt: isoTimestamp(value.updatedAt, 'updatedAt'),
+    history: validateHistory(value.history),
+    evidence: validateEvidence(value.evidence),
+  }
+
+  if (value.terminalReason !== undefined) {
+    checkpoint.terminalReason = nonEmptyString(value.terminalReason, 'terminalReason')
+  }
+  if (TERMINAL_STATES.has(value.state) && value.state !== 'succeeded' && !checkpoint.terminalReason) {
+    throw new Error(`${value.state} checkpoints require terminalReason`)
+  }
+
+  return checkpoint
+}
+
+export function createCheckpoint({ taskId, objective, maxAttempts, nextAction, now = new Date().toISOString() }) {
+  return parseCheckpoint({
+    schemaVersion: 1,
+    taskId,
+    objective,
+    state: 'planned',
+    attempts: 0,
+    maxAttempts: positiveInteger(maxAttempts, 'maxAttempts'),
+    nextAction,
+    createdAt: now,
+    updatedAt: now,
+    history: [],
+    evidence: [],
+  })
+}
+
+export function transitionCheckpoint(checkpointValue, to, options = {}, now = new Date().toISOString()) {
+  const checkpoint = parseCheckpoint(checkpointValue)
+  if (TERMINAL_STATES.has(checkpoint.state)) {
+    throw new Error(`checkpoint is terminal: ${checkpoint.state}`)
+  }
+  if (!STATES.has(to) || !TRANSITIONS[checkpoint.state]?.has(to)) {
+    throw new Error(`invalid transition: ${checkpoint.state} -> ${to}`)
+  }
+  if (to === 'running' && checkpoint.attempts >= checkpoint.maxAttempts) {
+    throw new Error(`attempt budget exhausted: ${checkpoint.attempts}/${checkpoint.maxAttempts}`)
+  }
+  if ((to === 'failed' || to === 'blocked') && !options.reason) {
+    throw new Error(`${to} transitions require a reason`)
+  }
+  if (to === 'succeeded' && !checkpoint.evidence.some(({ outcome }) => outcome === 'passed')) {
+    throw new Error('succeeded requires at least one passing verification evidence record')
+  }
+
+  const next = {
+    ...checkpoint,
+    state: to,
+    attempts: checkpoint.attempts + (to === 'running' ? 1 : 0),
+    updatedAt: now,
+    history: [
+      ...checkpoint.history,
+      {
+        from: checkpoint.state,
+        to,
+        at: now,
+        ...(options.reason ? { reason: nonEmptyString(options.reason, 'reason') } : {}),
+      },
+    ],
+  }
+
+  if (options.nextAction !== undefined) next.nextAction = nonEmptyString(options.nextAction, 'nextAction')
+  if (to === 'failed' || to === 'blocked') next.terminalReason = nonEmptyString(options.reason, 'reason')
+
+  return parseCheckpoint(next)
+}
+
+export function appendEvidence(checkpointValue, evidence, now = new Date().toISOString()) {
+  const checkpoint = parseCheckpoint(checkpointValue)
+  if (checkpoint.state !== 'verifying') throw new Error('evidence can only be recorded while verifying')
+
+  return parseCheckpoint({
+    ...checkpoint,
+    updatedAt: now,
+    evidence: [
+      ...checkpoint.evidence,
+      {
+        check: evidence.check,
+        outcome: evidence.outcome,
+        at: now,
+        ...(evidence.artifact ? { artifact: evidence.artifact } : {}),
+      },
+    ],
+  })
+}
+
+export async function loadCheckpoint(file) {
+  const text = await readFile(file, 'utf8')
+  let value
+  try {
+    value = JSON.parse(text)
+  } catch (error) {
+    throw new Error(`checkpoint is not valid JSON: ${error.message}`)
+  }
+  return parseCheckpoint(value)
+}
+
+export async function saveCheckpoint(file, checkpointValue, { createParent = false } = {}) {
+  const checkpoint = parseCheckpoint(checkpointValue)
+  const parent = dirname(file)
+  if (createParent) await mkdir(parent, { recursive: true })
+  const temporary = join(parent, `.${basename(file)}.tmp-${process.pid}`)
+
+  try {
+    await writeFile(temporary, `${JSON.stringify(checkpoint, null, 2)}\n`, { mode: 0o600 })
+    await rename(temporary, file)
+  } catch (error) {
+    await unlink(temporary).catch(() => {})
+    throw error
+  }
+}
+
+function parseArguments(args) {
+  const command = args[0]
+  const options = {}
+  for (let index = 1; index < args.length; index += 2) {
+    const flag = args[index]
+    const value = args[index + 1]
+    if (!flag?.startsWith('--') || value === undefined) throw new Error(`invalid argument near ${flag || '<end>'}`)
+    options[flag.slice(2)] = value
+  }
+  return { command, options }
+}
+
+function requireOption(options, name) {
+  return nonEmptyString(options[name], `--${name}`)
+}
+
+async function runCli(args) {
+  const { command, options } = parseArguments(args)
+  const file = requireOption(options, 'file')
+
+  if (command === 'init') {
+    const checkpoint = createCheckpoint({
+      taskId: requireOption(options, 'task'),
+      objective: requireOption(options, 'objective'),
+      maxAttempts: Number(requireOption(options, 'max-attempts')),
+      nextAction: requireOption(options, 'next-action'),
+    })
+    await saveCheckpoint(file, checkpoint, { createParent: true })
+    return checkpoint
+  }
+
+  const checkpoint = await loadCheckpoint(file)
+  if (command === 'transition') {
+    const next = transitionCheckpoint(checkpoint, requireOption(options, 'to'), {
+      nextAction: options['next-action'],
+      reason: options.reason,
+    })
+    await saveCheckpoint(file, next)
+    return next
+  }
+  if (command === 'evidence') {
+    const next = appendEvidence(checkpoint, {
+      check: requireOption(options, 'check'),
+      outcome: requireOption(options, 'outcome'),
+      artifact: options.artifact,
+    })
+    await saveCheckpoint(file, next)
+    return next
+  }
+  if (command === 'status') {
+    if ((options.format || 'json') === 'summary') {
+      return `${checkpoint.taskId}: ${checkpoint.state}; attempts ${checkpoint.attempts}/${checkpoint.maxAttempts}; evidence ${checkpoint.evidence.length}; next: ${checkpoint.nextAction}`
+    }
+    if (options.format && options.format !== 'json') throw new Error('--format must be json or summary')
+    return checkpoint
+  }
+
+  throw new Error(`unknown command: ${command || '<missing>'}`)
+}
+
+const isMain = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]
+if (isMain) {
+  runCli(process.argv.slice(2))
+    .then((result) => {
+      process.stdout.write(typeof result === 'string' ? `${result}\n` : `${JSON.stringify(result, null, 2)}\n`)
+    })
+    .catch((error) => {
+      process.stderr.write(`checkpoint-loop: ${error.message}\n`)
+      process.exitCode = 1
+    })
+}

--- a/plugins/all-skills/skills/checkpointed-agent-loop/scripts/checkpoint-loop.test.mjs
+++ b/plugins/all-skills/skills/checkpointed-agent-loop/scripts/checkpoint-loop.test.mjs
@@ -1,0 +1,152 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  appendEvidence,
+  createCheckpoint,
+  loadCheckpoint,
+  saveCheckpoint,
+  transitionCheckpoint,
+} from './checkpoint-loop.mjs'
+
+const AT = '2026-08-19T00:00:00.000Z'
+
+function planned(overrides = {}) {
+  return createCheckpoint({
+    taskId: 'migrate-users',
+    objective: 'Migrate users without losing records',
+    maxAttempts: 2,
+    nextAction: 'Run the first migration batch',
+    now: AT,
+    ...overrides,
+  })
+}
+
+describe('checkpoint state machine', () => {
+  it('initializes a bounded planned checkpoint', () => {
+    assert.deepEqual(planned(), {
+      schemaVersion: 1,
+      taskId: 'migrate-users',
+      objective: 'Migrate users without losing records',
+      state: 'planned',
+      attempts: 0,
+      maxAttempts: 2,
+      nextAction: 'Run the first migration batch',
+      createdAt: AT,
+      updatedAt: AT,
+      history: [],
+      evidence: [],
+    })
+  })
+
+  it('completes only after entering verification and recording passing evidence', () => {
+    const running = transitionCheckpoint(planned(), 'running', {}, '2026-08-19T00:01:00.000Z')
+    const verifying = transitionCheckpoint(running, 'verifying', {}, '2026-08-19T00:02:00.000Z')
+    const evidenced = appendEvidence(verifying, {
+      check: 'npm test',
+      outcome: 'passed',
+      artifact: 'reports/test.txt',
+    }, '2026-08-19T00:03:00.000Z')
+    const succeeded = transitionCheckpoint(evidenced, 'succeeded', {}, '2026-08-19T00:04:00.000Z')
+
+    assert.equal(succeeded.state, 'succeeded')
+    assert.equal(succeeded.attempts, 1)
+    assert.deepEqual(succeeded.evidence[0], {
+      check: 'npm test',
+      outcome: 'passed',
+      artifact: 'reports/test.txt',
+      at: '2026-08-19T00:03:00.000Z',
+    })
+    assert.deepEqual(succeeded.history.map(({ from, to }) => ({ from, to })), [
+      { from: 'planned', to: 'running' },
+      { from: 'running', to: 'verifying' },
+      { from: 'verifying', to: 'succeeded' },
+    ])
+  })
+
+  it('counts each transition into running and rejects an exhausted retry', () => {
+    const firstRun = transitionCheckpoint(planned(), 'running', {}, AT)
+    const firstVerify = transitionCheckpoint(firstRun, 'verifying', {}, AT)
+    const secondRun = transitionCheckpoint(firstVerify, 'running', {
+      nextAction: 'Retry only failed records',
+      reason: 'The first verification found mismatched counts',
+    }, AT)
+    const secondVerify = transitionCheckpoint(secondRun, 'verifying', {}, AT)
+
+    assert.equal(secondRun.attempts, 2)
+    assert.equal(secondRun.nextAction, 'Retry only failed records')
+    assert.throws(
+      () => transitionCheckpoint(secondVerify, 'running', {}, AT),
+      /attempt budget exhausted/i,
+    )
+  })
+
+  it('rejects illegal transitions, terminal mutation, and success without passing evidence', () => {
+    assert.throws(() => transitionCheckpoint(planned(), 'succeeded', {}, AT), /invalid transition/i)
+
+    const verifying = transitionCheckpoint(
+      transitionCheckpoint(planned(), 'running', {}, AT),
+      'verifying',
+      {},
+      AT,
+    )
+    assert.throws(
+      () => transitionCheckpoint(verifying, 'succeeded', {}, AT),
+      /passing verification evidence/i,
+    )
+
+    const failed = transitionCheckpoint(
+      transitionCheckpoint(planned(), 'running', {}, AT),
+      'failed',
+      { reason: 'Migration command returned a permanent schema error' },
+      AT,
+    )
+    assert.equal(failed.terminalReason, 'Migration command returned a permanent schema error')
+    assert.throws(() => transitionCheckpoint(failed, 'running', {}, AT), /terminal/i)
+  })
+
+  it('records evidence only while verifying', () => {
+    assert.throws(
+      () => appendEvidence(planned(), { check: 'npm test', outcome: 'passed' }, AT),
+      /only be recorded while verifying/i,
+    )
+  })
+
+  it('validates positive attempt budgets and non-empty fields', () => {
+    assert.throws(() => planned({ maxAttempts: 0 }), /positive integer/i)
+    assert.throws(() => planned({ objective: ' ' }), /objective/i)
+  })
+})
+
+describe('checkpoint persistence', () => {
+  it('round-trips a valid checkpoint through an atomic save', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'checkpoint-loop-'))
+    const file = join(directory, 'nested', 'checkpoint.json')
+
+    await saveCheckpoint(file, planned(), { createParent: true })
+
+    assert.deepEqual(await loadCheckpoint(file), planned())
+  })
+
+  it('rejects malformed checkpoints with a useful field error', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'checkpoint-loop-'))
+    const file = join(directory, 'checkpoint.json')
+    await writeFile(file, '{"schemaVersion":1,"state":"mystery"}\n')
+
+    await assert.rejects(() => loadCheckpoint(file), /taskId/i)
+  })
+
+  it('does not rewrite the checkpoint when a transition is rejected', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'checkpoint-loop-'))
+    const file = join(directory, 'checkpoint.json')
+    await saveCheckpoint(file, planned(), { createParent: true })
+    const before = await readFile(file, 'utf8')
+
+    const checkpoint = await loadCheckpoint(file)
+    assert.throws(() => transitionCheckpoint(checkpoint, 'succeeded', {}, AT), /invalid transition/i)
+
+    assert.equal(await readFile(file, 'utf8'), before)
+  })
+})


### PR DESCRIPTION
## Summary

Adds `checkpointed-agent-loop`, a self-contained skill for long-running or failure-prone Claude Code tasks.

The contribution includes a standard-library Node.js utility that persists a schema-versioned checkpoint, enforces a bounded state machine, records verification evidence, supports resume, and saves updates atomically. The helper stores state only; it never executes commands, calls models, accesses secrets, spawns agents, or uses the network.

## Component Details

- **Name**: checkpointed-agent-loop
- **Type**: Skill
- **Category**: ai-agents

## Testing

- [x] Ran the focused harness tests (9 tests passed)
- [x] Ran a CLI smoke lifecycle from `planned` to `succeeded`
- [x] Ran skill validation (`node scripts/validate-skills.js`): 151 skills, no errors
- [x] Ran repository validation (`npm test`)
- [x] Verified checkpoint files are written with mode `600`
- [x] Audited the script for command execution, network calls, and secret access
- [x] No overlap with existing open issues or pull requests

## Examples

1. Resume an interrupted migration from the persisted `nextAction` instead of reconstructing progress from chat history.
2. Record a real focused test result during `verifying` before allowing `succeeded`.
3. Stop at an external dependency with `blocked`, or fail closed when the finite attempt budget is exhausted.

## Security Boundary

The helper accepts an explicit checkpoint path and performs only JSON parsing plus local file reads/writes. It does not run the check named by an evidence record. Mutations are validated before an atomic same-directory rename, rejected operations leave the original file untouched, and terminal states cannot be changed.

## Risk

This is a local checkpoint protocol, not a general workflow engine or cross-machine store. Users must choose a safe project-local path and keep secrets out of objective, reason, evidence, and artifact metadata.
