### PR TITLE
Add phaneslight plugin (v3.7.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2170,6 +2170,34 @@
         "repo": "JasonColapietro/suede-creator-skills"
       },
       "strict": false
+    },
+    {
+      "name": "phaneslight",
+      "description": "Multi-agent orchestration and project-memory system for Claude Code. One command turns a repository into a wired multi-agent environment: a project-specific agent roster, a documentation and session-summary tree, a tested script library, and enforcement hooks that hold size and stamp discipline at the harness layer. Re-runnable, so the setup grows with the codebase.",
+      "author": {
+        "name": "Aloim",
+        "url": "https://github.com/Aloim"
+      },
+      "homepage": "https://github.com/Aloim/phaneslightplugin",
+      "repository": "https://github.com/Aloim/phaneslightplugin",
+      "license": "CC-BY-NC-4.0",
+      "keywords": [
+        "orchestration",
+        "multi-agent",
+        "subagents",
+        "project-memory",
+        "documentation",
+        "hooks",
+        "bootstrap",
+        "code-quality",
+        "claude-code"
+      ],
+      "category": "orchestration",
+      "version": "3.7.1",
+      "source": {
+        "source": "github",
+        "repo": "Aloim/phaneslightplugin"
+      }
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2193,7 +2193,7 @@
         "claude-code"
       ],
       "category": "orchestration",
-      "version": "3.7.1",
+      "version": "3.7.2",
       "source": {
         "source": "github",
         "repo": "Aloim/phaneslightplugin"


### PR DESCRIPTION
Follow-up to #307, which you closed pending another pass. Thanks for the review, all four points are addressed and the blocking one needed more than a repointed URL.

## Blocking: the source now resolves as a plugin

You were right that `Aloim/phaneslight` is the manual-install prompt pack. Repointing at the plugin repo alone would still not have worked, though, and that is worth saying plainly: a marketplace `github` source takes `repo`, `ref` and `sha` and **has no `path` field**, so Claude Code loads `.claude-plugin/plugin.json` from the referenced repository's **root**. My plugin sat under `plugin/`, reachable only from that repo's own `marketplace.json`, which is exactly why `/plugin marketplace add` worked while a listing here would have resolved nothing.

So two things changed upstream:

- The repository was renamed `Aloim/phanesplugin` to **`Aloim/phaneslightplugin`**, because `phanesplugin` reads as "the plugin for Phanes" while the product is PhanesLight, and that is what sent the previous PR at the manual repo in the first place. The old URL still redirects.
- **The repository is flattened.** `.claude-plugin/plugin.json` and the plugin content (`skills/`, `hooks/`, `scripts/`, `templates/`) are now at the root, and that repo's own marketplace entry points at `./` instead of `./plugin`. This matches the layout of the other `github`-source entries here.

`source.repo` in this PR is `Aloim/phaneslightplugin`, and `claude plugin validate` on this file passes; the 5 warnings it reports are all pre-existing and belong to other entries and the collection metadata.

## Version and license

- **`version` is `3.7.1`**, in sync with the published plugin. `plugin.json` and the entry agree.
- **`license` is the SPDX id `CC-BY-NC-4.0`.** The licence itself never changed; the field was prose.

## The two upstream notes

Both fixed in the plugin, not just noted:

**The fabricated-authority persona is gone.** The run skill opened by calling PhanesLight a laureate of an award and chief architect of an institute, neither of which exists, and asked for "world-class, award-winning" sub-agents. That is cut, replaced by the plainer wording my v4.0 line already uses. No directive, phase or threshold moved, it is register only.

**The hooks are no longer PowerShell-only.** This turned out to be a regression rather than a Windows-first limitation, and the diagnosis is the useful part: before the plugin packaging, the setup run merged hook entries into each project's own `.claude/settings.json`, which happens on the target machine, so it could write a `powershell` entry on Windows, a `sh` entry on POSIX, and omit an entry entirely where no variant existed. Moving registration into the plugin's single static `hooks.json` took that choice away without replacing it, and the shipped file was PowerShell everywhere.

Entries now run `node "${CLAUDE_PLUGIN_ROOT}/scripts/hook-run.js" <hook-name>`. The launcher resolves the platform's own script extension, dispatches through `powershell` on Windows and `sh` elsewhere, and passes the hook's exit code through unchanged so the blocking `PreToolUse` guard still blocks. A hook with no variant on this platform is a silent no-op rather than a broken command, which is also what all of them are in a project that has no `.phaneslight/` at all. `install-notice.ps1` is ported to Node outright. Verified against a scratch tree: a child exit of 7 arrived as 7, a missing variant exited 0 silently, and the hook JSON payload reached the child's stdin intact.

One thing I want to be upfront about rather than have you find it: **part of the script library PhanesLight installs into a project is still Windows-only** (`preflight`, `scaffold`, `install-templates`, `ledger`, `manifest-write`, `census-diff`, `update-preflight`, `repo-manifest`, `batch-apply`, and the `hook-ledger-status` hook). On macOS and Linux the run does that work itself instead, and the day-to-day checks (`doc-check`, `doc-index`, `loc-check`, `register-check`, `new-file`, `module-list`, `list-apis`, and both enforcement hooks) are on both platforms. The README states this by name now instead of saying "Windows-first" and leaving a reader to guess what they lose.

Happy to take another pass on anything.
