### PR TITLE
Add suede-skills plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2137,6 +2137,39 @@
         "repo": "ridelink0/claude-computer-use"
       },
       "strict": false
+    },
+    {
+      "name": "suede-skills",
+      "description": "74 skills for Claude Code and Codex. A build DAG researches your repo, fans out disjoint lanes, and refutes its own review before anything lands. A blunt A-F ship grade blocks the bad merge instead of complimenting it. The same folder designs the page, writes the copy, and ships native iOS and Android builds. One skill argued Amazon out of $448.31.",
+      "version": "0.16.0",
+      "author": {
+        "name": "Jason Colapietro",
+        "url": "https://github.com/JasonColapietro"
+      },
+      "homepage": "https://skills.suedeai.ai/",
+      "repository": "https://github.com/JasonColapietro/suede-creator-skills",
+      "license": "MIT AND BSD-3-Clause",
+      "keywords": [
+        "agent-skills",
+        "multi-agent",
+        "agent-orchestration",
+        "code-review",
+        "ship-gate",
+        "ci",
+        "ai-eval",
+        "design",
+        "seo",
+        "ios",
+        "android",
+        "claude-code",
+        "codex"
+      ],
+      "category": "orchestration",
+      "source": {
+        "source": "github",
+        "repo": "JasonColapietro/suede-creator-skills"
+      },
+      "strict": false
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2140,7 +2140,7 @@
     },
     {
       "name": "suede-skills",
-      "description": "74 skills for Claude Code and Codex. A build DAG researches your repo, fans out disjoint lanes, and refutes its own review before anything lands. A blunt A-F ship grade blocks the bad merge instead of complimenting it. The same folder designs the page, writes the copy, and ships native iOS and Android builds. One skill argued Amazon out of $448.31.",
+      "description": "74 skills for Claude Code and Codex. A build DAG researches your repo, fans out disjoint lanes, and refutes its own review before anything lands. A blunt A-F ship grade blocks the bad merge instead of complimenting it. The same folder designs the page, writes the copy, and ships native iOS and Android builds.",
       "version": "0.16.0",
       "author": {
         "name": "Jason Colapietro",


### PR DESCRIPTION
## Summary

Adds `suede-skills` to the marketplace catalog: 74 open-source Agent Skills for Claude Code and Codex.

This uses the existing external-source pattern (`"source": {"source": "github", "repo": "..."}` with `"strict": false`), the same route as `computer-use`, `usage-limits`, `chamnan`, and `codex-orchestrator`. The diff is one catalog entry, 33 added lines, nothing copied into `plugins/`. Vendoring 74 skill directories would not have been a reviewable PR.

## Component Details

- **Name**: suede-skills
- **Type**: Plugin
- **Category**: orchestration
- **Repository**: https://github.com/JasonColapietro/suede-creator-skills
- **Homepage**: https://skills.suedeai.ai/
- **Version**: 0.16.0
- **License**: `MIT AND BSD-3-Clause`. The pack is MIT; `skills/suede-graph-flo-xr` is adapted from ETH Zurich's graph-of-thoughts and retains its BSD-3-Clause notice, with upstream text under `licenses/`.

The source repo publishes its own marketplace (`name: "suede"`, 4 plugins). This entry points at `suede-skills`, the full pack; users who want a subset can add the upstream marketplace directly.

## Testing

- [x] Ran validation (`npm test`) - exit 0. Subagents & Commands, Hooks, and Skills all passed; 14/14 unit tests pass.
- [x] `claude plugin validate` on the source repo: `Validation passed`.
- [x] `claude plugin validate` on this repo with the entry added produces byte-identical output to `main` - the new entry introduces zero new errors or warnings. (The 2 errors and 10 warnings it reports are pre-existing on `main` and belong to other entries.)
- [x] No overlap with existing components - no entry, PR, or issue for this repo previously.

## Examples

**Install**

```
/plugin marketplace add davepoon/buildwithclaude
/plugin install suede-skills@buildwithclaude
```

**Ship a repo change through the build DAG**

> "Use suede-graph-flo-xr to add rate limiting to the /api/upload route."

Researches the repo, fans out disjoint lanes, then refutes its own review before anything lands.

**Grade a branch before merging**

> "Run suede-code on this branch."

Returns findings plus a blunt A-F ship verdict, with instant-F triggers and grade caps, instead of complimenting the diff.
