### PR TITLE
Add usage-limits plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2081,6 +2081,33 @@
       ],
       "category": "mcp-servers",
       "source": "./plugins/cohesivity"
+    },
+    {
+      "name": "usage-limits",
+      "description": "Reads how much of your 5-hour and weekly Claude Code limit is left, converts it into turns of headroom rather than a percentage, and plans the work to fit inside it. Detects plan tier, splits spend by model and project, and adds a status line.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Ridelink",
+        "url": "https://github.com/ridelink0"
+      },
+      "homepage": "https://github.com/ridelink0/claude-code-usage-limits",
+      "repository": "https://github.com/ridelink0/claude-code-usage-limits",
+      "license": "MIT",
+      "keywords": [
+        "usage",
+        "limits",
+        "budget",
+        "cost",
+        "tokens",
+        "planning",
+        "claude-code"
+      ],
+      "category": "productivity",
+      "source": {
+        "source": "github",
+        "repo": "ridelink0/claude-code-usage-limits"
+      },
+      "strict": false
     }
   ]
 }


### PR DESCRIPTION
Adds `usage-limits` to the marketplace manifest as a `github` source entry, so nothing is vendored into this repo.

It reads the 5-hour and weekly usage percentages Claude Code already caches locally, cross-references the session transcripts to work out what one percentage point of the limit costs on that account, and reports the remaining headroom as turns of work rather than a bare percentage. It then names which window binds first and whether that window resets before the budget runs out.

Beyond the report it detects plan tier (Pro, Max 5x, Max 20x, Team, Enterprise), splits the window by model and by project, ships a `/usage-limits:check` command and a `--status` mode for the status line, and includes a low power switch that lowers effortLevel and restores exactly what it replaced.

Everything is read from local files. No network calls, no credentials read, no dependencies. MIT licensed, 66 tests, and it passes `claude plugin validate --strict` on both the plugin and marketplace manifests.

Filed under `productivity`, matching the category in its own plugin.json.

https://github.com/ridelink0/claude-code-usage-limits