### PR TITLE
Add project-milestone-tracker: self-contained project planning & tracking skill

### DIFF
--- a/plugins/all-skills/skills/project-milestone-tracker/SKILL.md
+++ b/plugins/all-skills/skills/project-milestone-tracker/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: project-milestone-tracker
+description: "项目管理里程碑跟踪器（Project Milestone Tracker）——当用户要求代理在代码库/项目会话中规划、跟踪里程碑、记录承诺或事件、生成进度报告时使用。核心：三层里程碑规则（文件依据/客户提供/待确认）+ 原话+时间戳事件记录。Project milestone tracker: plan and track project milestones, record events with original text + timestamp, generate status reports, using a three-tier milestone rule (contract-sourced / stakeholder-stated / pending-confirmation)."
+category: project-management
+license: MIT
+---
+
+# Project Milestone Tracker 项目管理里程碑跟踪器
+
+A self-contained local tracker for planning and tracking project work in a repo session — no external service, no cloud, pure local files (Python stdlib only).
+
+## When to Use
+
+Use this skill when the user asks the agent to:
+- Plan milestones for a project / break work into tracked milestones
+- Track milestone progress and mark items done
+- Record a promise, decision, or event with **original text + timestamp** (traceable claims)
+- Generate a project status report (markdown)
+
+It is designed for **repo-session work**: the agent runs local commands and keeps state in a local JSON file.
+
+## Three-Tier Milestone Rule (三层里程碑规则)
+
+Never invent milestone dates. Every milestone must carry a source tier:
+
+| Tier | source | Meaning | Behavior |
+|------|--------|---------|----------|
+| 1 | `file` | Extracted from a contract/document | Authoritative; note the source document |
+| 2 | `client` | Stated verbally by stakeholder | Recorded as stated; suggest written confirmation |
+| 3 | `pending` | No milestone info yet | Flag "ask the client" — never self-plan |
+
+## How to Use
+
+All commands run via the bundled script (stdlib only, no install):
+
+```bash
+python3 scripts/pm_track.py --file .pm.json init "东区改造项目"
+python3 scripts/pm_track.py --file .pm.json add-milestone "3月15日竣工验收" --source file --due 2026-03-15 --note "依据合同第四章"
+python3 scripts/pm_track.py --file .pm.json add-milestone "甲方口头承诺月底回款" --source client --due 2026-03-31
+python3 scripts/pm_track.py --file .pm.json add-milestone "材料进场节点待确认" --source pending
+python3 scripts/pm_track.py --file .pm.json add-event "甲方说马上回款" --who 王总 --when "2026-03-10 14:30"
+python3 scripts/pm_track.py --file .pm.json status
+python3 scripts/pm_track.py --file .pm.json report   # markdown report
+python3 scripts/pm_track.py --file .pm.json done 1
+```
+
+## Commands
+
+| Command | What it does |
+|---------|--------------|
+| `init <name>` | Initialize a project tracker file |
+| `add-milestone <title> --source file\|client\|pending [--due] [--note]` | Add a milestone with a source tier |
+| `add-event <text> [--who] [--when]` | Record an event with original text + timestamp |
+| `done <id>` | Mark a milestone done |
+| `status` | Show all milestones + events + pending warnings |
+| `report` | Print a markdown progress report |
+
+## Example
+
+```bash
+$ python3 scripts/pm_track.py --file .pm.json init "门店装修"
+$ python3 scripts/pm_track.py --file .pm.json add-milestone "6月10日完工验收" --source file --due 2026-06-10
+$ python3 scripts/pm_track.py --file .pm.json add-milestone "水电改造完成" --source client
+$ python3 scripts/pm_track.py --file .pm.json add-event "甲方电话说马上回款" --who 李总
+$ python3 scripts/pm_track.py --file .pm.json status
+📋 Project: 门店装修
+=== 里程碑 (2 open) ===
+  ⬜ #1 [file  ] 6月10日完工验收  (due 2026-06-10)
+  ⬜ #2 [client] 水电改造完成
+=== 事件记录 (1) ===
+  • [2026-08-25 15:20] (李总) 甲方电话说马上回款
+```
+
+## Data & Portability
+
+- State is stored in a local JSON file (default `.project-tracker.json`, or pass `--file`).
+- Pure Python 3.8+ stdlib (`argparse`, `json`, `datetime`) — no pip installs, no network.
+- Works anywhere the agent has a shell. The JSON file can be committed to the repo or git-ignored.
+
+## Templates
+
+A milestone planning checklist and a status report template live in `templates/` — copy and adapt.
+
+## Pitfalls
+
+- **Never invent due dates for `pending` milestones** — the whole point of the three-tier rule is that the agent asks the client instead of guessing.
+- **Store original text, not paraphrases** — events keep `text` verbatim plus `when`/`who` so claims are traceable.
+- `report` prints markdown to stdout; pipe to a file (`> report.md`) to save.

