### PR TITLE
Add go-table-tests, go-error-handling and go-module-hygiene skills

### DIFF
--- a/plugins/all-skills/skills/go-error-handling/SKILL.md
+++ b/plugins/all-skills/skills/go-error-handling/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: go-error-handling
+description: Applies idiomatic Go error handling (wrapping with %w, sentinel vs typed errors, errors.Is/As/Join, handle-once, translating errors at layer boundaries, safe defer-close, panics only for programmer bugs). Use when writing or reviewing Go code that creates, returns, wraps, logs or checks errors, when designing a package's error API, when mapping domain errors to HTTP/gRPC status codes, or when the user asks why an errors.Is check fails.
+category: development-code
+license: MIT
+---
+
+# Go error handling
+
+## Core rules
+
+1. **Add context when you return**, describing what *this* function was doing, not what failed below it:
+   `return fmt.Errorf("load invoice %s: %w", id, err)`. The final message reads like a path: `create order: load invoice 42: query: connection refused`.
+2. **Handle once.** Either return the error (wrapped) or handle it (log, fall back, retry, convert to a response). Log-and-return produces duplicate log lines with no extra information.
+3. **Match with `errors.Is` / `errors.As`**, never `err == ErrX` on a possibly wrapped error, and never `strings.Contains(err.Error(), ...)` on errors you own.
+4. **Error strings** are lowercase, no trailing punctuation, no "failed to"/"error:" prefixes (`open config: permission denied`, not `Failed to open config.`).
+5. **Check every error.** `_ =` only with a comment explaining why ignoring is safe.
+
+## Choosing `%w` vs `%v`
+
+`%w` makes the wrapped error part of your API: callers can `errors.Is` it, and you can no longer swap the underlying library without breaking them. Use `%w` for your own sentinels and for errors callers are expected to inspect (e.g. `context.Canceled`, `fs.ErrNotExist`). Use `%v` at a boundary where you deliberately hide the implementation (e.g. do not leak `pgx` errors out of your repository package).
+
+## Designing a package's errors
+
+| Need | Use | Example |
+|---|---|---|
+| Caller branches on a condition | Sentinel | `var ErrNotFound = errors.New("user not found")` |
+| Caller needs data about the failure | Typed error | `type ValidationError struct{ Field, Msg string }` |
+| Several independent failures | `errors.Join(errs...)` | config validation reporting every bad field |
+| Nobody branches on it | `fmt.Errorf` | most errors |
+
+Typed errors use pointer receivers and are matched with `errors.As`:
+
+```go
+type ValidationError struct{ Field, Msg string }
+
+func (e *ValidationError) Error() string { return e.Field + " " + e.Msg }
+
+// Optional: let it match a category sentinel too.
+func (e *ValidationError) Is(target error) bool { return target == ErrInvalid }
+
+var ve *ValidationError
+if errors.As(err, &ve) {
+	log.Printf("bad field %s", ve.Field)
+}
+```
+
+Never return a typed nil pointer as an `error`; the interface is non-nil:
+
+```go
+func validate() error {
+	var ve *ValidationError // nil pointer
+	return ve               // BUG: err != nil is true for the caller
+}
+```
+
+## Translating at boundaries
+
+Each layer speaks its own vocabulary:
+
+```go
+// repository: storage error -> domain error
+if errors.Is(err, pgx.ErrNoRows) { // or sql.ErrNoRows
+	return User{}, fmt.Errorf("get user %d: %w", id, domain.ErrNotFound)
+}
+
+// transport: domain error -> status code, in ONE function
+func statusFor(err error) int {
+	var ve *domain.ValidationError
+	switch {
+	case errors.As(err, &ve):
+		return http.StatusUnprocessableEntity
+	case errors.Is(err, domain.ErrNotFound):
+		return http.StatusNotFound
+	case errors.Is(err, domain.ErrConflict):
+		return http.StatusConflict
+	case errors.Is(err, context.DeadlineExceeded):
+		return http.StatusGatewayTimeout
+	default:
+		return http.StatusInternalServerError // log full err; send a generic message
+	}
+}
+```
+
+Clients get a stable, safe message. Full detail (wrapped chain, IDs) goes to logs only.
+
+## Close and defer
+
+Errors from `Close` on writable resources matter (buffered data may not be flushed). Use a named result and `errors.Join`:
+
+```go
+func writeReport(path string, r Report) (err error) {
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("create report: %w", err)
+	}
+	defer func() { err = errors.Join(err, f.Close()) }()
+
+	if err := json.NewEncoder(f).Encode(r); err != nil {
+		return fmt.Errorf("encode report: %w", err)
+	}
+	return nil
+}
+```
+
+For read-only handles (`resp.Body`, `rows`) a plain `defer x.Close()` is fine, but for `*sql.Rows` always check `rows.Err()` after the loop.
+
+## Context errors
+
+- Check `ctx.Err()` before expensive work in loops.
+- `context.Canceled` usually means the caller went away: do not log it at error level, do not retry.
+- `context.DeadlineExceeded` is a timeout: map to 504/`codes.DeadlineExceeded`, consider retrying if the operation is idempotent.
+- `context.Cause(ctx)` returns the reason given to `context.WithCancelCause`; use it in error messages.
+
+## Panics
+
+- `panic` only for programmer errors that cannot happen in correct code (impossible switch default, violated invariant, `Must*` helpers used at init with constant input).
+- Never panic across a package boundary for expected failures (bad input, I/O, not found).
+- Recover only at goroutine or request boundaries (HTTP middleware, worker loop), log with stack, and convert to a 500 or a restart. Re-panic `http.ErrAbortHandler`.
+- A panic in a goroutine you started crashes the whole process; recovery middleware does not cover it.
+
+## Review checklist
+
+- [ ] No ignored errors (`go vet` does not catch these; look for `x, _ :=` and bare calls like `f.Close()` on writers).
+- [ ] No `err` shadowing that drops an error (`err :=` inside an `if` block, then the outer `err` is returned).
+- [ ] Wrapping adds context without repeating the callee's words.
+- [ ] Sentinels are compared with `errors.Is`, typed errors with `errors.As`.
+- [ ] Error-to-status mapping lives in one place and defaults to 500 without leaking detail.
+- [ ] No log-and-return.
+- [ ] No typed-nil returned as `error`.

