### PR TITLE
Add FunASR MCP plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "scripts": {
     "test": "npm run validate && npm run test:unit",
-    "test:unit": "node --test scripts/github-search-pagination.test.js && node --experimental-strip-types --test web-ui/lib/indexer/search-pagination.test.ts web-ui/lib/search/search-types.test.ts web-ui/lib/search/search-hydration.test.ts web-ui/lib/stories-server.test.ts",
+    "test:unit": "node --test scripts/github-search-pagination.test.js plugins/funasr-mcp/mcp/launch.test.mjs && node --experimental-strip-types --test web-ui/lib/indexer/search-pagination.test.ts web-ui/lib/search/search-types.test.ts web-ui/lib/search/search-hydration.test.ts web-ui/lib/stories-server.test.ts",
     "test:integration": "./tests/plugin-test-harness.sh",
     "validate": "node scripts/validate-all.js",
     "validate:subagents": "node scripts/validate-subagents.js",

--- a/plugins/funasr-mcp/.claude-plugin/plugin.json
+++ b/plugins/funasr-mcp/.claude-plugin/plugin.json
@@ -1,0 +1,23 @@
+{
+  "name": "funasr-mcp",
+  "displayName": "FunASR MCP",
+  "version": "0.1.2",
+  "description": "Transcribe local audio through the official FunASR MCP server with private, on-device SenseVoice inference.",
+  "author": {
+    "name": "ModelScope",
+    "url": "https://github.com/modelscope"
+  },
+  "homepage": "https://github.com/modelscope/FunASR/tree/main/examples/mcp_server",
+  "repository": "https://github.com/modelscope/FunASR",
+  "license": "MIT",
+  "keywords": [
+    "audio",
+    "asr",
+    "funasr",
+    "mcp",
+    "sensevoice",
+    "speech-to-text",
+    "transcription"
+  ],
+  "mcpServers": "./.mcp.json"
+}

--- a/plugins/funasr-mcp/.mcp.json
+++ b/plugins/funasr-mcp/.mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "funasr": {
+      "command": "node",
+      "args": [
+        "${CLAUDE_PLUGIN_ROOT}/mcp/launch.mjs"
+      ]
+    }
+  }
+}

