### PR TITLE
Add midpoint-card-prices plugin (remote MCP: trading card prices and grading ROI)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -25,6 +25,30 @@
   },
   "plugins": [
     {
+      "name": "midpoint-card-prices",
+      "description": "Trading card market prices and grading ROI through one remote MCP server. Raw and graded prices for 1.5M+ Pokémon, Magic, Yu-Gi-Oh!, One Piece, Lorcana and sports cards, PSA 9 and PSA 10 premiums, net profit after grading fees, price history, 30-day movers and priced set checklists. Read-only, no account, no API key.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Midpoint",
+        "url": "https://www.cardcenteringtool.com"
+      },
+      "homepage": "https://www.cardcenteringtool.com/mcp",
+      "repository": "https://github.com/kolourr/midpoint-mcp",
+      "license": "MIT",
+      "keywords": [
+        "mcp",
+        "trading-cards",
+        "pokemon",
+        "sports-cards",
+        "card-prices",
+        "card-grading",
+        "psa",
+        "collectibles"
+      ],
+      "category": "mcp-servers",
+      "source": "./plugins/midpoint-card-prices"
+    },
+    {
       "name": "tlsradar",
       "description": "SSL/TLS certificate scanning, free Let's Encrypt issuance (private key stays local), and ongoing certificate-expiry monitoring — through a single remote MCP server. Free anonymous scans and cert issuance need no account; OAuth via /mcp unlocks ongoing monitoring.",
       "version": "0.6.1",

--- a/plugins/midpoint-card-prices/.claude-plugin/plugin.json
+++ b/plugins/midpoint-card-prices/.claude-plugin/plugin.json
@@ -1,0 +1,23 @@
+{
+  "name": "midpoint-card-prices",
+  "displayName": "Midpoint Card Prices",
+  "version": "1.0.0",
+  "description": "Trading card market prices and grading ROI for Claude Code through one remote MCP server. Ask what a Pokémon, Magic, Yu-Gi-Oh!, One Piece, Lorcana, baseball, basketball, football, hockey or soccer card is worth and get raw and graded prices for 1.5M+ cards, PSA 9 and PSA 10 premiums, net profit after grading fees, price history, 30-day movers and priced set checklists. Read-only, no account, no API key.",
+  "author": {
+    "name": "Midpoint",
+    "url": "https://www.cardcenteringtool.com"
+  },
+  "homepage": "https://www.cardcenteringtool.com/mcp",
+  "repository": "https://github.com/kolourr/midpoint-mcp",
+  "license": "MIT",
+  "keywords": [
+    "mcp",
+    "trading-cards",
+    "pokemon",
+    "sports-cards",
+    "card-prices",
+    "card-grading",
+    "psa",
+    "collectibles"
+  ]
+}

--- a/plugins/midpoint-card-prices/LICENSE
+++ b/plugins/midpoint-card-prices/LICENSE
@@ -1,0 +1,19 @@
+MIT License
+
+Copyright (c) 2026 Midpoint (cardcenteringtool.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this plugin package (the manifest, configuration, documentation and skill
+files in this directory) to deal in it without restriction, including without
+limitation the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the package.
+
+THE PACKAGE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY ARISING FROM THE
+USE OF THE PACKAGE. The remote service at mcp.cardcenteringtool.com is
+provided under its own terms: https://www.cardcenteringtool.com/terms

--- a/plugins/midpoint-card-prices/README.md
+++ b/plugins/midpoint-card-prices/README.md
@@ -1,0 +1,51 @@
+# Midpoint Card Prices
+
+Trading card market prices and grading ROI inside Claude Code, through one remote MCP server.
+Read-only, no account, no API key.
+
+```
+/plugin install midpoint-card-prices@buildwithclaude
+```
+
+Or register the server directly:
+
+```
+claude mcp add --transport http midpoint https://mcp.cardcenteringtool.com/mcp
+```
+
+## What you can ask
+
+- "What is a PSA 10 Base Set Charizard worth?"
+- "Is my Umbreon VMAX alt art worth grading?"
+- "1986 Fleer Michael Jordan raw and PSA 10 price"
+- "How has the 1952 Topps Mantle PSA 10 moved this year?"
+- "Which Pokémon cards jumped the most this month?"
+- "Most valuable cards in Evolving Skies"
+- "Best basketball cards to grade"
+
+Every answer includes USD market values from real sold listings, the capture date, and a link
+to the card page on [cardcenteringtool.com](https://www.cardcenteringtool.com/prices).
+
+## Tools
+
+| Tool | Use it when |
+|---|---|
+| `search_cards` | the user names a card; returns prices and the card id |
+| `get_card_prices` | full raw-by-condition and graded ladder (PSA, CGC, BGS, SGC, TAG) |
+| `grading_roi` | "worth grading?": PSA 9 / PSA 10 premium, net after fees, expected value, verdict |
+| `get_price_history` | 7–180 days of dated values, raw or a PSA grade |
+| `best_cards_to_grade` | biggest expected grading profit in a game or set |
+| `trending_cards` | biggest 30-day gainers or drops |
+| `liquid_movers` | rising cards with real sales volume |
+| `list_sets` / `get_set_cards` | set ids and priced checklists |
+
+All tools are read-only (`readOnlyHint: true`). Coverage: Pokémon, Magic: The Gathering,
+Yu-Gi-Oh!, One Piece, Disney Lorcana, Riftbound, Gundam, Dragon Ball, Digimon; baseball,
+basketball, football, hockey, soccer, wrestling, UFC, racing, tennis, golf, boxing; Marvel,
+Star Wars, Garbage Pail Kids and other entertainment and TCG sets.
+
+## Links
+
+- Docs and connect instructions: <https://www.cardcenteringtool.com/mcp>
+- Source: <https://github.com/kolourr/midpoint-mcp>
+- Privacy: <https://www.cardcenteringtool.com/privacy> · Terms: <https://www.cardcenteringtool.com/terms>

--- a/plugins/midpoint-card-prices/skills/card-prices/SKILL.md
+++ b/plugins/midpoint-card-prices/skills/card-prices/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: card-prices
+description: Use when the user asks what a trading card is worth, whether a card is worth grading, PSA 9 vs PSA 10 prices, card price history, trending or rising cards, or the most valuable cards in a set. Covers Pokémon, Magic, Yu-Gi-Oh!, One Piece, Lorcana, Gundam, baseball, basketball, football, hockey, soccer, wrestling, UFC and entertainment cards via the Midpoint MCP server.
+---
+
+# Card prices and grading ROI
+
+The `midpoint` MCP server exposes Midpoint's card price database as read-only tools.
+Prices are USD market values from real sold listings, refreshed daily. Every result
+carries the capture date and a link to the card page on cardcenteringtool.com; cite it.
+
+## Workflow
+
+1. **Resolve the card first.** Call `search_cards` with the user's words, e.g.
+   `{"query": "1986 fleer michael jordan", "game": "basketball"}`. Pass `game` when the
+   user names one. Results are ranked by how much of the query each card explains
+   (name, set, year, number). If several look alike, show the top few and confirm the
+   set and number before going deeper.
+2. **Then use the id.** Card ids are the public URL keys (`swsh7-215`,
+   `pricecharting-72584`). Pass them to:
+   - `get_card_prices` for the full raw-by-condition and graded ladder (PSA, CGC, BGS, SGC, TAG).
+   - `grading_roi` for "is it worth grading": PSA 9 / PSA 10 premium, net after $25/$50/$150
+     fees, expected value at 25/50/75 % gem rates, break-even gem rate, which company pays most,
+     and a verdict. Pass `grading_fee_usd` if the user states a fee.
+   - `get_price_history` for 7–180 days of dated values (`grade` for a PSA series, omit for raw).
+3. **Market questions need no id.** `trending_cards` (30-day gainers or drops, per game or all),
+   `liquid_movers` (rising cards with real sales volume), `best_cards_to_grade` (biggest expected
+   grading profit in a game or set), `list_sets` then `get_set_cards` (priced checklists).
+
+## Answering
+
+- Lead with the numbers the user asked for, then the verdict, then the link.
+- Say which series a change refers to; `trending_cards` states `basis` (PSA 10 or raw).
+- Never present prices as predictions. The server has no forecasts.
+- The server cannot grade or measure a card from a photo; point to the Midpoint app or the
+  web scanner link in `grading_roi` results for that.
+
+## Game keys
+
+`pokemon magicthegathering yugioh onepiece lorcana riftbound gundam dragonball digimon baseball
+basketball football hockey soccer wrestling ufc racing tennis golf boxing marvel starwars gpk
+entertainment othertcg`


### PR DESCRIPTION
## What

Adds **midpoint-card-prices**, a plugin that connects Claude Code to Midpoint's remote MCP server (`https://mcp.cardcenteringtool.com/mcp`, Streamable HTTP, no auth) for trading card market prices and grading ROI.

- `plugins/midpoint-card-prices/.claude-plugin/plugin.json` — manifest
- `plugins/midpoint-card-prices/.mcp.json` — remote server config (`type: http`)
- `plugins/midpoint-card-prices/skills/card-prices/SKILL.md` — teaches the search → card id → prices / ROI / history flow
- `plugins/midpoint-card-prices/README.md`, `LICENSE` (MIT for the plugin package)
- Entry in `.claude-plugin/marketplace.json` under `mcp-servers`

## The server

Nine read-only tools (`readOnlyHint: true` on all): `search_cards`, `get_card_prices`, `grading_roi`, `get_price_history`, `best_cards_to_grade`, `trending_cards`, `liquid_movers`, `list_sets`, `get_set_cards`. Raw and graded USD prices for 1.5M+ Pokémon, Magic, Yu-Gi-Oh!, One Piece, Lorcana, sports and entertainment cards; every result carries the capture date and links to the card page.

- Docs: https://www.cardcenteringtool.com/mcp
- Source: https://github.com/kolourr/midpoint-mcp
- Same pattern as the existing `tlsradar` and `cashflow` entries (remote MCP via `.mcp.json` + skill).

## Checks

- `plugin.json`, `.mcp.json` and `marketplace.json` parse as JSON; the entry is inserted without reformatting the rest of the file.
- Verified end to end with `claude mcp add --transport http midpoint https://mcp.cardcenteringtool.com/mcp` and the MCP Inspector.