### PR TITLE
Add phaneslight plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2175,7 +2175,7 @@
       "name": "phaneslight",
       "description": "Multi-agent orchestration and project-memory system for Claude Code. One command turns a repository into a wired multi-agent environment: a project-specific agent roster, a documentation and session-summary tree, a tested script library, and enforcement hooks that hold size and stamp discipline at the harness layer. Re-runnable, so the setup grows with the codebase.",
       "author": {
-        "name": "Blueprompt",
+        "name": "Aloim",
         "url": "https://github.com/Aloim"
       },
       "homepage": "https://github.com/Aloim/phaneslight",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2170,6 +2170,34 @@
         "repo": "JasonColapietro/suede-creator-skills"
       },
       "strict": false
+    },
+    {
+      "name": "phaneslight",
+      "description": "Multi-agent orchestration and project-memory system for Claude Code. One command turns a repository into a wired multi-agent environment: a project-specific agent roster, a documentation and session-summary tree, a tested script library, and enforcement hooks that hold size and stamp discipline at the harness layer. Re-runnable, so the setup grows with the codebase.",
+      "author": {
+        "name": "Blueprompt",
+        "url": "https://github.com/Aloim"
+      },
+      "homepage": "https://github.com/Aloim/phaneslight",
+      "repository": "https://github.com/Aloim/phaneslight",
+      "license": "See LICENSE",
+      "keywords": [
+        "orchestration",
+        "multi-agent",
+        "subagents",
+        "project-memory",
+        "documentation",
+        "hooks",
+        "bootstrap",
+        "code-quality",
+        "claude-code"
+      ],
+      "category": "orchestration",
+      "version": "3.7.0",
+      "source": {
+        "source": "github",
+        "repo": "Aloim/phaneslight"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds **PhanesLight** to the marketplace: a multi-agent orchestration and project-memory system for Claude Code. One command turns a repository into a wired multi-agent environment with a project-specific agent roster, a documentation and session-summary tree, a tested script library, and enforcement hooks that hold size and stamp discipline at the harness layer. It is re-runnable rather than install-once, so the setup grows with the codebase instead of rotting beside it.

## Component details

| | |
|---|---|
| **Name** | `phaneslight` |
| **Type** | Plugin (two skills, three hooks, a shipped template library) |
| **Category** | `orchestration` |
| **Version** | 3.7.0 |
| **License** | See LICENSE (in-repo) |
| **Source** | `{"source": "github", "repo": "Aloim/phaneslight"}` |

Referenced by external repository rather than vendored under `plugins/`, matching the 13 existing `github`-source entries. The plugin ships a 220 KB skill body and a 40-file template library, so a vendored copy would drift from upstream on every release.

## Testing

- [x] **Validation passed.** `node scripts/validate-all.js` reports Hooks ✅ and Skills ✅. Subagents & Commands reports 512 errors, all in `plugins/all-commands/`, and they are **pre-existing on unmodified `main`**: identical count before and after this change, and none of them references `phaneslight`.
- [x] **Functionality tested.** `claude plugin validate ./plugin --strict` and `claude plugin validate . --strict` both pass on the source repository. A scratch-project end-to-end install completes at exit 0 with 27 files installed and the CLI smoke chain passing.
- [x] **No overlaps.** No existing entry named `phaneslight`; the entry is appended and no other line in the file is touched (28 insertions, 0 deletions).

## Usage examples

**1. Bootstrap a repository**

```
/phaneslight:run
```

Surveys the repository, infers module boundaries, generates a five-agent roster prefixed with the project slug, scaffolds `documentation/` and `tests/`, installs the script library, and writes the project memory. Pauses once to confirm module boundaries and once to ask whether to install the four recommended MCP servers.

**2. Keep an existing install current**

```
/phaneslight:run
```

The same command on an already-installed project runs as an update: it re-surveys, upgrades the sub-agents to the current lineup, fills in missing infrastructure, and bumps the run counter. A ledger lets a session that dies or compacts mid-run resume from the last completed phase.

**3. Migrate an older or manually installed project**

```
/phaneslight:upgrade
```

Detects the installed version from the project rather than from the prompt, archives any leftover manual command files instead of deleting them, removes project-level hook registrations now that the plugin owns them, and upgrades the structure on a dedicated branch behind an evidence-verified checklist.