--- a/plugins/funasr-mcp/README.md
+++ b/plugins/funasr-mcp/README.md
@@ -1,0 +1,58 @@
+# FunASR MCP
+
+Transcribe audio from Claude Code with the official FunASR MCP server. The
+plugin runs the published `ghcr.io/modelscope/funasr-mcp:0.1.2` image over
+stdio, pinned to its OCI digest, and keeps model inference on your machine.
+
+## Requirements
+
+- Docker
+- Node.js 18 or newer
+
+The published container currently targets `linux/amd64`. Docker Desktop can
+use x86 emulation on Apple Silicon, with a performance cost. For native ARM or
+non-Docker use, follow the upstream Python setup instead.
+
+## Install
+
+```text
+/plugin marketplace add davepoon/buildwithclaude
+/plugin install funasr-mcp@buildwithclaude
+```
+
+By default, the plugin mounts Claude Code's current project directory at
+`/audio` inside the container, read-only. To expose a different directory,
+set `FUNASR_AUDIO_DIR` before starting Claude Code:
+
+```bash
+export FUNASR_AUDIO_DIR="$HOME/recordings"
+claude
+```
+
+The first container run downloads the image and SenseVoiceSmall model. Model
+files persist in the `funasr-mcp-cache` Docker volume.
+
+## Use
+
+Pass paths as the container sees them. For example, if
+`$FUNASR_AUDIO_DIR/meeting.wav` exists, ask Claude:
+
+```text
+Transcribe /audio/meeting.wav with FunASR.
+```
+
+The server exposes one MCP tool, `transcribe_audio`, with optional language
+hints for Mandarin, Cantonese, English, Japanese, and Korean. The default
+SenseVoiceSmall setup performs local inference on CPU. See the
+[upstream server guide](https://github.com/modelscope/FunASR/tree/main/examples/mcp_server)
+for direct Python, CUDA, and custom-model configurations.
+
+## Privacy And Licenses
+
+The selected host directory is mounted read-only, and audio is processed by
+the local container. The plugin does not upload audio or require an API key.
+
+FunASR source code is MIT licensed. Model weights retain the license stated on
+their model card; the default
+[SenseVoiceSmall](https://huggingface.co/FunAudioLLM/SenseVoiceSmall) weights
+use the linked FunASR model license.

--- a/plugins/funasr-mcp/mcp/launch.mjs
+++ b/plugins/funasr-mcp/mcp/launch.mjs
@@ -1,0 +1,49 @@
+import { spawn } from 'node:child_process'
+import { statSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const IMAGE =
+	'ghcr.io/modelscope/funasr-mcp:0.1.2@sha256:ef616a3767df44d31cb257fd0b195e690f5b556b72d0f916f601b24143c912d6'
+
+export function resolveAudioDir(env = process.env, cwd = process.cwd()) {
+	return path.resolve(env.FUNASR_AUDIO_DIR?.trim() || env.CLAUDE_PROJECT_DIR?.trim() || cwd)
+}
+
+export function buildDockerArgs(audioDir) {
+	return [
+		'run',
+		'--rm',
+		'-i',
+		'--platform',
+		'linux/amd64',
+		'--mount',
+		`type=bind,src=${audioDir},dst=/audio,readonly`,
+		'--mount',
+		'type=volume,src=funasr-mcp-cache,dst=/root/.cache/modelscope',
+		IMAGE,
+	]
+}
+
+export function main() {
+	const audioDir = resolveAudioDir()
+	if (!statSync(audioDir).isDirectory()) {
+		throw new Error(`FUNASR_AUDIO_DIR is not a directory: ${audioDir}`)
+	}
+
+	const child = spawn('docker', buildDockerArgs(audioDir), { stdio: 'inherit' })
+	for (const signal of ['SIGINT', 'SIGTERM']) {
+		process.once(signal, () => child.kill(signal))
+	}
+	child.once('error', (error) => {
+		console.error(`Failed to start the FunASR MCP container: ${error.message}`)
+		process.exitCode = 1
+	})
+	child.once('exit', (code) => {
+		process.exitCode = code ?? 1
+	})
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+	main()
+}

--- a/plugins/funasr-mcp/mcp/launch.test.mjs
+++ b/plugins/funasr-mcp/mcp/launch.test.mjs
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { buildDockerArgs, resolveAudioDir } from './launch.mjs'
+
+test('buildDockerArgs pins the official image and mounts only the audio directory read-only', () => {
+	assert.deepEqual(buildDockerArgs('/workspace/audio'), [
+		'run',
+		'--rm',
+		'-i',
+		'--platform',
+		'linux/amd64',
+		'--mount',
+		'type=bind,src=/workspace/audio,dst=/audio,readonly',
+		'--mount',
+		'type=volume,src=funasr-mcp-cache,dst=/root/.cache/modelscope',
+		'ghcr.io/modelscope/funasr-mcp:0.1.2@sha256:ef616a3767df44d31cb257fd0b195e690f5b556b72d0f916f601b24143c912d6',
+	])
+})
+
+test('resolveAudioDir prefers an explicit audio directory, then the Claude project, then cwd', () => {
+	assert.equal(
+		resolveAudioDir({ FUNASR_AUDIO_DIR: ' /media/recordings ', CLAUDE_PROJECT_DIR: '/workspace/project' }, '/plugin/root'),
+		'/media/recordings',
+	)
+	assert.equal(resolveAudioDir({ CLAUDE_PROJECT_DIR: '/workspace/project' }, '/plugin/root'), '/workspace/project')
+	assert.equal(resolveAudioDir({}, '/workspace/project'), '/workspace/project')
+})


### PR DESCRIPTION
## Summary

- add an installable `funasr-mcp` Claude Code plugin backed by the official FunASR MCP release
- pin the GHCR image tag to its immutable digest
- mount the project directory read-only by default, with `FUNASR_AUDIO_DIR` as an explicit override
- persist the model cache in a Docker volume and document the current `linux/amd64` boundary
- distinguish the MIT-licensed FunASR source from model-specific weight licenses

## Component Details

- Name: `funasr-mcp`
- Type: MCP plugin
- Upstream: `modelscope/FunASR/examples/mcp_server`
- Tool: `transcribe_audio`

## Testing

- `npm test`: repository validations passed; Node suites passed 5/5 and 14/14
- focused launcher tests passed 2/2
- `git diff --check` passed
- anonymous GHCR manifest request returned HTTP 200
- image index digest verified as `sha256:ef616a3767df44d31cb257fd0b195e690f5b556b72d0f916f601b24143c912d6`
- commit is SSH-signed and includes DCO sign-off

Related to #160.