--- a/plugins/all-skills/skills/go-module-hygiene/SKILL.md
+++ b/plugins/all-skills/skills/go-module-hygiene/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: go-module-hygiene
+description: Keeps Go modules and dependencies healthy (go.mod go/toolchain directives, go mod tidy, go.sum, the Go 1.24 tool directive, replace and go.work pitfalls, major-version import paths, upgrades, govulncheck, private modules). Use when adding, upgrading or removing a Go dependency, when editing go.mod or go.work, when `go build` reports missing or ambiguous modules, when setting up dev tools like staticcheck or mockgen, or when the user asks about Go versions, vulnerabilities or private repos.
+category: development-code
+license: MIT
+---
+
+# Go module hygiene
+
+## Ground rules
+
+- Never hand-edit `go.sum`. Change imports or `go.mod`, then run `go mod tidy`.
+- Commit `go.mod` and `go.sum` together. Do not commit `go.work` or `go.work.sum` unless the repo is intentionally a multi-module workspace.
+- After any dependency change run: `go mod tidy && go build ./... && go test ./...`.
+- Prefer the standard library. Before adding a module, check: is it maintained (recent commits/releases), how many transitive deps does it pull (`go mod graph | wc -l` before/after), is the license compatible.
+
+## `go` and `toolchain` directives
+
+- `go 1.24` is the minimum language version; it also enables version-gated semantics (per-iteration loop vars since 1.22).
+- `toolchain go1.24.5` is only a preference for which toolchain to use when the local one is older. Do not add or bump `toolchain` unless asked.
+- Raising the `go` line for a library forces it on every consumer. Raise it only when you need a feature; say so in the commit.
+
+## Adding and upgrading
+
+```bash
+go get example.com/lib@v1.4.2      # exact version (preferred in reviews)
+go get example.com/lib@latest      # newest release
+go get -u=patch ./...              # patch upgrades for everything used by the module
+go list -m -u all                  # what is outdated
+go mod why -m example.com/lib      # who needs this module
+go mod graph | grep example.com/lib
+```
+
+Avoid `go get -u ./...` in a feature branch: it upgrades every transitive dependency (minor versions included) and turns a small change into a risky one. Do broad upgrades in a dedicated PR.
+
+## Major versions
+
+Modules at v2+ must include the major version in the path: `github.com/jackc/pgx/v5`. Importing `github.com/jackc/pgx` gets v1-era code. When a user says "upgrade to v5", that means changing import paths, not just `go get`.
+
+## Dev tools (Go 1.24 `tool` directive)
+
+Go 1.24 tracks tools in go.mod instead of a `tools.go` file:
+
+```bash
+go get -tool honnef.co/go/tools/cmd/staticcheck@latest
+go tool staticcheck ./...
+go get -tool github.com/sqlc-dev/sqlc/cmd/sqlc@v1.27.0
+```
+
+This pins the tool version in go.mod/go.sum for the whole team. Downside: tool dependencies show up in the module graph; for libraries consumed by others you may prefer `go run pkg@version` in the Makefile instead. On Go < 1.24 keep the `//go:build tools` + blank-import `tools.go` pattern.
+
+## `replace` directives
+
+- OK temporarily for local debugging (`replace example.com/lib => ../lib`), never in a commit on main.
+- OK permanently in an application (not a library) to pin a fork, with a comment and an issue link.
+- `replace` in a dependency's go.mod is ignored by your build, so a library cannot fix its own dependencies that way.
+- For local multi-module work use `go work init . ../lib` and keep go.work uncommitted.
+
+## Vulnerabilities
+
+```bash
+go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+```
+
+govulncheck reports only vulnerabilities in code your program actually calls, which keeps noise low. Fix by upgrading the module to the listed fixed version; for stdlib findings, upgrade the Go toolchain (patch releases).
+
+## Private modules
+
+```bash
+go env -w GOPRIVATE='github.com/your-org/*'
+git config --global url."git@github.com:".insteadOf "https://github.com/"
+```
+
+`GOPRIVATE` skips the public proxy and checksum database for matching paths. In CI, provide a token via `.netrc` or `GOAUTH` (Go 1.24+) instead of rewriting URLs.
+
+## Layout reminders
+
+- Code under `internal/` can only be imported by code rooted at the parent of `internal`. Put everything not meant for other modules there.
+- One module per repo is the default. Split into several modules only when parts must be versioned separately; multi-module repos make every change harder.
+
+## Checklist
+
+- [ ] `go mod tidy` leaves no diff.
+- [ ] No `replace` pointing at a local path.
+- [ ] New dependency justified (what it replaces, why not stdlib).
+- [ ] Major-version path correct.
+- [ ] `govulncheck ./...` clean or findings explained.

