### PR TITLE
Add chamnan to the marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2030,6 +2030,35 @@
       ],
       "category": "productivity",
       "source": "./plugins/travel-agent-skill"
+    },
+    {
+      "name": "chamnan",
+      "description": "Makes a repository know itself and preserve the engineering context built while you work with it, so an agent stops rediscovering both. An architecture index and an impact map instead of scanning files; work state, session records and the decisions behind them instead of losing context between sessions; the procedures, tools and workflows you keep re-deriving. Everything is repository-local markdown, committed beside the code. For long-lived repos you revisit, not one-off scripts.",
+      "version": "1.3.1",
+      "author": {
+        "name": "ArcticFox2029",
+        "url": "https://github.com/ArcticFox2029"
+      },
+      "repository": "https://github.com/ArcticFox2029/chamnan",
+      "license": "MIT",
+      "keywords": [
+        "context",
+        "architecture",
+        "codebase-map",
+        "long-lived-projects",
+        "state",
+        "skills",
+        "continuity",
+        "repository-knowledge",
+        "memory",
+        "impact-map",
+        "developer-workflow"
+      ],
+      "category": "development",
+      "source": {
+        "source": "github",
+        "repo": "ArcticFox2029/chamnan"
+      }
     }
   ]
 }


### PR DESCRIPTION
One entry appended to `.claude-plugin/marketplace.json`, using the external-source form the nine entries like `archcore` and `backlogd` already use — `{"source": "github", "repo": "ArcticFox2029/chamnan"}` — so nothing is vendored here and the listing cannot go stale against the plugin it points at.

Every field was read out of chamnan's own `.claude-plugin/plugin.json` rather than retyped, for the same reason.

**[chamnan](https://github.com/ArcticFox2029/chamnan)** — an agent starts every session not knowing the repository, so the first turns go on rediscovering the architecture, the reasons behind past decisions, and the traps already hit. chamnan scans the repo once into an architecture index and injects a few thousand tokens of it at session start, keeps the work state and decisions that would otherwise be lost between sessions, and accumulates the procedures you keep re-deriving.

Eight skills, four hooks, two subagents. Version 1.3.1, MIT.

### The numbers, and how to check them

On a 529-file polyglot corpus: 1,373,242 tokens of source become a 53,646-token index, of which about 3,000 reach each session. The impact map stays out of the injection entirely and is grepped when needed.

The corpus is published rather than described — [chamnan-corpus](https://github.com/ArcticFox2029/chamnan-corpus), 800 files across 72 file types with comments in eight writing systems. Clone it and the figures reproduce, including the one that matters more than the ratio: none of its 28 planted credentials appear in the generated index.

### Fit

- Passes `claude plugin validate --strict`
- 378 checks pass — `python3 tests/run_tests.py`, no pytest
- Python 3.8+, standard library only. No packages, no network, no account, no telemetry; nothing leaves the machine, and the README commits to it staying that way
- Category `development`, which is where the architecture and context plugins already sit

Happy to move it to a different category, split the description, or switch to a vendored copy under `plugins/` if you would rather every entry live in-tree.
