### PR TITLE
Update claude-prospector to v0.15.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1820,7 +1820,7 @@
     {
       "name": "claude-prospector",
       "description": "Claude Code efficiency and hygiene toolkit. Surfaces token spend across the 5h / 7d / Sonnet-7d billing windows with per-model / per-agent / per-skill attribution, and audits your effective Claude Code configuration (custom + plugin agents and skills) for overlap and conflicts. Ships an interactive dashboard, a conversational usage-analysis skill, and a structured config-audit skill.",
-      "version": "0.10.0",
+      "version": "0.15.0",
       "author": {
         "name": "Christopher Beaulieu",
         "url": "https://github.com/glitchwerks"


### PR DESCRIPTION
## Summary

Update the community marketplace listing for claude-prospector from v0.10.0 to v0.15.0.

The listing description and keywords already match the current plugin manifest, so this PR changes only the display version.

Release: https://github.com/glitchwerks/claude-prospector/releases/tag/v0.15.0

## Verification

- Fork `main` was synchronized with upstream before branching.
- The branch is one commit ahead and zero commits behind upstream `main`.
- The diff changes one line in `.claude-plugin/marketplace.json`.

> 🤖 _Generated by Codex on behalf of @cbeaulieu-gt_