--- a/plugins/all-skills/skills/go-table-tests/SKILL.md
+++ b/plugins/all-skills/skills/go-table-tests/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: go-table-tests
+description: Writes and refactors Go tests as idiomatic table-driven tests (t.Run subtests, clear got/want messages, t.Helper helpers, safe t.Parallel, httptest for handlers, fuzz seeds, benchmarks with b.Loop). Use when the user asks to add, fix, extend or clean up Go tests, when creating or editing a _test.go file, when a Go function or HTTP handler has no tests, when a bug fix needs a regression test, or when several near-identical test functions should become one table.
+category: development-code
+license: MIT
+---
+
+# Go table-driven tests
+
+Goal: tests that are cheap to extend (add a row, not a function), print a failure a stranger can act on, and pass deterministically under `go test -race -count=1 ./...`.
+
+## Before writing
+
+1. Read the function under test and its callers. List behaviours: happy path, every validation branch, every error return, boundaries (0, 1, max, max+1, empty, nil, unicode), and concurrent use if it holds state.
+2. Check what the package already uses: stdlib only, `github.com/google/go-cmp/cmp`, or `testify`. Match it. Do not add an assertion library to a project that has none.
+3. Check the `go` directive in go.mod; some helpers below need a minimum version.
+4. Choose the package: `package foo_test` (black-box, tests the public API, preferred for exported code) or `package foo` (white-box, for unexported helpers or injecting fakes into unexported fields).
+
+## Canonical shape
+
+```go
+func TestParseSize(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    int64
+		wantErr error // matched with errors.Is; nil means success
+	}{
+		{name: "bytes", in: "512", want: 512},
+		{name: "kibibytes", in: "4KiB", want: 4096},
+		{name: "surrounding spaces", in: " 1KiB ", want: 1024},
+		{name: "empty", in: "", wantErr: ErrEmpty},
+		{name: "negative", in: "-1", wantErr: ErrNegative},
+		{name: "unknown unit", in: "3XB", wantErr: ErrUnit},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseSize(tt.in)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("ParseSize(%q) error = %v, want %v", tt.in, err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("ParseSize(%q) = %d, want %d", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+```
+
+`errors.Is(nil, nil)` is true, so one comparison covers "expected success" and "expected this error".
+
+## Rules
+
+- **Names**: short, lowercase, unique, and describing the case, not the expected result ("empty input", not "returns error"). Spaces become underscores, so `go test -run 'TestParseSize/empty'` works.
+- **Messages**: `Func(args) = got, want want`. Print the input. Got before want.
+- **Fatal vs Error**: `t.Fatalf` when continuing would panic or be meaningless (unexpected error, nil result); `t.Errorf` otherwise so one run reports every mismatch.
+- **Comparing structs**: with go-cmp, `if diff := cmp.Diff(tt.want, got); diff != "" { t.Errorf("Func() mismatch (-want +got):\n%s", diff) }`. Stdlib only: compare fields explicitly or use `reflect.DeepEqual` for plain data. Compare `time.Time` with `Equal`, never `==`.
+- **Errors**: prefer `wantErr error` + `errors.Is`. For typed errors use `errors.As` and check fields. Substring matching on `err.Error()` is a last resort for errors you do not own.
+- **One behaviour per row**. If rows need very different setup or assertions, write a separate test function instead of adding `if tt.special` branches.
+- **Table as slice** keeps order stable. A `map[string]struct{...}` is also idiomatic and randomizes order, which surfaces hidden coupling between cases.
+- **Loop variables**: since Go 1.22 each iteration has its own `tt`. Delete `tt := tt` when go.mod says `go 1.22` or later.
+
+## Helpers, setup, cleanup
+
+```go
+func newTestStore(t *testing.T) *Store {
+	t.Helper() // failures point at the caller's line
+	dir := t.TempDir() // removed automatically
+	s, err := Open(filepath.Join(dir, "db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { s.Close() })
+	return s
+}
+```
+
+- `t.Helper()` is the first line of every helper that can fail.
+- Use `t.Cleanup` over `defer` inside helpers; it runs when the test (not the helper) ends.
+- `t.Context()` (Go 1.24+) returns a context canceled just before cleanup runs. On older Go: `ctx, cancel := context.WithCancel(context.Background()); t.Cleanup(cancel)`.
+- `t.Setenv` and `t.Chdir` (Go 1.24+) restore state automatically but cannot be combined with `t.Parallel()`. Better: make the code take `getenv func(string) string` and pass a map.
+
+## Parallelism
+
+Call `t.Parallel()` in the parent and in each subtest only when rows share no mutable state (no shared fake, no package globals, no `t.Setenv`). Parallel subtests finish before the parent's `t.Cleanup` runs, so shared fixtures created in the parent are safe to read.
+
+## Determinism
+
+- Inject time: `now func() time.Time` field or parameter. Never assert on `time.Now()`.
+- Inject randomness and IDs (`newID func() string`).
+- Never `time.Sleep` to wait for a goroutine. Synchronize with channels or `sync.WaitGroup`, or use `testing/synctest` (stable in Go 1.25 as `synctest.Test`; experimental in Go 1.24 behind `GOEXPERIMENT=synctest`).
+- Run new tests with `-count=10 -race` once to flush out flakiness.
+
+## HTTP handlers
+
+```go
+req := httptest.NewRequest(http.MethodPost, "/v1/items", strings.NewReader(`{"name":"x"}`))
+req.Header.Set("Content-Type", "application/json")
+rec := httptest.NewRecorder()
+handler.ServeHTTP(rec, req)
+if rec.Code != http.StatusCreated {
+	t.Fatalf("status = %d, want %d; body: %s", rec.Code, http.StatusCreated, rec.Body)
+}
+```
+
+Test through the router (the real `http.Handler`) so path patterns and middleware are exercised. Use `httptest.NewServer` when testing an HTTP client.
+
+## Fakes over mocks
+
+Write small hand-rolled fakes for the interfaces your code consumes. To override one method of a big interface, embed it:
+
+```go
+type failingRepo struct {
+	Repository // nil: any method you did not override panics, loudly
+	err error
+}
+func (f failingRepo) Save(context.Context, Item) error { return f.err }
+```
+
+## Fuzz and golden files
+
+- Turn good table inputs into fuzz seeds: `for _, tt := range tests { f.Add(tt.in) }`, then assert properties (no panic, round-trip `Parse(Format(x)) == x`). Run with `go test -fuzz=FuzzParseSize -fuzztime=30s`.
+- Large expected outputs go in `testdata/*.golden` with an `-update` flag: `var update = flag.Bool("update", false, "update golden files")`.
+
+## Benchmarks (Go 1.24+)
+
+```go
+func BenchmarkParseSize(b *testing.B) {
+	for b.Loop() { // setup before the loop is excluded from timing
+		ParseSize("4KiB")
+	}
+}
+```
+
+On older Go use `for i := 0; i < b.N; i++` and `b.ResetTimer()` after setup.
+
+## Checklist before you finish
+
+- [ ] Every error branch in the function has a row.
+- [ ] Failure messages include the input and got/want.
+- [ ] No sleeps, no real network, no dependence on wall-clock time or map order.
+- [ ] `go test -race -count=1 ./<pkg>` passes; `go vet ./<pkg>` is clean.
+- [ ] A bug-fix test fails without the fix (say so in your summary).