--- a/plugins/all-skills/skills/project-milestone-tracker/scripts/pm_track.py
+++ b/plugins/all-skills/skills/project-milestone-tracker/scripts/pm_track.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Project Milestone Tracker — a self-contained local tracker for planning and tracking project work.
+
+Three-tier milestone rule (from the original product design, kept as requested):
+  1. source=file    — milestone extracted from a contract/document (authoritative, note the document)
+  2. source=client  — milestone provided verbally by the client/stakeholder (recorded as stated)
+  3. source=pending — no milestone info yet; the tracker flags it as "ask the client", never self-invented
+
+Events are stored with original text + timestamp (who/what/when) so claims can be traced.
+
+Pure Python stdlib. Data lives in a local JSON file (default .project-tracker.json in CWD).
+"""
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime
+
+DEFAULT_FILE = ".project-tracker.json"
+
+
+def now() -> str:
+    return datetime.now().strftime("%Y-%m-%d %H:%M")
+
+
+def load(path):
+    if os.path.exists(path):
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    return {"project": None, "milestones": [], "events": [], "created_at": now()}
+
+
+def save(path, data):
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+
+
+def cmd_init(args, data):
+    data["project"] = args.name
+    data["created_at"] = now()
+    save(args.file, data)
+    print(f"✅ Project initialized: {args.name} (tracker: {args.file})")
+
+
+def cmd_add_milestone(args, data):
+    mid = len(data["milestones"]) + 1
+    item = {
+        "id": mid,
+        "title": args.title,
+        "source": args.source,          # file | client | pending
+        "due": args.due or "",
+        "status": "open",
+        "note": args.note or "",
+        "added_at": now(),
+    }
+    if args.source == "pending":
+        item["note"] = (args.note + " | ") if args.note else ""
+        item["note"] += "⚠️ 无节点信息——需向客户/文件确认，勿自行推算"
+    data["milestones"].append(item)
+    save(args.file, data)
+    print(f"✅ Milestone #{mid} added [{args.source}]: {args.title}")
+    if args.source == "file":
+        print(f"   依据文件标注，来源权威（合同/文档）")
+    elif args.source == "client":
+        print(f"   客户口头提供，按原话记录（建议补书面确认）")
+    else:
+        print(f"   ⚠️ PENDING：需要向客户索取节点信息，不要自行规划")
+
+
+def cmd_add_event(args, data):
+    eid = len(data["events"]) + 1
+    data["events"].append({
+        "id": eid,
+        "text": args.text,
+        "who": args.who or "",
+        "when": args.when or now(),
+        "recorded_at": now(),
+    })
+    save(args.file, data)
+    print(f"✅ Event #{eid} recorded: 「{args.text}」 @ {data['events'][-1]['when']}")
+
+
+def cmd_done(args, data):
+    for m in data["milestones"]:
+        if str(m["id"]) == str(args.id):
+            m["status"] = "done"
+            m["done_at"] = now()
+            save(args.file, data)
+            print(f"✅ Milestone #{args.id} marked done: {m['title']}")
+            return
+    print(f"❌ Milestone #{args.id} not found")
+
+
+def cmd_status(args, data):
+    print(f"📋 Project: {data['project'] or '(not set)'}  (created {data.get('created_at','')})")
+    print()
+    open_m = [m for m in data["milestones"] if m["status"] != "done"]
+    done_m = [m for m in data["milestones"] if m["status"] == "done"]
+    print(f"=== 里程碑 Milestones ({len(open_m)} open / {len(done_m)} done) ===")
+    for m in data["milestones"]:
+        mark = "✅" if m["status"] == "done" else "⬜"
+        print(f"  {mark} #{m['id']} [{m['source']:7s}] {m['title']}" + (f"  (due {m['due']})" if m.get("due") else ""))
+    print()
+    print(f"=== 事件记录 Events ({len(data['events'])}) — 原话+时间戳 ===")
+    for e in data["events"]:
+        who = f" ({e['who']})" if e.get("who") else ""
+        print(f"  • [{e['when']}]{who} {e['text']}")
+    print()
+    if open_m and any(m["source"] == "pending" for m in open_m):
+        print("⚠️ 有 PENDING 里程碑——记得向客户索取节点信息")
+
+
+def cmd_report(args, data):
+    print(f"# 项目进度报告 — {data['project'] or '(未命名)'}\n")
+    print(f"_生成时间：{now()}_\n")
+    print("## 里程碑")
+    for m in data["milestones"]:
+        mark = "✅" if m["status"] == "done" else "⬜"
+        print(f"- {mark} **#{m['id']}** [{m['source']}] {m['title']}" + (f"（due {m['due']}）" if m.get("due") else ""))
+        if m.get("note"):
+            print(f"  - {m['note']}")
+    print("\n## 事件记录")
+    for e in data["events"]:
+        who = f" ({e['who']})" if e.get("who") else ""
+        print(f"- [{e['when']}]{who} {e['text']}")
+    print("\n## 风险提示")
+    pending = [m for m in data["milestones"] if m["source"] == "pending" and m["status"] != "done"]
+    if pending:
+        print("- ⚠️ 以下里程碑无节点信息，需向客户确认（不要自行推算）：")
+        for m in pending:
+            print(f"  - #{m['id']} {m['title']}")
+    else:
+        print("- ✅ 无待确认节点")
+
+
+def main():
+    p = argparse.ArgumentParser(prog="pm_track", description="Project Milestone Tracker (three-tier rule)")
+    p.add_argument("--file", default=DEFAULT_FILE, help=f"data file (default {DEFAULT_FILE})")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    sp = sub.add_parser("init", help="initialize a project")
+    sp.add_argument("name")
+    sp.set_defaults(fn=cmd_init)
+
+    sp = sub.add_parser("add-milestone", help="add a milestone with a source tier")
+    sp.add_argument("title")
+    sp.add_argument("--source", choices=["file", "client", "pending"], default="file")
+    sp.add_argument("--due", default="")
+    sp.add_argument("--note", default="")
+    sp.set_defaults(fn=cmd_add_milestone)
+
+    sp = sub.add_parser("add-event", help="record an event (original text + timestamp)")
+    sp.add_argument("text")
+    sp.add_argument("--who", default="")
+    sp.add_argument("--when", default="")
+    sp.set_defaults(fn=cmd_add_event)
+
+    sp = sub.add_parser("done", help="mark a milestone done")
+    sp.add_argument("id")
+    sp.set_defaults(fn=cmd_done)
+
+    sp = sub.add_parser("status", help="show current status")
+    sp.set_defaults(fn=cmd_status)
+
+    sp = sub.add_parser("report", help="print a markdown report")
+    sp.set_defaults(fn=cmd_report)
+
+    args = p.parse_args()
+    data = load(args.file)
+    args.fn(args, data)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/all-skills/skills/project-milestone-tracker/templates/milestone-checklist.md
+++ b/plugins/all-skills/skills/project-milestone-tracker/templates/milestone-checklist.md
@@ -1,0 +1,14 @@
+# 里程碑规划清单 / Milestone Planning Checklist
+
+Use this checklist when the agent is asked to plan project milestones. Fill each row; never leave a milestone without a source tier.
+
+| # | Milestone / 节点 | Source tier | Due date | Evidence / 依据 | Status |
+|---|------------------|-------------|----------|-----------------|--------|
+| 1 | | file / client / pending | | contract / stated / to-ask | open |
+| 2 | | file / client / pending | | | open |
+| 3 | | file / client / pending | | | open |
+
+## Rules
+- `file` — cite the document (chapter/section) as evidence.
+- `client` — record verbatim what the stakeholder said; suggest written confirmation.
+- `pending` — do NOT invent a date; list it under "ask the client" in the report.

--- a/plugins/all-skills/skills/project-milestone-tracker/templates/status-report.md
+++ b/plugins/all-skills/skills/project-milestone-tracker/templates/status-report.md
@@ -1,0 +1,18 @@
+# 项目状态报告模板 / Project Status Report Template
+
+## 项目 / Project
+- Name:
+- Owner:
+- As of:
+
+## 里程碑 / Milestones
+- ✅ done:
+- ⬜ open (file):
+- ⬜ open (client):
+- ⬜ open (pending — need to ask client):
+
+## 事件记录 / Events (original text + timestamp)
+- [date] (who) verbatim text
+
+## 风险提示 / Risks
+- Pending milestones that must be confirmed with the client (never self-invented):


### PR DESCRIPTION
Fresh PR addressing the feedback on #294 (thanks @davepoon for the clear bar).

**project-milestone-tracker** — a self-contained, runnable Claude Code skill for planning and tracking project work in a repo session.

## What changed vs #294
- ❌ Dropped: WeChat Work / cloud-host / "already implemented" product-spec claims
- ✅ Kept: the **three-tier milestone rule** (file / client / pending — never self-invent dates) and **"record original text + timestamp"** event logging
- ✅ Usable in Claude Code as written: bundled `scripts/pm_track.py` (pure Python stdlib, no install), runnable local commands, plus checklist + status-report templates in `templates/`

## How it works
```bash
python3 scripts/pm_track.py --file .pm.json init "东区改造项目"
python3 scripts/pm_track.py --file .pm.json add-milestone "3月15日竣工验收" --source file --due 2026-03-15 --note "依据合同第四章"
python3 scripts/pm_track.py --file .pm.json add-milestone "甲方口头承诺月底回款" --source client --due 2026-03-31
python3 scripts/pm_track.py --file .pm.json add-milestone "材料进场节点待确认" --source pending
python3 scripts/pm_track.py --file .pm.json add-event "甲方电话说马上回款" --who 王总
python3 scripts/pm_track.py --file .pm.json status
python3 scripts/pm_track.py --file .pm.json report
```

- Local JSON state, no network, works in any repo session
- Fully tested locally (init → milestones → events → status → done → report)
- `category: project-management` — validated against the collection schema

Happy to adjust anything else to fit the collection.
