### PR TITLE
Add proposal-drafter skill

### DIFF
--- a/plugins/all-skills/skills/proposal-drafter/SKILL.md
+++ b/plugins/all-skills/skills/proposal-drafter/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: proposal-drafter
+description: Draft a tailored freelance proposal or platform profile bio from a real job posting/brief and the freelancer's actual background. Use when responding to a listing on Contra/Upwork/etc, or writing/updating a freelance profile. Never invents experience, clients, or credentials that weren't provided.
+category: business-productivity
+---
+
+# Proposal Drafter
+
+Turns a job posting (or "write my profile bio") plus the freelancer's real background into a proposal or bio that sounds like it was written for this one client, not copy-pasted.
+
+## Required inputs before drafting
+
+Ask for these if not already provided — never fabricate them:
+- The job posting or brief (or, for a profile bio, the platform and target client type)
+- The freelancer's real skills, tools, and years of relevant experience
+- 1-3 real past projects or outcomes (even informal ones — side projects count if true)
+- Any real portfolio links
+
+If any of this is missing, ask before writing. A confident-sounding proposal built on invented credentials is a liability, not an asset.
+
+## Structure for a proposal (platform message, ~100-150 words)
+
+1. **Opening line** — restate the client's actual problem in your own words, proving you read the brief. Never open with "I am a passionate developer with X years of experience."
+2. **2-3 concrete connections** — specific ways the freelancer's real background maps to *this* ask, not a resume dump.
+3. **One relevant proof point** — a real past project/outcome that's the closest match, in one sentence.
+4. **Clear next step** — propose a concrete first action (a question, a quick call, a scoped first milestone), not "let me know if interested."
+
+## Structure for a profile bio (longer, ~150-300 words)
+
+1. **First line = the outcome you deliver**, not a job title. ("I build automation that saves technical teams hours a week" beats "Full-stack developer.")
+2. **Skill areas grouped by client-recognizable outcome**, not tech jargon dumps.
+3. **1-2 real project highlights** with a concrete result if known (time saved, bug fixed, feature shipped) — omit the metric if it isn't real, don't estimate one.
+4. **Close with working style** — availability, communication style, what kind of projects are the best fit.
+
+## Tone rules
+
+- Specific beats clever. Cut any sentence that could apply to any freelancer.
+- No unverifiable superlatives ("best-in-class", "world-class") — let the proof points carry the claim.
+- Active voice, short sentences. This is being read by someone deciding in under 30 seconds.
+
+## Part of a larger workflow
+
+This skill is one piece of a 5-skill freelance workflow (proposal → scope-of-work → client update → invoice summary → project handoff), all built around the same rule: if the input doesn't have it, the output doesn't claim it. The other 4 are available as a paid bundle: [Freelance Toolkit for Claude Code](https://ribster014.gumroad.com/l/voqthx).

--- a/stories/freelance-proposals-that-dont-lie/index.md
+++ b/stories/freelance-proposals-that-dont-lie/index.md
@@ -1,0 +1,45 @@
+---
+slug: freelance-proposals-that-dont-lie
+title: I built a Claude Code skill that refuses to lie in my freelance proposals
+excerpt: It writes a confident proposal when I give it real background — and flatly refuses when I don't.
+author:
+  name: Eder Ribeiro
+  handle: ederribeirosilva
+  avatarHue: 190
+target:
+  name: proposal-drafter
+  kind: skill
+  href: /skill/proposal-drafter
+category: Skills
+platforms:
+  - Claude Code
+cover: green
+coverAlt: A freelancer's laptop with a half-written proposal on screen
+date: Sep 4, 2026
+readTime: 4
+featured: false
+pinned: false
+pullQuote: If the input doesn't have it, the output doesn't claim it.
+---
+
+I'm a backend engineer picking up freelance work on the side. The paperwork around freelancing — proposals, scope docs, invoices — is the part nobody enjoys, so I started asking Claude Code to draft it for me.
+
+It worked, and that was the problem. It worked *too* well. Ask for a proposal with a thin brief and it will happily invent "5+ years of relevant experience" and a portfolio link that doesn't exist. Confident, well-written, and false. That's not a productivity win — it's a liability with my name on it.
+
+So I wrote `proposal-drafter` with one rule baked in: if the input doesn't have it, the output doesn't claim it.
+
+## The test that mattered
+
+I didn't trust my own skill until I tried to break it. I gave it a real job posting and nothing else — no background, no past work, no portfolio:
+
+> "Write me a proposal for this job: need a script that scrapes prices from 3 competitor sites daily and emails a summary."
+
+It refused:
+
+> "I can't draft your proposal yet — I'm missing the required inputs to do it without inventing credentials. Could you share: your real skills and experience, 1-3 real past projects, any real portfolio links? Once you share those, I'll draft a proposal tailored to this job. If you have no directly relevant past project, just say so — I'll omit the proof point rather than invent one."
+
+That's the whole point of the skill in one interaction. Give it something real, and it writes a tight, client-specific proposal instead of a template. Give it nothing, and it stops and asks instead of guessing.
+
+## What's here vs. what's not
+
+`proposal-drafter` is free and open, listed above. It's one piece of a 5-skill freelance workflow I built with the same anti-fabrication rule end to end — proposal → scope-of-work → client update → invoice summary → project handoff. The other 4 are a small paid bundle ([Freelance Toolkit for Claude Code](https://ribster014.gumroad.com/l/voqthx)) if the whole workflow is useful to you. This one stands on its own either way.


### PR DESCRIPTION
## Summary
- Adds `proposal-drafter`, a Claude Code skill that drafts freelance proposals/profile bios from a real job brief + the freelancer's actual background — and refuses to write one if the background isn't provided, rather than inventing experience or credentials.
- Adds a companion story walking through the anti-fabrication behavior with a real before/after example.

## Component Details
- **Name**: proposal-drafter
- **Type**: Skill
- **Category**: business-productivity

## Testing
- [x] Ran validation (`npm test`) — Skills validation passes clean. (The `npm run validate:subagents` failures are pre-existing, in files this PR doesn't touch — confirmed via `git status` before committing.)
- [x] Tested functionality — verified with a real job posting + no background provided; the skill correctly asked for real inputs instead of fabricating them.
- [x] No overlap with existing components

## Examples
1. `"Write me a proposal for this job: <job posting>"` with real background supplied → tailored ~100-150 word proposal referencing the actual background.
2. `"Write my profile bio for Contra"` with real background → longer bio, outcome-first opening.
3. Same request with no background supplied → skill declines and asks for the specific missing inputs instead of guessing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)