### PR DESCRIPTION
## Summary

Adds three Go skills. The catalogue currently has 171 skills and none of them cover Go, even though there is already a `golang-expert` agent under `plugins/agents-language-specialists/`. These skills give that agent (and Claude in general) the concrete Go conventions it is missing: table-driven tests, error wrapping, and module hygiene.

They are extracted from the MIT-licensed Claude Code Go Pack (https://github.com/fabiangftech/claude-go-pack) and are self-contained: no MCP server, no API key, no external service. Each one is stdlib-first.

Full disclosure: the upstream repository is the free core of a pack that also has a paid Pro edition. These three skills are MIT and work on their own; nothing here requires a purchase.

## Component Details

- **Name**: go-table-tests, go-error-handling, go-module-hygiene
- **Type**: Skill
- **Category**: development-code

## Testing

- [x] Ran `npm install && npm test` from the repo root on this branch: 14 tests pass, 0 fail.
- [x] Checked for overlap: `plugins/all-skills/skills/` had no Go skill before this PR.
- [x] Frontmatter follows CONTRIBUTING (`name` matching the directory, `category`, `description`), plus `license: MIT`.

Not claimed: I did not re-install these three files from this fork into a separate Claude Code session. They are in daily use in the upstream repository they come from.

## Examples

- "Add table-driven tests for ParseSize in internal/units, including every error branch."
  -> go-table-tests produces one `t.Run` subtest per case with got/want messages and a `t.Helper` fixture.
- "Refactor the error handling in internal/store/user.go so handlers can tell not-found from other failures."
  -> go-error-handling introduces a sentinel error, wraps with `%w`, and maps it once at the HTTP boundary.
- "Upgrade the pgx dependency and make sure go.mod is clean."
  -> go-module-hygiene runs the upgrade, `go mod tidy` and `govulncheck`, and explains the toolchain directive.
