### PR TITLE
Update claude-prospector to v0.14.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1820,7 +1820,7 @@
     {
       "name": "claude-prospector",
       "description": "Claude Code efficiency and hygiene toolkit. Surfaces token spend across the 5h / 7d / Sonnet-7d billing windows with per-model / per-agent / per-skill attribution, and audits your effective Claude Code configuration (custom + plugin agents and skills) for overlap and conflicts. Ships an interactive dashboard, a conversational usage-analysis skill, and a structured config-audit skill.",
-      "version": "0.10.0",
+      "version": "0.14.0",
       "author": {
         "name": "Christopher Beaulieu",
         "url": "https://github.com/glitchwerks"


### PR DESCRIPTION
## Summary

Update the `claude-prospector` community marketplace entry from `0.10.0` to the current `0.14.0` release.

The listing description and keywords already match the current plugin manifest, so this PR changes only the display version.

## Verification

- upstream `main` was synced into the fork before branching
- `claude-prospector` v0.14.0 is published on GitHub and PyPI

> 🤖 _Generated by Codex on behalf of @cbeaulieu-gt_