### PR TITLE
Add you-web-search skill

### DIFF
--- a/hook-validation-report.json
+++ b/hook-validation-report.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2026-09-08T04:58:01.614Z",
+  "timestamp": "2026-07-17T16:45:25.243Z",
   "totalFiles": 33,
   "errors": 0,
   "warnings": 0,

--- a/hook-validation-report.json
+++ b/hook-validation-report.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2026-07-17T16:45:25.243Z",
+  "timestamp": "2026-09-08T04:58:01.614Z",
   "totalFiles": 33,
   "errors": 0,
   "warnings": 0,

--- a/plugins/all-skills/skills/you-web-search/SKILL.md
+++ b/plugins/all-skills/skills/you-web-search/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: you-web-search
+category: research
+description: "Search the live web and read URLs through the You.com MCP server. Use when you need current information beyond training data: recent releases, docs, pricing, news, or any question where facts may have changed. Two endpoints: keyless basic search at https://api.you.com/mcp?profile=free, or full tools with an API key from https://you.com/platform/api-keys."
+---
+
+# You.com Web Search
+
+Current web search and URL content extraction for Claude Code via the You.com MCP server.
+
+## Setup
+
+The MCP server is remote — no local install, just one config entry.
+
+**Option A — keyless (basic search):**
+
+```json
+{
+  "mcpServers": {
+    "you": {
+      "url": "https://api.you.com/mcp?profile=free"
+    }
+  }
+}
+```
+
+**Option B — full tools (API key):**
+
+```json
+{
+  "mcpServers": {
+    "you": {
+      "url": "https://api.you.com/mcp",
+      "headers": {
+        "Authorization": "Bearer ${YDC_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+Get a key at [you.com/platform/api-keys](https://you.com/platform/api-keys) and set `YDC_API_KEY` in your environment.
+
+## Tools
+
+- `you-search` — web search with fresh results and source URLs (available on both endpoints)
+- URL/content extraction and cited research tools (available with an API key)
+
+## When to Use
+
+- "What's the current stable version of Node.js?"
+- "Find recent posts about the new React compiler and summarize the reception"
+- "Check the latest docs for this API before writing the integration"
+
+Any question where your training data might be stale, or where the user asks for sources.
+
+## How to Use
+
+1. Call `you-search` with a focused query.
+2. Extract key facts from the results and cite the source URLs.
+3. For deeper dives, fetch the page content of the most relevant results.
+
+**User**: "What changed in the latest Python release?"
+
+**Output**: summary of release notes with links to the official announcement.
+
+## Tips
+
+- Search narrowly — one question per query, then refine.
+- Always include source URLs in your answer.
+- If the server isn't configured, tell the user to add it with the JSON above (one entry, no install step).

--- a/plugins/all-skills/skills/you-web-search/SKILL.md
+++ b/plugins/all-skills/skills/you-web-search/SKILL.md
@@ -43,8 +43,12 @@ Get a key at [you.com/platform/api-keys](https://you.com/platform/api-keys) and 
 
 ## Tools
 
-- `you-search` — web search with fresh results and source URLs (available on both endpoints)
-- URL/content extraction and cited research tools (available with an API key)
+Both endpoints expose:
+
+- `you-search` — web search returning ranked results with URLs and snippets
+- `you-contents` — fetch full page content as markdown or HTML (read results with this before answering; snippets are not page content)
+
+The authenticated endpoint adds multi-step research and finance tools.
 
 ## When to Use
 


### PR DESCRIPTION
## Summary

Adds a `you-web-search` skill that gives Claude Code current web search and URL reading through the You.com MCP server. It follows the catalog's MCP-backed skill pattern (like `coinpaprika-api`): one SKILL.md that documents the remote MCP endpoint, setup, and when the model should reach for it.

## Component Details
- **Name**: you-web-search
- **Type**: Skill
- **Category**: research

The server is remote, so setup is a single `mcpServers` entry — no local install. Two options are documented:
- keyless basic search: `https://api.you.com/mcp?profile=free`
- full tools with an API key: `https://api.you.com/mcp` + `Authorization: Bearer ${YDC_API_KEY}` (key from https://you.com/platform/api-keys)

There's currently no web-search skill in the catalog backed by a remote MCP server, so this fills a gap for questions where training data is stale.

## Testing
- [x] Ran validation (`npm test`) — skills schema, subagents, hooks, and all 14 unit tests pass
- [x] Tested functionality — MCP endpoints verified live (keyless `you-search` responds over the `profile=free` endpoint)
- [x] No overlap with existing components — searched the catalog; no You.com or remote-search MCP skill exists

## Examples

- "What's the current stable version of Node.js?" → `you-search`, answer with source URLs
- "Find recent posts about the React compiler and summarize the reception" → search, extract, cite
- "Check the latest docs for this API before writing the integration" → search + URL reading

The upstream You.com skills also ship as an installable plugin (`/plugin marketplace add youdotcom-oss/agent-skills` then `/plugin install you@you-com`) for users who want the full set; this catalog entry is the lighter single-skill path.